### PR TITLE
fix: rustls 0.23 needs manual crypto provider

### DIFF
--- a/ark-sample/Cargo.toml
+++ b/ark-sample/Cargo.toml
@@ -18,6 +18,7 @@ esplora-client = { version = "0.10", features = ["async-https"] }
 futures = "0.3"
 jiff = "0.2.1"
 rand = "0.8"
+rustls = { version = "0.23", features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -157,6 +157,10 @@ struct Config {
 async fn main() -> Result<()> {
     init_tracing();
 
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let cli = Cli::parse();
 
     let seed = fs::read_to_string(cli.seed)?;


### PR DESCRIPTION
In rustls 0.23+, crypto providers are no longer automatically installed. We need to explicitly install one before using any rustls functionality.

This is needed if we want to access an ark-server behind https.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Initializes a standardized TLS cryptography provider at startup to ensure secure, consistent behavior across environments.

- Chores
  - Added a cryptography dependency to support the new TLS provider initialization.

- Reliability
  - Application now verifies successful cryptography provider setup on launch; startup will fail fast if initialization is unsuccessful, preventing unclear runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->