### PR TITLE
Refactor ark-core::generate_outgoing_vtxo_transaction_history

### DIFF
--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -33,6 +33,7 @@ tonic = "0.12"
 # `ark-grpc`, but only `ark-rest` can support WASM.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 backon = { version = "1", features = ["gloo-timers-sleep"] }
+futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 getrandom = { version = "0.2", features = ["wasm-bindgen", "js"] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 tonic = { version = "0.12", default-features = false, features = ["prost", "codegen"] }

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -938,9 +938,9 @@ async fn transaction_history(
 
         incoming_transactions.append(&mut new_incoming_transactions);
 
-        let mut relevant_txs =
+        let relevant_txs =
             generate_outgoing_vtxo_transaction_history(vtxo_list.spent(), vtxo_list.spendable())?;
-        for relevant_tx in &mut relevant_txs {
+        for relevant_tx in relevant_txs {
             match relevant_tx {
                 history::OutgoingTransaction::Complete(tx) => outgoing_transactions.push(tx),
                 history::OutgoingTransaction::Incomplete(incomplete_tx) => {

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -924,8 +924,6 @@ async fn transaction_history(
         }
     }
 
-    let runtime = tokio::runtime::Handle::current();
-
     let mut incoming_transactions = Vec::new();
     let mut outgoing_transactions = Vec::new();
     for vtxo in vtxos.iter() {
@@ -940,25 +938,23 @@ async fn transaction_history(
 
         incoming_transactions.append(&mut new_incoming_transactions);
 
-        let mut new_outgoing_transactions = generate_outgoing_vtxo_transaction_history(
-            vtxo_list.spent(),
-            vtxo_list.spendable(),
-            |outpoint: OutPoint| {
-                block_in_place(|| {
-                    runtime.block_on(async {
-                        let request = GetVtxosRequest::new_for_outpoints(&[outpoint]);
-                        let list = grpc_client
-                            .list_vtxos(request)
-                            .await
-                            .map_err(ark_core::Error::ad_hoc)?;
+        let mut relevant_txs =
+            generate_outgoing_vtxo_transaction_history(vtxo_list.spent(), vtxo_list.spendable())?;
+        for relevant_tx in &mut relevant_txs {
+            match relevant_tx {
+                history::OutgoingTransaction::Complete(tx) => outgoing_transactions.push(tx),
+                history::OutgoingTransaction::Incomplete(incomplete_tx) => {
+                    let request =
+                        GetVtxosRequest::new_for_outpoints(&[incomplete_tx.first_outpoint()]);
+                    let list = grpc_client.list_vtxos(request).await?;
 
-                        Ok(list.all().first().cloned())
-                    })
-                })
-            },
-        )?;
-
-        outgoing_transactions.append(&mut new_outgoing_transactions);
+                    if let Some(spend_tx_vtxo) = list.all().first() {
+                        let tx = incomplete_tx.finish(spend_tx_vtxo)?;
+                        outgoing_transactions.push(tx);
+                    }
+                }
+            }
+        }
     }
 
     let mut txs = [

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -367,6 +367,7 @@ pub async fn set_up_client(
         nigiri,
         wallet.clone(),
         "http://localhost:7070".to_string(),
+        Duration::from_secs(30),
     )
     .connect()
     .await


### PR DESCRIPTION
While working on trying to solve issue #65 in ark-client, I came across the `generate_outgoing_vtxo_transaction_history` function in ark-code. This refactor aims to address two main issues:
1. **Error propagation** – Inside the callback used to retrieve VTXOs from arkd, I found I couldn’t throw an `ark-client::Error` but an `ark_core::Error` instead, which isn’t strictly correct since the failure occurs at the ark-client layer when querying arkd, not within ark-core.
2. **Blocking behavior** – The current approach forces ark-client to block the current thread due to the `Runtime::block_on` call.

By changing `generate_outgoing_vtxo_transaction_history` to return an iterator (as proposed in this PR), both problems are resolved.

I’m not sure if this approach aligns with your expectations (cc: @luckysori). I also plan to refine some of the naming for the new types/enums introduced here, as they could be clearer. In the meantime, I’d appreciate feedback on whether I should continue down this path or consider a different approach, both in relation to the refactoring and the introduction of the timeout in ark-client.

Fixes #65 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-client timeout configurable at client creation and applied across all network/blockchain I/O.
  * Outgoing transactions now stream as Complete or Incomplete items finishable on demand.

* **Improvements**
  * Replaced blocking runtime usage with fully asynchronous, timeout-bounded flows across send, batch, unilateral-exit, fee retrieval, and history streaming.
  * Platform-aware timeout helper added for cross-target support.

* **Documentation**
  * Examples updated to show a 30-second timeout.

* **Chores**
  * Tests, samples, and wasm dependency updated for timeout plumbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->