### PR TITLE
[FIX] prevent duplicate inputs in round transactions when multiple UTXOs exist at same boarding address

### DIFF
--- a/ark-client/src/round.rs
+++ b/ark-client/src/round.rs
@@ -168,6 +168,9 @@ where
         let mut boarding_inputs: Vec<round::OnChainInput> = Vec::new();
         let mut total_amount = Amount::ZERO;
 
+        // To track unique outpoints and prevent duplicates
+        let mut seen_outpoints = std::collections::HashSet::new();
+
         let now = Timestamp::now();
 
         // Find outpoints for each boarding output.
@@ -185,11 +188,19 @@ where
                     is_spent: false,
                 } = o
                 {
+                    // Check for duplicate outpoints
+                    if seen_outpoints.contains(outpoint) {
+                        continue;
+                    }
+
                     // Only include confirmed boarding outputs with an _inactive_ exit path.
                     if !boarding_output.can_be_claimed_unilaterally_by_owner(
                         now.as_duration().try_into().map_err(Error::ad_hoc)?,
                         std::time::Duration::from_secs(*confirmation_blocktime),
                     ) {
+                        // Mark this outpoint as seen
+                        seen_outpoints.insert(*outpoint);
+
                         boarding_inputs.push(round::OnChainInput::new(
                             boarding_output.clone(),
                             *amount,


### PR DESCRIPTION
## Problem
The `fetch_round_transaction_inputs()` function was creating duplicate inputs when multiple UTXOs existed at the same boarding address. This occurred because:
- `wallet.get_boarding_outputs()` returns boarding output definitions
- For each boarding output, `blockchain.find_outpoints()` scans for all UTXOs at that address
- When multiple UTXOs exist at the same address, the same outpoints could be processed multiple times
- This resulted in duplicate inputs in the round transaction, causing Bitcoin Core to reject with `"bad-txns-inputs-duplicate"`

## Solution
Added deduplication logic using a `HashSet<OutPoint>` to track processed outpoints:
- Check if outpoint was already seen before processing
- Skip duplicate outpoints with `continue`
- Insert outpoint into tracking set after validation
- Maintains all existing validation logic for exit paths and confirmation requirements

## Changes
- Added `seen_outpoints` HashSet to track unique outpoints
- Added duplicate check before processing each UTXO
- Preserves all existing functionality while preventing duplicates

> Fixes: [arkive-sdk#12](https://github.com/pingu-73/arkive-sdk/pull/12#issue-3208425576)

**Please refer: https://github.com/pingu-73/arkive-sdk/pull/12#issue-3208425576 for more details**