### PR TITLE
Retry if `e2e_rest_client_get_info` fails

### DIFF
--- a/e2e-tests/tests/e2e_rest_client_get_info.rs
+++ b/e2e-tests/tests/e2e_rest_client_get_info.rs
@@ -1,8 +1,30 @@
 use ark_rest::Client;
+use std::time::Duration;
 
 #[tokio::test]
 #[ignore]
 async fn can_get_info_from_ark_server() {
     let client = Client::new("http://localhost:7070".to_string());
-    let _info = client.get_info().await.unwrap();
+
+    let mut n_retries = 0;
+    while n_retries < 5 {
+        let res = client.get_info().await;
+
+        match res {
+            Ok(_) => {
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Failed to get info, retrying");
+
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
+                n_retries += 1;
+
+                continue;
+            }
+        };
+    }
+
+    panic!("Failed to get info after several retries");
 }


### PR DESCRIPTION
Our e2e tests tend to start earlier than arkd is actually ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by adding retry logic to the REST client “get info” check, reducing transient failures.
  * Introduced backoff between attempts to better handle temporary service unavailability.
  * Replaced brittle error handling to prevent false negatives in CI.
  * Overall, this enhances CI stability and confidence in releases without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->