### PR TITLE
ci: test the next version inside the CI 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
 # Where arkd's server can be found. By default it is a sub-directory in this project but you can change this to a custom directory
 ARK_GO_DIR=./ark-go
 ARKD_DIR=${ARK_GO_DIR}/ark/server
-ARKD_WALLET_DIR=${ARK_GO_DIR}/pkg/ark-wallet
+ARKD_WALLET_DIR=${ARK_GO_DIR}/ark/pkg/ark-wallet

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         arkd-version: [
           '6246f89716f7795801c2d453a02ec911898c4e15',
-          'master'
+          'master',
+          'next-version'
           # Add more versions as needed
         ]
 


### PR DESCRIPTION
This fixes some small documentation issues that allow the user to run the test environment. This is trivial, but I think it is good to have the path ready to go inside the examples.

In addition, adding the next version to see potential breaking change that are going to happen with the v7

Thanks for the support to get this up and running :)