### PR TITLE
fix: replace clone() with std::slice::from_ref for single element slices

### DIFF
--- a/ark-dlc-sample/src/main.rs
+++ b/ark-dlc-sample/src/main.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<()> {
             (&bob_payout_vtxo.to_ark_address(), bob_refund_payout),
         ],
         None,
-        &[dlc_vtxo_input.clone()],
+        std::slice::from_ref(&dlc_vtxo_input),
         server_info.dust,
     )
     .context("building refund TX")?;
@@ -213,7 +213,7 @@ async fn main() -> Result<()> {
             (&bob_payout_vtxo.to_ark_address(), bob_heads_payout),
         ],
         None,
-        &[dlc_vtxo_input.clone()],
+        std::slice::from_ref(&dlc_vtxo_input),
         server_info.dust,
     )
     .context("building heads CET")?;
@@ -226,7 +226,7 @@ async fn main() -> Result<()> {
             (&bob_payout_vtxo.to_ark_address(), bob_tails_payout),
         ],
         None,
-        &[dlc_vtxo_input.clone()],
+        std::slice::from_ref(&dlc_vtxo_input),
         server_info.dust,
     )
     .context("building tails CET")?;

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -229,7 +229,7 @@ async fn main() -> Result<()> {
             let amount = Amount::from_sat(*amount);
 
             let virtual_tx_outpoints = {
-                let spendable_vtxos = spendable_vtxos(&grpc_client, &[vtxo.clone()], false).await?;
+                let spendable_vtxos = spendable_vtxos(&grpc_client, std::slice::from_ref(&vtxo), false).await?;
                 list_virtual_tx_outpoints(find_outpoints_fn, spendable_vtxos)?
             };
 
@@ -333,7 +333,7 @@ async fn main() -> Result<()> {
         }
         Commands::Settle => {
             let virtual_tx_outpoints = {
-                let spendable_vtxos = spendable_vtxos(&grpc_client, &[vtxo.clone()], true).await?;
+                let spendable_vtxos = spendable_vtxos(&grpc_client, std::slice::from_ref(&vtxo), true).await?;
                 list_virtual_tx_outpoints(find_outpoints_fn, spendable_vtxos)?
             };
             let boarding_outpoints =


### PR DESCRIPTION
Clippy was flagging inefficient use of .clone() when creating single-element slices. This change replaces &[item.clone()] with std::slice::from_ref(&item) which is more efficient as it avoids unnecessary cloning.

Fixed in:
- ark-dlc-sample/src/main.rs: 3 occurrences in DLC transaction building
- ark-sample/src/main.rs: 2 occurrences in VTXO operations

```
  Checking ark-sample v0.7.0 (/home/runner/work/rust-sdk/rust-sdk/ark-sample)
error: this call to `clone` can be replaced with `std::slice::from_ref`
   --> ark-sample/src/main.rs:232:69
    |
232 |                 let spendable_vtxos = spendable_vtxos(&grpc_client, &[vtxo.clone()], false).await?;
    |                                                                     ^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&vtxo)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs
    = note: `-D clippy::cloned-ref-to-slice-refs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cloned_ref_to_slice_refs)]`

error: this call to `clone` can be replaced with `std::slice::from_ref`
   --> ark-sample/src/main.rs:336:69
    |
336 |                 let spendable_vtxos = spendable_vtxos(&grpc_client, &[vtxo.clone()], true).await?;
    |                                                                     ^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&vtxo)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs

error: could not compile `ark-sample` (bin "ark-sample") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized handling of single-item inputs by borrowing instead of cloning, reducing temporary allocations and copies.
  * Improvements apply to refund and contract execution transactions, as well as balance and settlement flows.
  * Enhances efficiency and may slightly reduce memory usage and latency under load.
  * No functional changes or public API updates; behavior remains the same.
  * No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->