### PR TITLE
feat: allow to switch tls-provider in client and grpc

### DIFF
--- a/ark-bdk-wallet/Cargo.toml
+++ b/ark-bdk-wallet/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-ark-client = { path = "../ark-client" }
+ark-client = { path = "../ark-client", default-features = false }
 ark-core = { path = "../ark-core" }
 async-stream = "0.3"
 bdk_wallet = "1.0.0"

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -24,9 +24,9 @@ tokio = { version = "1.41.0", features = ["sync", "rt-multi-thread"] }
 tracing = "0.1.37"
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
-ark-grpc = { path = "../ark-grpc", version = "0.7.0" }
+ark-grpc = { path = "../ark-grpc", version = "0.7.0", default-features = false }
 backon = { version = "1", features = ["tokio-sleep"] }
-tonic = { version = "0.12", features = ["tls-native-roots"] }
+tonic = "0.12"
 
 # TODO: We do not yet support WASM in `ark-client`. To support WASM in this high level crate, we
 # will need to make it possible to use either `ark-grpc` or `ark-rest`. The current default is
@@ -44,3 +44,8 @@ tonic-build = { version = "0.12.3" }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros", "rt"] }
+
+[features]
+default = ["tls-native-roots"]
+tls-native-roots = ["tonic/tls-native-roots", "ark-grpc/tls-native-roots"]
+tls-webpki-roots = ["tonic/tls-webpki-roots", "ark-grpc/tls-webpki-roots"]

--- a/ark-grpc/Cargo.toml
+++ b/ark-grpc/Cargo.toml
@@ -19,10 +19,15 @@ musig = { package = "ark-secp256k1", path = "../ark-rust-secp256k1", features = 
 prost = { version = "0.13", default-features = false }
 prost-types = { version = "0.13", default-features = false }
 serde_json = "1.0"
-tonic = { version = "0.12", default-features = false, features = ["tls-native-roots", "transport", "codegen", "prost"] }
+tonic = { version = "0.12", default-features = false, features = ["transport", "codegen", "prost"] }
 
 [target.'cfg(genproto)'.build-dependencies]
 tonic-build = { version = "0.12" }
+
+[features]
+default = ["tls-webpki-roots"]
+tls-native-roots = ["tonic/tls-native-roots"]
+tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 [dev-dependencies]
 console_log = "1"


### PR DESCRIPTION
tls-native-roots allows uses the platform's native certificate store while tls-webpki-roots contains  Mozilla's trusted root certificates for use. The former one can be used on most platforms but might lead to issues on mobile platforms such as Android. For Android webpki works well. We provide a feature flag to switch between those two options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency and feature management for improved control over TLS options in related components.
  * Centralized TLS feature configuration, allowing selection between native and webpki TLS roots via feature flags.
  * No changes to user-facing functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->