### PR TITLE
feat: add to client-sample send-on-chain collaboratively

### DIFF
--- a/ark-client-sample/justfile
+++ b/ark-client-sample/justfile
@@ -30,3 +30,7 @@ settle actor:
 # Subscribe to an address
 subscribe actor address:
     cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed subscribe {{ address }}
+
+# Send coins to an Onchain address from a given actor, e.g. just send-onchain bob bc1... 1234
+send-onchain actor address amount:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed send-onchain {{ address }} {{ amount }}


### PR DESCRIPTION
Useful to show-case how to send on-chain funds (was useful to find a bug in the flutter-sample)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI subcommand to send funds on-chain with address and amount parameters.
- Chores
  - Added a Justfile recipe to easily invoke the on-chain send command with sample configs, including example usage.
- Style
  - Updated status output wording: “confirmed” replaces “spendable” for both offchain and onchain balances to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->