### PR TITLE
ci: remove the need to pass clippy for the e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,8 @@ jobs:
       - name: Disallow squash! commits
         run: git log --pretty=format:%s origin/master..HEAD | grep -zv squash!
 
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [ clippy ]
     steps:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v2
@@ -66,7 +54,6 @@ jobs:
         run: RUST_BACKTRACE=1 cargo test --workspace --exclude ark-secp256k1
 
   e2e-tests:
-    needs: [ clippy ]
     strategy:
       fail-fast: false
       matrix:
@@ -123,3 +110,15 @@ jobs:
 
       - name: Build crates for WASM
         run: PATH="/opt/homebrew/opt/llvm/bin:$PATH" cargo build -p ark-core -p ark-rest --target wasm32-unknown-unknown
+
+  clippy:
+    runs-on: ubuntu-latest
+    needs: [ wasm_ubuntu, wasm_macos ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Sometimes it is nice to have a fixup commit and be able to run the tests without having to pass clippy or other repo rules passing before running the e2e tests.

Built in https://github.com/arkade-os/rust-sdk/pull/98, but independent from it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to decouple linting from tests: tests no longer wait on linting; linting runs after builds complete across platforms.
  * Linting now runs with strict warnings to enforce code quality post-build.

* **Notes**
  * No user-facing changes; app behavior and public APIs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->