### PR TITLE
fix: update ARKD_DIR path

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # Where arkd's server can be found. By default it is a sub-directory in this project but you can change this to a custom directory
 ARK_GO_DIR=./ark-go
-ARKD_DIR=${ARK_GO_DIR}/ark/server
+ARKD_DIR=${ARK_GO_DIR}/ark
 ARKD_WALLET_DIR=${ARK_GO_DIR}/ark/pkg/ark-wallet
 ARK_DB_TYPE=sqlite
 ARK_EVENT_DB_TYPE=badger

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -12,7 +12,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   ARK_GO_DIR: ./ark-go
-  ARKD_DIR: ./ark-go/ark/server
+  ARKD_DIR: ./ark-go/ark
   ARKD_WALLET_DIR: ./ark-go/ark/pkg/ark-wallet
   ARK_LIVE_STORE_TYPE: inmemory
   ARK_DB_TYPE: sqlite


### PR DESCRIPTION
This is moving stuff forward to the v7 migration, nothing much happening, but just the arkd architecture is changing a bit and this is restoring the right arkd path in order to run the e2e tests

---
- Update ARKD_DIR from './ark-go/ark/server' to './ark-go/ark' in .env.sample
- Update ARKD_DIR path in GitHub Actions workflow e2e-core.yml

This change aligns the ARKD_DIR path across configuration files and provides a convenient script for setting up the development environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ARKD_DIR environment variable to reference a higher-level directory in configuration files and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->