### PR TITLE
Do not consider expired on-chain VTXOs spendable

### DIFF
--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -479,20 +479,16 @@ where
                     .iter()
                     .find(|explorer_utxo| explorer_utxo.outpoint == virtual_tx_outpoint.outpoint)
                 {
-                    // Include VTXOs that have been confirmed on the blockchain, but whose
-                    // exit path is still _inactive_.
+                    // Exclude VTXOs that have been confirmed on the blockchain, but whose exit path
+                    // is now _active_. These should be claimed unilaterally instead.
                     Some(ExplorerUtxo {
                         confirmation_blocktime: Some(confirmation_blocktime),
                         ..
-                    }) if !vtxo.can_be_claimed_unilaterally_by_owner(
+                    }) if vtxo.can_be_claimed_unilaterally_by_owner(
                         now.as_duration().try_into().map_err(Error::ad_hoc)?,
                         Duration::from_secs(*confirmation_blocktime),
-                    ) =>
-                    {
-                        spendable_outpoints.push(virtual_tx_outpoint);
-                    }
-                    // The VTXO has not been confirmed on the blockchain yet. Therefore, it
-                    // cannot have expired.
+                    ) => {}
+                    // All other VTXOs are spendable.
                     _ => {
                         spendable_outpoints.push(virtual_tx_outpoint);
                     }


### PR DESCRIPTION
I noticed this thanks to https://github.com/arkade-os/rust-sdk/pull/102#pullrequestreview-3133903445.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmed outputs that have an active exit path are no longer included for automatic spending; they must be claimed manually.
  * All other outputs remain spendable as before.
  * Unconfirmed funds detected by the explorer continue to be eligible for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->