### PR TITLE
Add support for (reverse) submarine swaps via Boltz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+          components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Cargo.lock
 
 # Repository for arkd
 /ark-go
+
+**/*.sqlite

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ async fn init_client() -> Result<Client<MyBlockchain, MyWallet>, ark_client::Err
         blockchain,
         wallet,
         "https://ark-server.example.com".to_string(),
+        InMemorySwapStorage::default(),
+        "http://boltz.example.com".to_string(),
+        timeout,
     );
 
     // Connect to the Ark server and get server info

--- a/ark-client-sample/alice/ark.config.toml
+++ b/ark-client-sample/alice/ark.config.toml
@@ -1,4 +1,7 @@
 ark_server_url = "http://localhost:7070"
 esplora_url = "http://localhost:30000"
+swap_storage_path = "./swap/"
+boltz_url = "http://localhost:9001"
+
 # ark_server_url = "http://mutinynet.arkade.sh"
 # esplora_url = "https://mutinynet.com/api"

--- a/ark-client-sample/bob/ark.config.toml
+++ b/ark-client-sample/bob/ark.config.toml
@@ -1,2 +1,4 @@
 ark_server_url = "http://localhost:7070"
 esplora_url = "http://localhost:30000"
+swap_storage_path = "./swap_storage.sqlite"
+boltz_url = "http://localhost:9001"

--- a/ark-client-sample/insiders/ark.config.toml
+++ b/ark-client-sample/insiders/ark.config.toml
@@ -2,3 +2,4 @@
 # esplora_url = "https://mutinynet.com/api"
 ark_server_url = "https://mutinynet.arkade.sh"
 esplora_url = "https://mutinynet.com/api"
+swap_storage_path = "./swap_storage.sqlite"

--- a/ark-client-sample/justfile
+++ b/ark-client-sample/justfile
@@ -34,3 +34,19 @@ subscribe actor address:
 # Send coins to an Onchain address from a given actor, e.g. just send-onchain bob bc1... 1234
 send-onchain actor address amount:
     cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed send-onchain {{ address }} {{ amount }}
+
+# Receive via lightning
+lightning-invoice actor amount:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed lightning-invoice {{ amount }}
+
+# Pay lightning invoice
+pay-invoice actor invoice:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed pay-invoice {{ invoice }}
+
+# Refund a submarine swap collaboratively
+refund-swap-collab actor swap_id:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed refund-swap {{ swap_id }}
+
+# Refund a submarine swap without the receiver
+refund-swap actor swap_id:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed refund-swap-without-receiver {{ swap_id }}

--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -120,7 +120,7 @@ impl FromStr for AddressesAndAmounts {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = input.split(',').collect();
 
-        if parts.len() % 2 != 0 {
+        if !parts.len().is_multiple_of(2) {
             bail!("invalid input: expected comma-separated pairs of <address,amount in sats>");
         }
 

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -11,15 +11,22 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(genproto)'] }
 [dependencies]
 ark-core = { path = "../ark-core", version = "0.7.0" }
 async-stream = "0.3"
+async-trait = "0.1"
 base64 = "0.22.1"
 bech32 = "0.11"
-bitcoin = { version = "0.32.4", features = ["rand"] }
+bitcoin = { version = "0.32.4", features = ["rand", "serde"] }
 futures = "0.3.31"
 jiff = "0.2.1"
+lightning-invoice = { version = "0.33.2", features = ["serde"] }
 musig = { package = "ark-secp256k1", path = "../ark-rust-secp256k1", features = ["serde"] }
 prost = "0.13.3"
 prost-types = "0.13.3"
 rand = "0.8"
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = "3.14.1"
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "migrate", "chrono"] }
 tokio = { version = "1.41.0", features = ["sync", "rt-multi-thread"] }
 tracing = "0.1.37"
 
@@ -45,6 +52,7 @@ wasm-bindgen-futures = { version = "0.4" }
 tonic-build = { version = "0.14" }
 
 [dev-dependencies]
+tempfile = "3.8"
 tokio = { version = "1.41.0", features = ["macros", "rt"] }
 
 [features]

--- a/ark-client/migrations/001_initial.sql
+++ b/ark-client/migrations/001_initial.sql
@@ -1,0 +1,23 @@
+-- Initial schema for swap storage with separate tables for submarine and reverse swaps
+
+-- Create submarine swaps table
+CREATE TABLE submarine_swaps (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL,  -- JSON serialized SubmarineSwapData
+    created_at INTEGER NOT NULL,  -- Unix timestamp
+    updated_at INTEGER NOT NULL   -- Unix timestamp
+);
+
+-- Create reverse swaps table
+CREATE TABLE reverse_swaps (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL,  -- JSON serialized ReverseSwapData
+    created_at INTEGER NOT NULL,  -- Unix timestamp
+    updated_at INTEGER NOT NULL   -- Unix timestamp
+);
+
+-- Create indexes for time-based queries
+CREATE INDEX idx_submarine_swaps_created_at ON submarine_swaps(created_at);
+CREATE INDEX idx_submarine_swaps_updated_at ON submarine_swaps(updated_at);
+CREATE INDEX idx_reverse_swaps_created_at ON reverse_swaps(created_at);
+CREATE INDEX idx_reverse_swaps_updated_at ON reverse_swaps(updated_at);

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -1,0 +1,1015 @@
+use crate::error::ErrorContext;
+use crate::swap_storage::SwapStorage;
+use crate::timeout_op;
+use crate::wallet::BoardingWallet;
+use crate::wallet::OnchainWallet;
+use crate::Blockchain;
+use crate::Client;
+use crate::Error;
+use ark_core::send::build_offchain_transactions;
+use ark_core::send::sign_ark_transaction;
+use ark_core::send::sign_checkpoint_transaction;
+use ark_core::send::OffchainTransactions;
+use ark_core::send::VtxoInput;
+use ark_core::send::VTXO_CONDITION_KEY;
+use ark_core::server::GetVtxosRequest;
+use ark_core::vhtlc::VhtlcOptions;
+use ark_core::vhtlc::VhtlcScript;
+use ark_core::ArkAddress;
+use bitcoin::absolute::LockTime;
+use bitcoin::consensus::Encodable;
+use bitcoin::hashes::ripemd160;
+use bitcoin::hashes::sha256;
+use bitcoin::hashes::Hash;
+use bitcoin::io::Write;
+use bitcoin::key::Secp256k1;
+use bitcoin::psbt;
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::schnorr;
+use bitcoin::taproot::LeafVersion;
+use bitcoin::Amount;
+use bitcoin::Psbt;
+use bitcoin::PublicKey;
+use bitcoin::Sequence;
+use bitcoin::Txid;
+use bitcoin::VarInt;
+use bitcoin::XOnlyPublicKey;
+use lightning_invoice::Bolt11Invoice;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
+use std::str::FromStr;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+#[derive(Clone, Debug)]
+pub struct SubmarineSwapResult {
+    pub swap_id: String,
+    pub txid: Txid,
+    pub amount: Amount,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReverseSwapResult {
+    pub swap_id: String,
+    pub amount: Amount,
+    pub invoice: Bolt11Invoice,
+}
+
+impl<B, W, S> Client<B, W, S>
+where
+    B: Blockchain,
+    W: BoardingWallet + OnchainWallet,
+    S: SwapStorage + 'static,
+{
+    // Submarine swap.
+
+    /// Pay a BOLT11 invoice by performing a submarine swap via Boltz. This allows to make Lightning
+    /// payments with an Ark wallet.
+    ///
+    /// # Arguments
+    ///
+    /// - `invoice`: a [`Bolt11Invoice`] to be paid.
+    ///
+    /// # Returns
+    ///
+    /// - A [`SubmarineSwapResult`], including an identifier for the swap and the TXID of the Ark
+    ///   transaction that funds the VHTLC.
+    pub async fn pay_ln_invoice(
+        &self,
+        invoice: Bolt11Invoice,
+    ) -> Result<SubmarineSwapResult, Error> {
+        let refund_public_key = self.inner.kp.public_key();
+
+        let preimage_hash = invoice.payment_hash();
+        let preimage_hash = ripemd160::Hash::hash(preimage_hash.as_byte_array());
+
+        let request = CreateSubmarineSwapRequest {
+            from: Asset::Ark,
+            to: Asset::Btc,
+            invoice,
+            refund_public_key: refund_public_key.into(),
+        };
+        let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to send submarine swap request")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .map_err(|e| Error::ad_hoc(e.to_string()))
+                .context("failed to read error text")?;
+
+            return Err(Error::ad_hoc(format!(
+                "failed to create submarine swap: {error_text}"
+            )));
+        }
+
+        let swap_response: CreateSubmarineSwapResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to deserialize submarine swap response")?;
+
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(Error::ad_hoc)
+            .context("failed to compute created_at")?;
+
+        self.swap_storage()
+            .insert_submarine(
+                swap_response.id.clone(),
+                SubmarineSwapData {
+                    id: swap_response.id.clone(),
+                    status: SwapStatus::Created,
+                    preimage_hash,
+                    refund_public_key: refund_public_key.into(),
+                    claim_public_key: swap_response.claim_public_key,
+                    vhtlc_address: swap_response.address,
+                    timeout_block_heights: swap_response.timeout_block_heights,
+                    amount: swap_response.expected_amount,
+                    invoice: request.invoice.clone(),
+                    created_at: created_at.as_secs(),
+                },
+            )
+            .await?;
+
+        let vhtlc_address = swap_response.address;
+        let amount = swap_response.expected_amount;
+        let txid = self.send_vtxo(vhtlc_address, amount).await?;
+
+        tracing::info!(swap_id = swap_response.id, %amount, "Funded VHTLC");
+
+        Ok(SubmarineSwapResult {
+            swap_id: swap_response.id,
+            txid,
+            amount,
+        })
+    }
+
+    /// Wait for the Lightning invoice associated with a submarine swap to be paid by Boltz.
+    ///
+    /// Boltz will first need to claim our VHTLC before paying the invoice.
+    pub async fn wait_for_invoice_paid(&self, swap_id: &str) -> Result<(), Error> {
+        use futures::StreamExt;
+
+        let stream = self.subscribe_to_swap_updates(swap_id.to_string());
+        tokio::pin!(stream);
+
+        while let Some(status_result) = stream.next().await {
+            match status_result {
+                Ok(status) => {
+                    tracing::debug!(current = ?status, "Swap status");
+                    if status == SwapStatus::InvoicePaid {
+                        return Ok(());
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(Error::ad_hoc("Status stream ended unexpectedly"))
+    }
+
+    /// Refund a VHTLC after the timelock has expired.
+    ///
+    /// This path does not require a signature from Boltz.
+    pub async fn refund_expired_vhtlc(&self, swap_id: &str) -> Result<Txid, Error> {
+        let swap_data = self
+            .swap_storage()
+            .get_submarine(swap_id)
+            .await?
+            .ok_or(Error::ad_hoc("Submarine swap not found"))?;
+
+        let timeout_block_heights = swap_data.timeout_block_heights;
+
+        let vhtlc = VhtlcScript::new(
+            VhtlcOptions {
+                sender: swap_data.refund_public_key.into(),
+                receiver: swap_data.claim_public_key.into(),
+                server: self.server_info.pk.into(),
+                preimage_hash: swap_data.preimage_hash,
+                refund_locktime: timeout_block_heights.refund,
+                unilateral_claim_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_claim,
+                ),
+                unilateral_refund_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund,
+                ),
+                unilateral_refund_without_receiver_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund_without_receiver,
+                ),
+            },
+            self.server_info.network,
+        )
+        .map_err(Error::ad_hoc)?;
+
+        let vhtlc_address = vhtlc.address();
+        if vhtlc_address != swap_data.vhtlc_address {
+            return Err(Error::ad_hoc(format!(
+                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
+                swap_data.vhtlc_address
+            )));
+        }
+
+        let vhtlc_outpoint = {
+            let request = GetVtxosRequest::new_for_addresses(&[vhtlc_address]);
+
+            let list = timeout_op(
+                self.inner.timeout,
+                self.network_client().list_vtxos(request),
+            )
+            .await
+            .context("Failed to fetch VHTLC")??;
+
+            // We expect a single outpoint.
+            let all = list.all();
+            let vhtlc_outpoint = all.first().ok_or_else(|| {
+                Error::ad_hoc(format!("no outpoint found for address {vhtlc_address}"))
+            })?;
+
+            vhtlc_outpoint.clone()
+        };
+
+        let (refund_address, _) = self.get_offchain_address()?;
+        let refund_amount = swap_data.amount;
+
+        let outputs = vec![(&refund_address, refund_amount)];
+
+        let refund_script = vhtlc.refund_without_receiver_script();
+
+        let spend_info = vhtlc.taproot_spend_info();
+        let script_ver = (refund_script, LeafVersion::TapScript);
+        let control_block = spend_info
+            .control_block(&script_ver)
+            .ok_or(Error::ad_hoc("control block not found for refund script"))?;
+
+        let script_pubkey = vhtlc.script_pubkey();
+
+        let vhtlc_input = VtxoInput::new(
+            script_ver.0,
+            Some(
+                LockTime::from_height(swap_data.timeout_block_heights.refund)
+                    .map_err(|e| Error::ad_hoc(format!("invalid block height: {e}")))?,
+            ),
+            control_block,
+            vhtlc.tapscripts(),
+            script_pubkey,
+            refund_amount,
+            vhtlc_outpoint.outpoint,
+        );
+
+        let OffchainTransactions {
+            mut ark_tx,
+            checkpoint_txs,
+        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+
+        let sign_fn = |_: &mut psbt::Input,
+                       msg: secp256k1::Message|
+         -> Result<(schnorr::Signature, XOnlyPublicKey), ark_core::Error> {
+            let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, self.kp());
+            let pk = self.kp().x_only_public_key().0;
+
+            Ok((sig, pk))
+        };
+
+        let checkpoint_tx = checkpoint_txs.first().expect("one checkpoint PSBT");
+
+        sign_ark_transaction(
+            sign_fn,
+            &mut ark_tx,
+            &[(checkpoint_tx.1.clone(), checkpoint_tx.2)],
+            0,
+        )?;
+
+        let ark_txid = ark_tx.unsigned_tx.compute_txid();
+
+        let res = self
+            .network_client()
+            .submit_offchain_transaction_request(
+                ark_tx,
+                checkpoint_txs
+                    .into_iter()
+                    .map(|(psbt, _, _, _)| psbt)
+                    .collect(),
+            )
+            .await?;
+
+        let mut checkpoint_psbt = res
+            .signed_checkpoint_txs
+            .first()
+            .ok_or_else(|| Error::ad_hoc("no checkpoint PSBTs found"))?
+            .clone();
+
+        sign_checkpoint_transaction(sign_fn, &mut checkpoint_psbt, &vhtlc_input)?;
+
+        timeout_op(
+            self.inner.timeout,
+            self.network_client()
+                .finalize_offchain_transaction(ark_txid, vec![checkpoint_psbt]),
+        )
+        .await?
+        .map_err(Error::ark_server)
+        .context("failed to finalize offchain transaction")?;
+
+        tracing::info!(txid = %ark_txid, "Refunded VHTLC");
+
+        Ok(ark_txid)
+    }
+
+    /// Refund a VHTLC with collaboration from Boltz.
+    // TODO: This path is not supported by Boltz yet.
+    pub async fn refund_vhtlc(&self, swap_id: &str) -> Result<Txid, Error> {
+        let swap_data = self
+            .swap_storage()
+            .get_submarine(swap_id)
+            .await?
+            .ok_or(Error::ad_hoc("Submarine swap not found"))?;
+
+        let timeout_block_heights = swap_data.timeout_block_heights;
+
+        let vhtlc = VhtlcScript::new(
+            VhtlcOptions {
+                sender: swap_data.refund_public_key.into(),
+                receiver: swap_data.claim_public_key.into(),
+                server: self.server_info.pk.into(),
+                preimage_hash: swap_data.preimage_hash,
+                refund_locktime: timeout_block_heights.refund,
+                unilateral_claim_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_claim,
+                ),
+                unilateral_refund_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund,
+                ),
+                unilateral_refund_without_receiver_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund_without_receiver,
+                ),
+            },
+            self.server_info.network,
+        )
+        .map_err(Error::ad_hoc)?;
+
+        let vhtlc_address = vhtlc.address();
+        if vhtlc_address != swap_data.vhtlc_address {
+            return Err(Error::ad_hoc(format!(
+                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
+                swap_data.vhtlc_address
+            )));
+        }
+
+        let vhtlc_outpoint = {
+            let request = GetVtxosRequest::new_for_addresses(&[vhtlc_address]);
+
+            let list = timeout_op(
+                self.inner.timeout,
+                self.network_client().list_vtxos(request),
+            )
+            .await
+            .context("Failed to fetch VHTLC")??;
+
+            // We expect a single outpoint.
+            let all = list.all();
+            let vhtlc_outpoint = all.first().ok_or_else(|| {
+                Error::ad_hoc(format!("no outpoint found for address {vhtlc_address}"))
+            })?;
+
+            vhtlc_outpoint.clone()
+        };
+
+        let (refund_address, _) = self.get_offchain_address()?;
+        let refund_amount = swap_data.amount;
+
+        let outputs = vec![(&refund_address, refund_amount)];
+
+        let refund_script = vhtlc.refund_script();
+
+        let spend_info = vhtlc.taproot_spend_info();
+        let script_ver = (refund_script, LeafVersion::TapScript);
+        let control_block = spend_info
+            .control_block(&script_ver)
+            .ok_or(Error::ad_hoc("control block not found for refund script"))?;
+
+        let script_pubkey = vhtlc.script_pubkey();
+
+        let vhtlc_input = VtxoInput::new(
+            script_ver.0,
+            Some(
+                LockTime::from_height(swap_data.timeout_block_heights.refund)
+                    .map_err(|e| Error::ad_hoc(format!("invalid block height: {e}")))?,
+            ),
+            control_block,
+            vhtlc.tapscripts(),
+            script_pubkey,
+            refund_amount,
+            vhtlc_outpoint.outpoint,
+        );
+
+        let OffchainTransactions {
+            mut ark_tx,
+            checkpoint_txs,
+        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+
+        let sign_fn = |_: &mut psbt::Input,
+                       msg: secp256k1::Message|
+         -> Result<(schnorr::Signature, XOnlyPublicKey), ark_core::Error> {
+            // TODO: Implement this once Boltz supports this path and we can test it.
+
+            let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, self.kp());
+            let pk = self.kp().x_only_public_key().0;
+
+            Ok((sig, pk))
+        };
+
+        let checkpoint_tx = checkpoint_txs.first().expect("one checkpoint PSBT");
+
+        sign_ark_transaction(
+            sign_fn,
+            &mut ark_tx,
+            &[(checkpoint_tx.1.clone(), checkpoint_tx.2)],
+            0,
+        )?;
+
+        let url = format!(
+            "{}/v2/swap/submarine/{swap_id}/refund/ark",
+            self.inner.boltz_url
+        );
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .json(&RefundSwapRequest {
+                transaction: ark_tx.to_string(),
+            })
+            .send()
+            .await
+            .map_err(Error::ad_hoc)?;
+
+        let refund_response: RefundSwapResponse = response.json().await.map_err(Error::ad_hoc)?;
+        if let Some(err) = refund_response.error.as_deref() {
+            return Err(Error::ad_hoc(format!("Boltz refund request failed: {err}")));
+        }
+
+        let signed_ark_tx = Psbt::from_str(refund_response.transaction.as_str())
+            .map_err(Error::ad_hoc)
+            .context("Could not parse refund transaction to psbt")?;
+
+        let ark_txid = signed_ark_tx.unsigned_tx.compute_txid();
+
+        let res = self
+            .network_client()
+            .submit_offchain_transaction_request(
+                signed_ark_tx,
+                checkpoint_txs
+                    .into_iter()
+                    .map(|(psbt, _, _, _)| psbt)
+                    .collect(),
+            )
+            .await?;
+
+        let mut checkpoint_psbt = res
+            .signed_checkpoint_txs
+            .first()
+            .ok_or_else(|| Error::ad_hoc("no checkpoint PSBTs found"))?
+            .clone();
+
+        sign_checkpoint_transaction(sign_fn, &mut checkpoint_psbt, &vhtlc_input)?;
+
+        timeout_op(
+            self.inner.timeout,
+            self.network_client()
+                .finalize_offchain_transaction(ark_txid, vec![checkpoint_psbt]),
+        )
+        .await?
+        .map_err(Error::ark_server)
+        .context("failed to finalize offchain transaction")?;
+
+        tracing::info!(txid = %ark_txid, "Refunded VHTLC");
+
+        Ok(ark_txid)
+    }
+
+    // Reverse submarine swap.
+
+    /// Generate a BOLT11 invoice to perform a reverse submarine swap via Boltz. This allows to
+    /// receive Lightning payments into an Ark wallet.
+    ///
+    /// # Arguments
+    ///
+    /// - `amount`: the expected [`Amount`] to be received.
+    ///
+    /// # Returns
+    ///
+    /// - A `ReverseSwapResult`, including an identifier for the reverse swap and the
+    ///   [`Bolt11Invoice`] to be paid.
+    pub async fn get_ln_invoice(&self, amount: Amount) -> Result<ReverseSwapResult, Error> {
+        let preimage: [u8; 32] = musig::rand::random();
+        let preimage_hash_sha256 = sha256::Hash::hash(&preimage);
+        let preimage_hash = ripemd160::Hash::hash(preimage_hash_sha256.as_byte_array());
+
+        let claim_public_key = self.inner.kp.public_key();
+
+        let request = CreateReverseSwapRequest {
+            from: Asset::Btc,
+            to: Asset::Ark,
+            invoice_amount: amount,
+            claim_public_key: claim_public_key.into(),
+            preimage_hash: preimage_hash_sha256,
+        };
+
+        let url = format!("{}/v2/swap/reverse", self.inner.boltz_url);
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to send reverse swap request")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .map_err(|e| Error::ad_hoc(e.to_string()))
+                .context("failed to read error text")?;
+
+            return Err(Error::ad_hoc(format!(
+                "failed to create reverse swap: {error_text}"
+            )));
+        }
+
+        let response: CreateReverseSwapResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to deserialize reverse swap response")?;
+
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(Error::ad_hoc)
+            .context("failed to compute created_at")?;
+
+        let swap = ReverseSwapData {
+            id: response.id.clone(),
+            status: SwapStatus::Created,
+            preimage,
+            vhtlc_address: response.lockup_address,
+            preimage_hash,
+            refund_public_key: response.refund_public_key,
+            amount: response.onchain_amount,
+            claim_public_key: claim_public_key.into(),
+            timeout_block_heights: response.timeout_block_heights,
+            created_at: created_at.as_secs(),
+        };
+
+        self.swap_storage()
+            .insert_reverse(response.id.clone(), swap.clone())
+            .await
+            .context("failed to persist swap data")?;
+
+        Ok(ReverseSwapResult {
+            swap_id: swap.id,
+            invoice: response.invoice,
+            amount: response.onchain_amount,
+        })
+    }
+
+    /// Wait for the VHTLC associated with a reverse submarine swap to be funded, then claim it.
+    pub async fn wait_for_vhtlc(&self, swap_id: &str) -> Result<(), Error> {
+        use futures::StreamExt;
+
+        let swap = self
+            .swap_storage()
+            .get_reverse(swap_id)
+            .await
+            .context("failed to get reverse swap data")?
+            .ok_or_else(|| Error::ad_hoc(format!("reverse swap data not found: {swap_id}")))?;
+
+        let stream = self.subscribe_to_swap_updates(swap_id.to_string());
+        tokio::pin!(stream);
+
+        while let Some(status_result) = stream.next().await {
+            match status_result {
+                Ok(status) => {
+                    tracing::debug!(current = ?status, "Swap status");
+                    if matches!(
+                        status,
+                        SwapStatus::TransactionMempool | SwapStatus::TransactionConfirmed
+                    ) {
+                        break;
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        tracing::debug!("Ark transaction for swap found");
+
+        let timeout_block_heights = swap.timeout_block_heights;
+
+        let vhtlc = VhtlcScript::new(
+            VhtlcOptions {
+                sender: swap.refund_public_key.into(),
+                receiver: swap.claim_public_key.into(),
+                server: self.server_info.pk.into(),
+                preimage_hash: swap.preimage_hash,
+                refund_locktime: timeout_block_heights.refund,
+                unilateral_claim_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_claim,
+                ),
+                unilateral_refund_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund,
+                ),
+                unilateral_refund_without_receiver_delay: Sequence::from_height(
+                    timeout_block_heights.unilateral_refund_without_receiver,
+                ),
+            },
+            self.server_info.network,
+        )
+        .map_err(Error::ad_hoc)?;
+
+        let vhtlc_address = vhtlc.address();
+        if vhtlc_address != swap.vhtlc_address {
+            return Err(Error::ad_hoc(format!(
+                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
+                swap.vhtlc_address
+            )));
+        }
+
+        // TODO: Ideally we can skip this if the vout is always the same (probably 0).
+        let vhtlc_outpoint = {
+            let request = GetVtxosRequest::new_for_addresses(&[vhtlc_address]);
+
+            let list = timeout_op(
+                self.inner.timeout,
+                self.network_client().list_vtxos(request),
+            )
+            .await
+            .context("Failed to fetch VHTLC")??;
+
+            // We expect a single outpoint.
+            let all = list.all();
+            let vhtlc_outpoint = all.first().ok_or_else(|| {
+                Error::ad_hoc(format!("no outpoint found for address {vhtlc_address}"))
+            })?;
+
+            vhtlc_outpoint.clone()
+        };
+
+        let (claim_address, _) = self.get_offchain_address()?;
+        let claim_amount = swap.amount;
+
+        let outputs = vec![(&claim_address, claim_amount)];
+
+        let spend_info = vhtlc.taproot_spend_info();
+        let script_ver = (vhtlc.claim_script(), LeafVersion::TapScript);
+        let control_block = spend_info
+            .control_block(&script_ver)
+            .ok_or(Error::ad_hoc("control block not found for claim script"))?;
+
+        let script_pubkey = vhtlc.script_pubkey();
+
+        let vhtlc_input = VtxoInput::new(
+            script_ver.0,
+            None,
+            control_block,
+            vhtlc.tapscripts(),
+            script_pubkey,
+            claim_amount,
+            vhtlc_outpoint.outpoint,
+        );
+
+        let OffchainTransactions {
+            mut ark_tx,
+            checkpoint_txs,
+        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+
+        let sign_fn = |input: &mut psbt::Input,
+                       msg: secp256k1::Message|
+         -> Result<(schnorr::Signature, XOnlyPublicKey), ark_core::Error> {
+            // Add preimage to PSBT input.
+            {
+                // Initialized with a 1, because we only have one witness element: the preimage.
+                let mut bytes = vec![1];
+
+                let length = VarInt::from(swap.preimage.len() as u64);
+
+                length
+                    .consensus_encode(&mut bytes)
+                    .expect("valid length encoding");
+
+                bytes
+                    .write_all(&swap.preimage)
+                    .expect("valid preimage encoding");
+
+                input.unknown.insert(
+                    psbt::raw::Key {
+                        type_value: u8::MAX,
+                        key: VTXO_CONDITION_KEY.to_vec(),
+                    },
+                    bytes,
+                );
+            }
+
+            let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, self.kp());
+            let pk = self.kp().x_only_public_key().0;
+
+            Ok((sig, pk))
+        };
+
+        let checkpoint_tx = checkpoint_txs.first().expect("one checkpoint PSBT");
+
+        sign_ark_transaction(
+            sign_fn,
+            &mut ark_tx,
+            &[(checkpoint_tx.1.clone(), checkpoint_tx.2)],
+            0,
+        )?;
+
+        let ark_txid = ark_tx.unsigned_tx.compute_txid();
+
+        let res = self
+            .network_client()
+            .submit_offchain_transaction_request(
+                ark_tx,
+                checkpoint_txs
+                    .into_iter()
+                    .map(|(psbt, _, _, _)| psbt)
+                    .collect(),
+            )
+            .await?;
+
+        let mut checkpoint_psbt = res
+            .signed_checkpoint_txs
+            .first()
+            .ok_or_else(|| Error::ad_hoc("no checkpoint PSBTs found"))?
+            .clone();
+
+        sign_checkpoint_transaction(sign_fn, &mut checkpoint_psbt, &vhtlc_input)?;
+
+        timeout_op(
+            self.inner.timeout,
+            self.network_client()
+                .finalize_offchain_transaction(ark_txid, vec![checkpoint_psbt]),
+        )
+        .await?
+        .map_err(Error::ark_server)
+        .context("failed to finalize offchain transaction")?;
+
+        tracing::info!(txid = %ark_txid, "Spent VHTLC");
+
+        Ok(())
+    }
+
+    /// Use Boltz's API to learn about updates for a particular swap.
+    // TODO: Make sure this is WASM-compatible.
+    pub fn subscribe_to_swap_updates(
+        &self,
+        swap_id: String,
+    ) -> impl futures::Stream<Item = Result<SwapStatus, Error>> + '_ {
+        async_stream::stream! {
+            let mut last_status: Option<SwapStatus> = None;
+            let url = format!("{}/v2/swap/{swap_id}", self.inner.boltz_url);
+
+            loop {
+                let client = reqwest::Client::new();
+                let response = client
+                    .get(&url)
+                    .send()
+                    .await;
+
+                match response {
+                    Ok(resp) if resp.status().is_success() => {
+                        let status_response = resp
+                            .json::<GetSwapStatusResponse>()
+                            .await
+                            .map_err(|e| Error::ad_hoc(e.to_string()));
+
+                        match status_response {
+                            Ok(current_status) => {
+                                let current_status = current_status.status;
+
+                                // Only yield if status has changed
+                                if last_status.as_ref() != Some(&current_status) {
+                                    last_status = Some(current_status.clone());
+                                    yield Ok(current_status);
+                                }
+                            }
+                            Err(e) => {
+                                yield Err(Error::ad_hoc(format!(
+                                            "failed to deserialize swap status response: {e}"
+                                        )));
+                                break;
+                            }
+                        }
+                    }
+                    Ok(resp) => {
+                        let error_text = resp
+                            .text()
+                            .await
+                            .unwrap_or_else(|_| "Unknown error".to_string());
+
+                        yield Err(Error::ad_hoc(format!(
+                            "failed to check swap status: {error_text}"
+                        )));
+                        break;
+                    }
+                    Err(e) => {
+                        yield Err(Error::ad_hoc(e.to_string())
+                            .context("failed to send swap status request"));
+                        break;
+                    }
+                }
+
+                // Poll every second
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+/// Data related to a submarine swap.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubmarineSwapData {
+    /// Unique swap identifier.
+    pub id: String,
+    /// The preimage hash of the BOLT11 invoice.
+    pub preimage_hash: ripemd160::Hash,
+    /// Public key of the receiving party.
+    pub claim_public_key: PublicKey,
+    /// Public key of the sending party.
+    pub refund_public_key: PublicKey,
+    /// Amount locked up in the VHTLC.
+    pub amount: Amount,
+    /// All the timelocks for this swap.
+    pub timeout_block_heights: TimeoutBlockHeights,
+    /// Address where funds are locked.
+    #[serde_as(as = "DisplayFromStr")]
+    pub vhtlc_address: ArkAddress,
+    /// BOLT11 invoice associated with the swap.
+    pub invoice: Bolt11Invoice,
+    /// Current swap status.
+    pub status: SwapStatus,
+    /// UNIX timestamp when swap was created.
+    pub created_at: u64,
+}
+
+/// Data related to a reverse submarine swap.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReverseSwapData {
+    /// Unique swap identifier.
+    pub id: String,
+    /// Preimage for the swap.
+    pub preimage: [u8; 32],
+    /// The preimage hash of the BOLT11 invoice.
+    pub preimage_hash: ripemd160::Hash,
+    /// Public key of the receiving party.
+    pub claim_public_key: PublicKey,
+    /// Public key of the sending party.
+    pub refund_public_key: PublicKey,
+    /// Amount locked up in the VHTLC.
+    pub amount: Amount,
+    /// All the timelocks for this swap.
+    pub timeout_block_heights: TimeoutBlockHeights,
+    /// Address where funds are locked.
+    #[serde_as(as = "DisplayFromStr")]
+    pub vhtlc_address: ArkAddress,
+    /// Current swap status.
+    pub status: SwapStatus,
+    /// UNIX timestamp when swap was created.
+    pub created_at: u64,
+}
+
+/// All possible states of a Boltz swap.
+///
+/// Swaps progress through these states during their lifecycle.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SwapStatus {
+    /// Initial state when swap is created.
+    #[serde(rename = "swap.created")]
+    Created,
+    /// Lockup transaction detected in mempool.
+    #[serde(rename = "transaction.mempool")]
+    TransactionMempool,
+    /// Lockup transaction confirmed on-chain.
+    #[serde(rename = "transaction.confirmed")]
+    TransactionConfirmed,
+    /// Transaction refunded.
+    #[serde(rename = "transaction.refunded")]
+    TransactionRefunded,
+    /// Transaction failed.
+    #[serde(rename = "transaction.failed")]
+    TransactionFailed,
+    /// Transaction claimed.
+    #[serde(rename = "transaction.claimed")]
+    TransactionClaimed,
+    /// Lightning invoice has been set.
+    #[serde(rename = "invoice.set")]
+    InvoiceSet,
+    /// Waiting for Lightning invoice payment.
+    #[serde(rename = "invoice.pending")]
+    InvoicePending,
+    /// Lightning invoice successfully paid.
+    #[serde(rename = "invoice.paid")]
+    InvoicePaid,
+    /// Lightning invoice payment failed.
+    #[serde(rename = "invoice.failedToPay")]
+    InvoiceFailedToPay,
+    /// Invoice expired.
+    #[serde(rename = "invoice.expired")]
+    InvoiceExpired,
+    /// Swap expired - can be refunded.
+    #[serde(rename = "swap.expired")]
+    SwapExpired,
+    /// Swap failed with error.
+    #[serde(rename = "error")]
+    Error { error: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Copy)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeoutBlockHeights {
+    pub refund: u32,
+    pub unilateral_claim: u16,
+    pub unilateral_refund: u16,
+    pub unilateral_refund_without_receiver: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum Asset {
+    Btc,
+    Ark,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateReverseSwapRequest {
+    from: Asset,
+    to: Asset,
+    invoice_amount: Amount,
+    claim_public_key: PublicKey,
+    preimage_hash: sha256::Hash,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateReverseSwapResponse {
+    id: String,
+    #[serde_as(as = "DisplayFromStr")]
+    lockup_address: ArkAddress,
+    refund_public_key: PublicKey,
+    timeout_block_heights: TimeoutBlockHeights,
+    invoice: Bolt11Invoice,
+    onchain_amount: Amount,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CreateSubmarineSwapRequest {
+    from: Asset,
+    to: Asset,
+    invoice: Bolt11Invoice,
+    #[serde(rename = "refundPublicKey")]
+    refund_public_key: PublicKey,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateSubmarineSwapResponse {
+    id: String,
+    #[serde_as(as = "DisplayFromStr")]
+    address: ArkAddress,
+    expected_amount: Amount,
+    claim_public_key: PublicKey,
+    timeout_block_heights: TimeoutBlockHeights,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GetSwapStatusResponse {
+    status: SwapStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RefundSwapRequest {
+    transaction: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RefundSwapResponse {
+    transaction: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -271,7 +271,12 @@ where
         let OffchainTransactions {
             mut ark_tx,
             checkpoint_txs,
-        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+        } = build_offchain_transactions(
+            &outputs,
+            None,
+            std::slice::from_ref(&vhtlc_input),
+            &self.server_info,
+        )?;
 
         let sign_fn = |_: &mut psbt::Input,
                        msg: secp256k1::Message|
@@ -416,7 +421,12 @@ where
         let OffchainTransactions {
             mut ark_tx,
             checkpoint_txs,
-        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+        } = build_offchain_transactions(
+            &outputs,
+            None,
+            std::slice::from_ref(&vhtlc_input),
+            &self.server_info,
+        )?;
 
         let sign_fn = |_: &mut psbt::Input,
                        msg: secp256k1::Message|
@@ -691,7 +701,12 @@ where
         let OffchainTransactions {
             mut ark_tx,
             checkpoint_txs,
-        } = build_offchain_transactions(&outputs, None, &[vhtlc_input.clone()], &self.server_info)?;
+        } = build_offchain_transactions(
+            &outputs,
+            None,
+            std::slice::from_ref(&vhtlc_input),
+            &self.server_info,
+        )?;
 
         let sign_fn = |input: &mut psbt::Input,
                        msg: secp256k1::Message|

--- a/ark-client/src/coin_select.rs
+++ b/ark-client/src/coin_select.rs
@@ -1,3 +1,4 @@
+use crate::swap_storage::SwapStorage;
 use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
 use crate::Blockchain;
@@ -20,8 +21,8 @@ use std::collections::HashSet;
 /// https://github.com/bitcoindevkit/coin-select.
 ///
 /// TODO: Part of this logic needs to be extracted into `ark-core`.
-pub async fn coin_select_for_onchain<B, W>(
-    client: &Client<B, W>,
+pub async fn coin_select_for_onchain<B, W, S>(
+    client: &Client<B, W, S>,
     target_amount: Amount,
 ) -> Result<
     (
@@ -33,6 +34,7 @@ pub async fn coin_select_for_onchain<B, W>(
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
+    S: SwapStorage + 'static,
 {
     let boarding_outputs = client.inner.wallet.get_boarding_outputs()?;
 

--- a/ark-client/src/swap_storage/memory.rs
+++ b/ark-client/src/swap_storage/memory.rs
@@ -1,0 +1,109 @@
+use super::SwapStorage;
+use crate::boltz::ReverseSwapData;
+use crate::boltz::SubmarineSwapData;
+use crate::boltz::SwapStatus;
+use crate::Error;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// In-memory implementation of [`SwapStorage`].
+///
+/// This implementation stores swap data in memory using a [`HashMap`] protected by a [`Mutex`].
+/// Data is lost when the application restarts, making this suitable for development, testing,
+/// and scenarios where persistence is not required.
+pub struct InMemorySwapStorage {
+    submarine_swaps: Arc<Mutex<HashMap<String, SubmarineSwapData>>>,
+    reverse_swaps: Arc<Mutex<HashMap<String, ReverseSwapData>>>,
+}
+
+impl InMemorySwapStorage {
+    /// Create a new in-memory swap storage.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use ark_client::InMemorySwapStorage;
+    ///
+    /// let storage = InMemorySwapStorage::new();
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            submarine_swaps: Arc::new(Mutex::new(HashMap::new())),
+            reverse_swaps: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for InMemorySwapStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl SwapStorage for InMemorySwapStorage {
+    async fn insert_submarine(&self, id: String, data: SubmarineSwapData) -> Result<(), Error> {
+        let mut swaps = self.submarine_swaps.lock().expect("lock");
+        swaps.insert(id, data);
+        Ok(())
+    }
+
+    async fn insert_reverse(&self, id: String, data: ReverseSwapData) -> Result<(), Error> {
+        let mut swaps = self.reverse_swaps.lock().expect("lock");
+        swaps.insert(id, data);
+        Ok(())
+    }
+
+    async fn get_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error> {
+        let swaps = self.submarine_swaps.lock().expect("lock");
+        Ok(swaps.get(id).cloned())
+    }
+
+    async fn get_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error> {
+        let swaps = self.reverse_swaps.lock().expect("lock");
+        Ok(swaps.get(id).cloned())
+    }
+
+    async fn update_status_submarine(&self, id: &str, status: SwapStatus) -> Result<(), Error> {
+        let mut swaps = self.submarine_swaps.lock().expect("lock");
+        if let Some(swap) = swaps.get_mut(id) {
+            swap.status = status;
+            Ok(())
+        } else {
+            Err(Error::consumer(format!("swap not found: {id}")))
+        }
+    }
+
+    async fn update_status_reverse(&self, id: &str, status: SwapStatus) -> Result<(), Error> {
+        let mut swaps = self.reverse_swaps.lock().expect("lock");
+        if let Some(swap) = swaps.get_mut(id) {
+            swap.status = status;
+            Ok(())
+        } else {
+            Err(Error::consumer(format!("swap not found: {id}")))
+        }
+    }
+
+    async fn list_all_submarine(&self) -> Result<Vec<SubmarineSwapData>, Error> {
+        let swaps = self.submarine_swaps.lock().expect("lock");
+        Ok(swaps.values().cloned().collect())
+    }
+
+    async fn list_all_reverse(&self) -> Result<Vec<ReverseSwapData>, Error> {
+        let swaps = self.reverse_swaps.lock().expect("lock");
+
+        Ok(swaps.values().cloned().collect())
+    }
+
+    async fn remove_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error> {
+        let mut swaps = self.submarine_swaps.lock().expect("lock");
+        Ok(swaps.remove(id))
+    }
+
+    async fn remove_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error> {
+        let mut swaps = self.reverse_swaps.lock().expect("lock");
+        Ok(swaps.remove(id))
+    }
+}

--- a/ark-client/src/swap_storage/mod.rs
+++ b/ark-client/src/swap_storage/mod.rs
@@ -1,0 +1,135 @@
+//! # Swap Storage
+//!
+//! The Ark client supports pluggable swap storage implementations, allowing you to persist
+//! swap data using your preferred storage backend while providing an in-memory fallback by default.
+//!
+//! ## Available Implementations
+//!
+//! - [`InMemorySwapStorage`] - Default in-memory implementation for development and testing
+//! - [`SqliteSwapStorage`] - SQLite-based persistent implementation for production use
+use crate::boltz::ReverseSwapData;
+use crate::boltz::SubmarineSwapData;
+use crate::boltz::SwapStatus;
+use crate::Error;
+use async_trait::async_trait;
+
+mod memory;
+mod sqlite;
+
+pub use memory::InMemorySwapStorage;
+pub use sqlite::SqliteSwapStorage;
+
+/// Trait for storing and retrieving swap data.
+///
+/// This trait provides a pluggable interface for swap persistence, allowing different
+/// storage backends to be used with the Ark client.
+#[async_trait]
+pub trait SwapStorage: Send + Sync {
+    /// Store submarine swap data.
+    ///
+    /// # Arguments
+    /// * `id` - Unique identifier for the swap
+    /// * `data` - The swap data to store
+    ///
+    /// # Errors
+    /// Returns an error if the swap cannot be stored (e.g., database error, duplicate ID).
+    async fn insert_submarine(&self, id: String, data: SubmarineSwapData) -> Result<(), Error>;
+
+    /// Store reverse submarine swap data.
+    ///
+    /// # Arguments
+    /// * `id` - Unique identifier for the swap
+    /// * `data` - The swap data to store
+    ///
+    /// # Errors
+    /// Returns an error if the swap cannot be stored (e.g., database error, duplicate ID).
+    async fn insert_reverse(&self, id: String, data: ReverseSwapData) -> Result<(), Error>;
+
+    /// Retrieve submarine swap data by ID.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to retrieve
+    ///
+    /// # Returns
+    /// * `Ok(Some(data))` if the swap exists
+    /// * `Ok(None)` if the swap does not exist
+    /// * `Err(error)` if there was an error accessing storage
+    async fn get_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error>;
+
+    /// Retrieve reverse submarine swap data by ID.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to retrieve
+    ///
+    /// # Returns
+    /// * `Ok(Some(data))` if the swap exists
+    /// * `Ok(None)` if the swap does not exist
+    /// * `Err(error)` if there was an error accessing storage
+    async fn get_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error>;
+
+    /// Update the status of an existing submarine swap.
+    ///
+    /// This is a convenience method that retrieves the swap, updates its status,
+    /// and saves it back to storage.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to update
+    /// * `status` - The new status to set
+    ///
+    /// # Errors
+    /// Returns an error if the swap doesn't exist or cannot be updated.
+    async fn update_status_submarine(&self, id: &str, status: SwapStatus) -> Result<(), Error>;
+
+    /// Update the status of an existing reverse submarine swap.
+    ///
+    /// This is a convenience method that retrieves the swap, updates its status,
+    /// and saves it back to storage.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to update
+    /// * `status` - The new status to set
+    ///
+    /// # Errors
+    /// Returns an error if the swap doesn't exist or cannot be updated.
+    async fn update_status_reverse(&self, id: &str, status: SwapStatus) -> Result<(), Error>;
+
+    /// List all stored submarine swaps.
+    ///
+    /// # Returns
+    /// A vector containing all swap data. The order may vary by implementation.
+    ///
+    /// # Errors
+    /// Returns an error if the swaps cannot be retrieved from storage.
+    async fn list_all_submarine(&self) -> Result<Vec<SubmarineSwapData>, Error>;
+
+    /// List all stored reverse submarine swaps.
+    ///
+    /// # Returns
+    /// A vector containing all swap data. The order may vary by implementation.
+    ///
+    /// # Errors
+    /// Returns an error if the swaps cannot be retrieved from storage.
+    async fn list_all_reverse(&self) -> Result<Vec<ReverseSwapData>, Error>;
+
+    /// Remove submarine swap data by ID.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to remove
+    ///
+    /// # Returns
+    /// * `Ok(Some(data))` if the swap existed and was removed
+    /// * `Ok(None)` if the swap did not exist
+    /// * `Err(error)` if there was an error accessing storage
+    async fn remove_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error>;
+
+    /// Remove reverse submarine swap data by ID.
+    ///
+    /// # Arguments
+    /// * `id` - The unique identifier of the swap to remove
+    ///
+    /// # Returns
+    /// * `Ok(Some(data))` if the swap existed and was removed
+    /// * `Ok(None)` if the swap did not exist
+    /// * `Err(error)` if there was an error accessing storage
+    async fn remove_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error>;
+}

--- a/ark-client/src/swap_storage/sqlite.rs
+++ b/ark-client/src/swap_storage/sqlite.rs
@@ -1,0 +1,483 @@
+use super::SwapStorage;
+use crate::boltz::ReverseSwapData;
+use crate::boltz::SubmarineSwapData;
+use crate::boltz::SwapStatus;
+use crate::Error;
+use async_trait::async_trait;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::sqlite::SqliteRow;
+use sqlx::Pool;
+use sqlx::Row;
+use sqlx::Sqlite;
+use std::path::Path;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+// TODO: move this into its own crate?
+/// SQLite-based persistent implementation of [`SwapStorage`].
+pub struct SqliteSwapStorage {
+    pool: Pool<Sqlite>,
+}
+
+impl SqliteSwapStorage {
+    /// Create a new SQLite swap storage with the specified database file path.
+    ///
+    /// The database file and parent directories will be created if they don't exist.
+    /// Database migrations will be automatically applied.
+    ///
+    /// # Arguments
+    /// * `db_path` - Path to the SQLite database file
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The database file cannot be created or opened
+    /// - Database migrations fail
+    /// - Parent directory cannot be created
+    pub async fn new<P: AsRef<Path>>(db_path: P) -> Result<Self, Error> {
+        let db_path = db_path.as_ref();
+
+        // Create parent directory if it doesn't exist
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                Error::consumer(format!("Failed to create database directory: {e}"))
+            })?;
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect_with(options)
+            .await
+            .map_err(|e| Error::consumer(format!("Failed to connect to database: {e}")))?;
+
+        // Run migrations
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .map_err(|e| Error::consumer(format!("Failed to run migrations: {e}")))?;
+
+        Ok(Self { pool })
+    }
+
+    /// Create a new SQLite swap storage with the default database path.
+    ///
+    /// The default path is `./swaps.db` in the current working directory.
+    /// This is convenient for development and single-instance deployments.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be created or opened in the current directory.
+    pub async fn new_default() -> Result<Self, Error> {
+        let db_path = Path::new("swaps.db");
+        Self::new(db_path).await
+    }
+
+    fn current_timestamp() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("valid duration")
+            .as_secs() as i64
+    }
+}
+
+#[async_trait]
+impl SwapStorage for SqliteSwapStorage {
+    async fn insert_submarine(&self, id: String, data: SubmarineSwapData) -> Result<(), Error> {
+        let data_json = serde_json::to_string(&data).map_err(|e| {
+            Error::consumer(format!("Failed to serialize submarine swap data: {e}"))
+        })?;
+
+        let now = Self::current_timestamp();
+
+        sqlx::query(
+            "INSERT INTO submarine_swaps (id, data, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(&data_json)
+        .bind(now)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| Error::consumer(format!("Failed to insert submarine swap: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn insert_reverse(&self, id: String, data: ReverseSwapData) -> Result<(), Error> {
+        let data_json = serde_json::to_string(&data)
+            .map_err(|e| Error::consumer(format!("Failed to serialize reverse swap data: {e}")))?;
+
+        let now = Self::current_timestamp();
+
+        sqlx::query(
+            "INSERT INTO reverse_swaps (id, data, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        )
+        .bind(&id)
+        .bind(&data_json)
+        .bind(now)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| Error::consumer(format!("Failed to insert reverse swap: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn get_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error> {
+        let row: Option<SqliteRow> = sqlx::query("SELECT data FROM submarine_swaps WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| Error::consumer(format!("Failed to query submarine swap: {e}")))?;
+
+        match row {
+            Some(row) => {
+                let data: String = row.get("data");
+                let swap_data: SubmarineSwapData = serde_json::from_str(&data).map_err(|e| {
+                    Error::consumer(format!("Failed to deserialize submarine swap data: {e}"))
+                })?;
+                Ok(Some(swap_data))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn get_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error> {
+        let row: Option<SqliteRow> = sqlx::query("SELECT data FROM reverse_swaps WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| Error::consumer(format!("Failed to query reverse swap: {e}")))?;
+
+        match row {
+            Some(row) => {
+                let data: String = row.get("data");
+                let swap_data: ReverseSwapData = serde_json::from_str(&data).map_err(|e| {
+                    Error::consumer(format!("Failed to deserialize reverse swap data: {e}"))
+                })?;
+                Ok(Some(swap_data))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn update_status_submarine(&self, id: &str, status: SwapStatus) -> Result<(), Error> {
+        // First, get the existing swap
+        let mut swap_data = self
+            .get_submarine(id)
+            .await?
+            .ok_or_else(|| Error::consumer(format!("Submarine swap not found: {id}")))?;
+
+        // Update the status
+        swap_data.status = status;
+
+        // Serialize and save back
+        let data_json = serde_json::to_string(&swap_data).map_err(|e| {
+            Error::consumer(format!("Failed to serialize submarine swap data: {e}"))
+        })?;
+
+        let now = Self::current_timestamp();
+
+        let result =
+            sqlx::query("UPDATE submarine_swaps SET data = ?, updated_at = ? WHERE id = ?")
+                .bind(&data_json)
+                .bind(now)
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| Error::consumer(format!("Failed to update submarine swap: {e}")))?;
+
+        if result.rows_affected() == 0 {
+            return Err(Error::consumer(format!("Submarine swap not found: {id}")));
+        }
+
+        Ok(())
+    }
+
+    async fn update_status_reverse(&self, id: &str, status: SwapStatus) -> Result<(), Error> {
+        // First, get the existing swap
+        let mut swap_data = self
+            .get_reverse(id)
+            .await?
+            .ok_or_else(|| Error::consumer(format!("Reverse swap not found: {id}")))?;
+
+        // Update the status
+        swap_data.status = status;
+
+        // Serialize and save back
+        let data_json = serde_json::to_string(&swap_data)
+            .map_err(|e| Error::consumer(format!("Failed to serialize reverse swap data: {e}")))?;
+
+        let now = Self::current_timestamp();
+
+        let result = sqlx::query("UPDATE reverse_swaps SET data = ?, updated_at = ? WHERE id = ?")
+            .bind(&data_json)
+            .bind(now)
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| Error::consumer(format!("Failed to update reverse swap: {e}")))?;
+
+        if result.rows_affected() == 0 {
+            return Err(Error::consumer(format!("Reverse swap not found: {id}")));
+        }
+
+        Ok(())
+    }
+
+    async fn list_all_submarine(&self) -> Result<Vec<SubmarineSwapData>, Error> {
+        let rows: Vec<SqliteRow> =
+            sqlx::query("SELECT data FROM submarine_swaps ORDER BY created_at ASC")
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| Error::consumer(format!("Failed to list submarine swaps: {e}")))?;
+
+        let mut swaps = Vec::new();
+        for row in rows {
+            let data: String = row.get("data");
+            let swap_data: SubmarineSwapData = serde_json::from_str(&data).map_err(|e| {
+                Error::consumer(format!("Failed to deserialize submarine swap data: {e}"))
+            })?;
+            swaps.push(swap_data);
+        }
+
+        Ok(swaps)
+    }
+
+    async fn list_all_reverse(&self) -> Result<Vec<ReverseSwapData>, Error> {
+        let rows: Vec<SqliteRow> =
+            sqlx::query("SELECT data FROM reverse_swaps ORDER BY created_at ASC")
+                .fetch_all(&self.pool)
+                .await
+                .map_err(|e| Error::consumer(format!("Failed to list reverse swaps: {e}")))?;
+
+        let mut swaps = Vec::new();
+        for row in rows {
+            let data: String = row.get("data");
+            let swap_data: ReverseSwapData = serde_json::from_str(&data).map_err(|e| {
+                Error::consumer(format!("Failed to deserialize reverse swap data: {e}"))
+            })?;
+            swaps.push(swap_data);
+        }
+
+        Ok(swaps)
+    }
+
+    async fn remove_submarine(&self, id: &str) -> Result<Option<SubmarineSwapData>, Error> {
+        // First get the swap data to return it
+        let swap_data = self.get_submarine(id).await?;
+
+        if swap_data.is_some() {
+            let result = sqlx::query("DELETE FROM submarine_swaps WHERE id = ?")
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| Error::consumer(format!("Failed to delete submarine swap: {e}")))?;
+
+            if result.rows_affected() == 0 {
+                return Ok(None);
+            }
+        }
+
+        Ok(swap_data)
+    }
+
+    async fn remove_reverse(&self, id: &str) -> Result<Option<ReverseSwapData>, Error> {
+        // First get the swap data to return it
+        let swap_data = self.get_reverse(id).await?;
+
+        if swap_data.is_some() {
+            let result = sqlx::query("DELETE FROM reverse_swaps WHERE id = ?")
+                .bind(id)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| Error::consumer(format!("Failed to delete reverse swap: {e}")))?;
+
+            if result.rows_affected() == 0 {
+                return Ok(None);
+            }
+        }
+
+        Ok(swap_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_core::ArkAddress;
+    use bitcoin::hashes::ripemd160;
+    use bitcoin::hashes::Hash;
+    use bitcoin::Amount;
+    use bitcoin::PublicKey;
+    use lightning_invoice::Bolt11Invoice;
+    use std::str::FromStr;
+    use tempfile::TempDir;
+
+    fn create_test_submarine_swap_data(id: &str) -> SubmarineSwapData {
+        SubmarineSwapData {
+            id: id.to_string(),
+            status: SwapStatus::Created,
+            preimage_hash: ripemd160::Hash::from_slice(&[2u8; 20]).unwrap(),
+            refund_public_key: PublicKey::from_str(
+                "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            )
+            .unwrap(),
+            claim_public_key: PublicKey::from_str(
+                "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            )
+            .unwrap(),
+            vhtlc_address: ArkAddress::decode("tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x").unwrap(),
+            timeout_block_heights: crate::boltz::TimeoutBlockHeights {
+                refund: 144,
+                unilateral_claim: 24,
+                unilateral_refund: 144,
+                unilateral_refund_without_receiver: 288,
+            },
+            amount: Amount::from_sat(100_000),
+            invoice: Bolt11Invoice::from_str("lnbcrt10u1p5d55pjpp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp57x0nwf7nzsndjdrvsre570ehg0szw34l284hswdz6zpqvktq9mrs9qxpqysgqllgxhxeny0tvtnxuqgn4s0t2qamc6yqc4t3pe6p2x5lgs8v8r3vxzxp3a3ax9j7d2ta5cduddln8n9se7q0jgg7s0h8t2vhljlu3wkcps9k8xs").unwrap(),
+            created_at: 1234567890,
+        }
+    }
+
+    fn create_test_reverse_swap_data(id: &str) -> ReverseSwapData {
+        ReverseSwapData {
+            id: id.to_string(),
+            status: SwapStatus::Created,
+            preimage: [1u8; 32],
+            vhtlc_address: ArkAddress::decode("tark1qqellv77udfmr20tun8dvju5vgudpf9vxe8jwhthrkn26fz96pawqfdy8nk05rsmrf8h94j26905e7n6sng8y059z8ykn2j5xcuw4xt846qj6x").unwrap(),
+            preimage_hash: ripemd160::Hash::from_slice(&[2u8; 20]).unwrap(),
+            refund_public_key: PublicKey::from_str(
+                "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            )
+            .unwrap(),
+            amount: Amount::from_sat(100_000),
+            claim_public_key: PublicKey::from_str(
+                "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            )
+            .unwrap(),
+            timeout_block_heights: crate::boltz::TimeoutBlockHeights {
+                refund: 144,
+                unilateral_claim: 24,
+                unilateral_refund: 144,
+                unilateral_refund_without_receiver: 288,
+            },
+            created_at: 1234567890,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_storage_submarine_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let storage = SqliteSwapStorage::new(&db_path).await.unwrap();
+
+        // Test insert and get
+        let swap1 = create_test_submarine_swap_data("swap1");
+        storage
+            .insert_submarine("swap1".to_string(), swap1.clone())
+            .await
+            .unwrap();
+
+        let retrieved = storage.get_submarine("swap1").await.unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.id, swap1.id);
+        assert_eq!(retrieved.status, swap1.status);
+
+        // Test get non-existent
+        let non_existent = storage.get_submarine("nonexistent").await.unwrap();
+        assert!(non_existent.is_none());
+
+        // Test list_all
+        let swap2 = create_test_submarine_swap_data("swap2");
+        storage
+            .insert_submarine("swap2".to_string(), swap2.clone())
+            .await
+            .unwrap();
+
+        let all_swaps = storage.list_all_submarine().await.unwrap();
+        assert_eq!(all_swaps.len(), 2);
+
+        // Test update_status
+        storage
+            .update_status_submarine("swap1", SwapStatus::InvoicePaid)
+            .await
+            .unwrap();
+        let updated = storage.get_submarine("swap1").await.unwrap().unwrap();
+        assert_eq!(updated.status, SwapStatus::InvoicePaid);
+
+        // Test remove
+        let removed = storage.remove_submarine("swap1").await.unwrap();
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().id, "swap1");
+
+        let after_remove = storage.get_submarine("swap1").await.unwrap();
+        assert!(after_remove.is_none());
+
+        let remaining = storage.list_all_submarine().await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "swap2");
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_storage_reverse_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let storage = SqliteSwapStorage::new(&db_path).await.unwrap();
+
+        // Test insert and get
+        let swap1 = create_test_reverse_swap_data("swap1");
+        storage
+            .insert_reverse("swap1".to_string(), swap1.clone())
+            .await
+            .unwrap();
+
+        let retrieved = storage.get_reverse("swap1").await.unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.id, swap1.id);
+        assert_eq!(retrieved.status, swap1.status);
+
+        // Test get non-existent
+        let non_existent = storage.get_reverse("nonexistent").await.unwrap();
+        assert!(non_existent.is_none());
+
+        // Test list_all
+        let swap2 = create_test_reverse_swap_data("swap2");
+        storage
+            .insert_reverse("swap2".to_string(), swap2.clone())
+            .await
+            .unwrap();
+
+        let all_swaps = storage.list_all_reverse().await.unwrap();
+        assert_eq!(all_swaps.len(), 2);
+
+        // Test update_status
+        storage
+            .update_status_reverse("swap1", SwapStatus::InvoicePaid)
+            .await
+            .unwrap();
+        let updated = storage.get_reverse("swap1").await.unwrap().unwrap();
+        assert_eq!(updated.status, SwapStatus::InvoicePaid);
+
+        // Test remove
+        let removed = storage.remove_reverse("swap1").await.unwrap();
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().id, "swap1");
+
+        let after_remove = storage.get_reverse("swap1").await.unwrap();
+        assert!(after_remove.is_none());
+
+        let remaining = storage.list_all_reverse().await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "swap2");
+    }
+}

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -1,6 +1,7 @@
 use crate::coin_select::coin_select_for_onchain;
 use crate::error::Error;
 use crate::error::ErrorContext;
+use crate::swap_storage::SwapStorage;
 use crate::utils::sleep;
 use crate::utils::timeout_op;
 use crate::wallet::BoardingWallet;
@@ -23,10 +24,11 @@ use std::collections::HashSet;
 
 // TODO: We should not _need_ to connect to the Ark server to perform unilateral exit. Currently we
 // do talk to the Ark server for simplicity.
-impl<B, W> Client<B, W>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
+    S: SwapStorage + 'static,
 {
     /// Build the unilateral exit transaction tree for all spendable VTXOs.
     ///

--- a/ark-core/Cargo.toml
+++ b/ark-core/Cargo.toml
@@ -12,6 +12,7 @@ musig = { package = "ark-secp256k1", path = "../ark-rust-secp256k1", features = 
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0"
 tracing = "0.1.37"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/ark-core/src/ark_address.rs
+++ b/ark-core/src/ark_address.rs
@@ -5,8 +5,9 @@ use bitcoin::key::TweakedPublicKey;
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use bitcoin::XOnlyPublicKey;
+use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ArkAddress {
     version: u8,
     hrp: Hrp,
@@ -77,6 +78,14 @@ impl ArkAddress {
 impl std::fmt::Display for ArkAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.encode())
+    }
+}
+
+impl FromStr for ArkAddress {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::decode(s)
     }
 }
 

--- a/ark-core/src/batch.rs
+++ b/ark-core/src/batch.rs
@@ -431,7 +431,7 @@ where
         forfeit_psbt.inputs[FORFEIT_TX_VTXO_INDEX].sighash_type =
             Some(TapSighashType::Default.into());
 
-        let (forfeit_script, forfeit_control_block) = vtxo.forfeit_spend_info();
+        let (forfeit_script, forfeit_control_block) = vtxo.forfeit_spend_info()?;
 
         let leaf_version = forfeit_control_block.leaf_version;
         forfeit_psbt.inputs[FORFEIT_TX_VTXO_INDEX].tap_scripts = BTreeMap::from_iter([(

--- a/ark-core/src/lib.rs
+++ b/ark-core/src/lib.rs
@@ -9,14 +9,15 @@ pub mod coin_select;
 pub mod conversions;
 pub mod history;
 pub mod proof_of_funds;
+pub mod script;
 pub mod send;
 pub mod server;
 pub mod unilateral_exit;
+pub mod vhtlc;
 pub mod vtxo;
 
 mod ark_address;
 mod error;
-mod script;
 mod tree_tx_output_script;
 mod tx_graph;
 

--- a/ark-core/src/proof_of_funds.rs
+++ b/ark-core/src/proof_of_funds.rs
@@ -43,6 +43,10 @@ pub struct Input {
     witness_utxo: TxOut,
     // We do not serialize this.
     tapscripts: Vec<ScriptBuf>,
+    // TODO: I think including this assumes that the input is always singlesig.
+    //
+    // For a more general VTXO, the requirement here is that we sign a spend path that does not
+    // involve the server (proving unilateral ownership of the VTXO, I guess).
     pk: XOnlyPublicKey,
     spend_info: (ScriptBuf, taproot::ControlBlock),
     is_onchain: bool,

--- a/ark-core/src/script.rs
+++ b/ark-core/src/script.rs
@@ -16,6 +16,7 @@ pub fn multisig_script(pk_0: XOnlyPublicKey, pk_1: XOnlyPublicKey) -> ScriptBuf 
 
 /// A [`ScriptBuf`] allowing the owner of `pk` to spend after `locktime_seconds` have passed from
 /// the time the corresponding output was included in a block.
+// TODO: Should support multisig.
 pub fn csv_sig_script(locktime: bitcoin::Sequence, pk: XOnlyPublicKey) -> ScriptBuf {
     ScriptBuf::builder()
         .push_int(locktime.to_consensus_u32() as i64)

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -197,13 +197,14 @@ pub fn create_unilateral_exit_transaction(
 
         let (exit_script, exit_control_block) = onchain_inputs
             .iter()
-            .find_map(|b| (b.outpoint == outpoint).then(|| b.boarding_output.exit_spend_info()))
+            .find_map(|b| (b.outpoint == outpoint).then(|| Ok(b.boarding_output.exit_spend_info())))
             .or_else(|| {
                 vtxo_inputs
                     .iter()
                     .find_map(|v| (v.outpoint == outpoint).then(|| v.vtxo.exit_spend_info()))
             })
-            .expect("spend info for input");
+            .expect("spend info for input")
+            .context("failed to get exit script for input")?;
 
         let leaf_version = exit_control_block.leaf_version;
         let leaf_hash = TapLeafHash::from_script(&exit_script, leaf_version);

--- a/ark-core/src/vhtlc.rs
+++ b/ark-core/src/vhtlc.rs
@@ -319,7 +319,7 @@ impl VhtlcOptions {
         }
 
         // Return the root node
-        Ok(lst.into_iter().next().unwrap())
+        Ok(lst.into_iter().next().expect("root node"))
     }
 
     /// Recursively add tree nodes to TaprootBuilder
@@ -577,7 +577,7 @@ mod tests {
                     if self.value < 512 {
                         return Err("seconds timelock must be greater or equal to 512".to_string());
                     }
-                    if self.value % 512 != 0 {
+                    if !self.value.is_multiple_of(512) {
                         return Err("seconds timelock must be multiple of 512".to_string());
                     }
                     Sequence::from_seconds_ceil(self.value)

--- a/ark-core/src/vhtlc.rs
+++ b/ark-core/src/vhtlc.rs
@@ -1,0 +1,869 @@
+//! Virtual Hash Time Lock Contract (VHTLC) implementation for Ark Lightning Swaps.
+//!
+//! This module implements VHTLC scripts that enable atomic swaps and conditional
+//! payments in the Ark protocol. The VHTLC provides multiple spending paths with
+//! different conditions and participants.
+
+use crate::ArkAddress;
+use crate::UNSPENDABLE_KEY;
+use bitcoin::hashes::ripemd160;
+use bitcoin::hashes::Hash;
+use bitcoin::opcodes::all::*;
+use bitcoin::taproot::TaprootBuilder;
+use bitcoin::taproot::TaprootSpendInfo;
+use bitcoin::Network;
+use bitcoin::PublicKey;
+use bitcoin::ScriptBuf;
+use bitcoin::Sequence;
+use bitcoin::XOnlyPublicKey;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VhtlcError {
+    #[error("Invalid preimage hash length: expected 20 bytes, got {0}")]
+    InvalidPreimageHashLength(usize),
+    #[error("Invalid public key length: expected 32 bytes, got {0}")]
+    InvalidPublicKeyLength(usize),
+    #[error("Invalid locktime: {0}")]
+    InvalidLocktime(String),
+    #[error("Invalid delay: {0}")]
+    InvalidDelay(String),
+    #[error("Taproot construction failed: {0}")]
+    TaprootError(String),
+}
+
+/// Represents a script with its weight for taproot tree construction
+#[derive(Debug, Clone)]
+struct TaprootScriptItem {
+    script: ScriptBuf,
+    weight: u32,
+}
+
+/// Internal tree node for building the taproot tree structure
+#[derive(Debug, Clone)]
+enum TaprootTreeNode {
+    Leaf {
+        script: ScriptBuf,
+        weight: u32,
+    },
+    Branch {
+        left: Box<TaprootTreeNode>,
+        right: Box<TaprootTreeNode>,
+        weight: u32,
+    },
+}
+
+/// Options for creating a VHTLC (Virtual Hash Time Lock Contract)
+///
+/// This structure contains all the necessary parameters to construct a VHTLC,
+/// including the public keys of participants and various timeout values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VhtlcOptions {
+    pub sender: XOnlyPublicKey,
+    pub receiver: XOnlyPublicKey,
+    pub server: XOnlyPublicKey,
+    pub preimage_hash: ripemd160::Hash,
+    pub refund_locktime: u32,
+    pub unilateral_claim_delay: Sequence,
+    pub unilateral_refund_delay: Sequence,
+    pub unilateral_refund_without_receiver_delay: Sequence,
+}
+
+impl VhtlcOptions {
+    pub fn validate(&self) -> Result<(), VhtlcError> {
+        if self.refund_locktime == 0 {
+            return Err(VhtlcError::InvalidLocktime(
+                "Refund locktime must be greater than 0".to_string(),
+            ));
+        }
+
+        if !self.unilateral_claim_delay.is_relative_lock_time()
+            || self.unilateral_claim_delay.to_consensus_u32() == 0
+        {
+            return Err(VhtlcError::InvalidDelay(
+                "Unilateral claim delay must be a valid non-zero CSV relative lock time"
+                    .to_string(),
+            ));
+        }
+
+        if !self.unilateral_refund_delay.is_relative_lock_time()
+            || self.unilateral_refund_delay.to_consensus_u32() == 0
+        {
+            return Err(VhtlcError::InvalidDelay(
+                "Unilateral refund delay must be a valid non-zero CSV relative lock time"
+                    .to_string(),
+            ));
+        }
+
+        if !self
+            .unilateral_refund_without_receiver_delay
+            .is_relative_lock_time()
+            || self
+                .unilateral_refund_without_receiver_delay
+                .to_consensus_u32()
+                == 0
+        {
+            return Err(VhtlcError::InvalidDelay(
+                "Unilateral refund without receiver delay must be a valid non-zero CSV relative lock time"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn build_taproot(&self) -> Result<TaprootSpendInfo, VhtlcError> {
+        let internal_pubkey = PublicKey::from_str(UNSPENDABLE_KEY)
+            .map_err(|e| VhtlcError::TaprootError(format!("Failed to parse internal key: {e}")))?;
+        let internal_key = XOnlyPublicKey::from(internal_pubkey);
+
+        // Create script list with weights
+        // Lower weight = more likely to be used = shallower in tree
+        let scripts = vec![
+            TaprootScriptItem {
+                script: self.claim_script(),
+                weight: 1, // Most likely - collaborative claim
+            },
+            TaprootScriptItem {
+                script: self.refund_script(),
+                weight: 1, // Most likely - collaborative refund
+            },
+            TaprootScriptItem {
+                script: self.refund_without_receiver_script(),
+                weight: 1, // Less common
+            },
+            TaprootScriptItem {
+                script: self.unilateral_claim_script(),
+                weight: 1, // Less common
+            },
+            TaprootScriptItem {
+                script: self.unilateral_refund_script(),
+                weight: 1, // Least common
+            },
+            TaprootScriptItem {
+                script: self.unilateral_refund_without_receiver_script(),
+                weight: 1, // Least common
+            },
+        ];
+
+        // Build the tree using the weight-based algorithm
+        let tree = Self::taproot_list_to_tree(scripts)?;
+
+        // Create TaprootBuilder and add the tree
+        let builder = TaprootBuilder::new();
+        let builder = Self::add_tree_to_builder(builder, &tree, 0)?;
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let taproot_spend_info = builder
+            .finalize(&secp, internal_key)
+            .map_err(|e| VhtlcError::TaprootError(format!("Failed to finalize taproot: {e:?}")))?;
+
+        Ok(taproot_spend_info)
+    }
+
+    /// Creates the claim script where receiver reveals the preimage
+    ///
+    /// Requires: preimage hash verification + receiver signature + server signature
+    pub fn claim_script(&self) -> ScriptBuf {
+        let preimage_hash = self.preimage_hash;
+
+        ScriptBuf::builder()
+            .push_opcode(OP_HASH160)
+            .push_slice(preimage_hash.as_byte_array())
+            .push_opcode(OP_EQUAL)
+            .push_opcode(OP_VERIFY)
+            .push_x_only_key(&self.receiver)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_x_only_key(&self.server)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Creates the collaborative refund script
+    ///
+    /// Requires: sender + receiver + server signatures
+    pub fn refund_script(&self) -> ScriptBuf {
+        ScriptBuf::builder()
+            .push_x_only_key(&self.sender)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_x_only_key(&self.receiver)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_x_only_key(&self.server)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Creates the refund script when receiver is unavailable
+    ///
+    /// Requires: CLTV timeout + sender + server signatures
+    pub fn refund_without_receiver_script(&self) -> ScriptBuf {
+        ScriptBuf::builder()
+            .push_int(self.refund_locktime as i64)
+            .push_opcode(OP_CLTV)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.sender)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_x_only_key(&self.server)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Creates the unilateral claim script (no server cooperation needed)
+    ///
+    /// Requires: preimage hash verification + CSV delay + receiver signature
+    pub fn unilateral_claim_script(&self) -> ScriptBuf {
+        let preimage_hash = self.preimage_hash;
+        let sequence = self.unilateral_claim_delay;
+
+        ScriptBuf::builder()
+            .push_opcode(OP_HASH160)
+            .push_slice(preimage_hash.as_byte_array())
+            .push_opcode(OP_EQUAL)
+            .push_opcode(OP_VERIFY)
+            .push_int(sequence.to_consensus_u32() as i64)
+            .push_opcode(OP_CSV)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.receiver)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Creates the unilateral refund script
+    ///
+    /// Requires: CSV delay + sender + receiver signatures
+    pub fn unilateral_refund_script(&self) -> ScriptBuf {
+        let sequence = self.unilateral_refund_delay;
+        ScriptBuf::builder()
+            .push_int(sequence.to_consensus_u32() as i64)
+            .push_opcode(OP_CSV)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.sender)
+            .push_opcode(OP_CHECKSIGVERIFY)
+            .push_x_only_key(&self.receiver)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Creates the unilateral refund script when receiver is unavailable
+    ///
+    /// Requires: CSV delay + sender signature
+    pub fn unilateral_refund_without_receiver_script(&self) -> ScriptBuf {
+        let sequence = self.unilateral_refund_without_receiver_delay;
+        ScriptBuf::builder()
+            .push_int(sequence.to_consensus_u32() as i64)
+            .push_opcode(OP_CSV)
+            .push_opcode(OP_DROP)
+            .push_x_only_key(&self.sender)
+            .push_opcode(OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Build a balanced taproot tree from a list of scripts with weights
+    /// Following the TypeScript algorithm from scure-btc-signer
+    fn taproot_list_to_tree(
+        scripts: Vec<TaprootScriptItem>,
+    ) -> Result<TaprootTreeNode, VhtlcError> {
+        if scripts.is_empty() {
+            return Err(VhtlcError::TaprootError("Empty script list".to_string()));
+        }
+
+        // Clone input and convert to nodes
+        let mut lst: Vec<TaprootTreeNode> = scripts
+            .into_iter()
+            .map(|item| TaprootTreeNode::Leaf {
+                script: item.script,
+                weight: item.weight,
+            })
+            .collect();
+
+        // Build tree by combining nodes with smallest weights
+        while lst.len() >= 2 {
+            // Sort: elements with smallest weight are at the end of queue
+            lst.sort_by(|a, b| {
+                let weight_a = match a {
+                    TaprootTreeNode::Leaf { weight, .. } => *weight,
+                    TaprootTreeNode::Branch { weight, .. } => *weight,
+                };
+                let weight_b = match b {
+                    TaprootTreeNode::Leaf { weight, .. } => *weight,
+                    TaprootTreeNode::Branch { weight, .. } => *weight,
+                };
+                // Reverse comparison to put smallest at end
+                weight_b.cmp(&weight_a)
+            });
+
+            // Pop the two smallest weight nodes
+            let b = lst.pop().expect("an element");
+            let a = lst.pop().expect("an element");
+
+            // Calculate combined weight
+            let weight_a = match &a {
+                TaprootTreeNode::Leaf { weight, .. } => *weight,
+                TaprootTreeNode::Branch { weight, .. } => *weight,
+            };
+            let weight_b = match &b {
+                TaprootTreeNode::Leaf { weight, .. } => *weight,
+                TaprootTreeNode::Branch { weight, .. } => *weight,
+            };
+
+            // Create branch with combined weight
+            lst.push(TaprootTreeNode::Branch {
+                weight: weight_a + weight_b,
+                left: Box::new(a),
+                right: Box::new(b),
+            });
+        }
+
+        // Return the root node
+        Ok(lst.into_iter().next().unwrap())
+    }
+
+    /// Recursively add tree nodes to TaprootBuilder
+    fn add_tree_to_builder(
+        builder: TaprootBuilder,
+        node: &TaprootTreeNode,
+        depth: u8,
+    ) -> Result<TaprootBuilder, VhtlcError> {
+        match node {
+            TaprootTreeNode::Leaf { script, .. } => builder
+                .add_leaf(depth, script.clone())
+                .map_err(|e| VhtlcError::TaprootError(format!("Failed to add leaf: {e}"))),
+            TaprootTreeNode::Branch { left, right, .. } => {
+                let builder = Self::add_tree_to_builder(builder, left, depth + 1)?;
+                Self::add_tree_to_builder(builder, right, depth + 1)
+            }
+        }
+    }
+}
+
+/// VHTLC Script builder and manager
+///
+/// This struct creates and manages VHTLC scripts with six different spending paths:
+/// 1. **Claim**: Receiver reveals preimage (collaborative with server)
+/// 2. **Refund**: Collaborative refund (all three parties)
+/// 3. **Refund without Receiver**: Sender refunds after locktime (with server)
+/// 4. **Unilateral Claim**: Receiver claims after delay (no server needed)
+/// 5. **Unilateral Refund**: Collaborative unilateral refund after delay
+/// 6. **Unilateral Refund without Receiver**: Sender unilateral refund after both timeouts
+pub struct VhtlcScript {
+    options: VhtlcOptions,
+    taproot_spend_info: TaprootSpendInfo,
+    network: Network,
+}
+
+impl VhtlcScript {
+    /// Creates a new VHTLC script with the given options
+    ///
+    /// This will validate the options and build the complete taproot tree
+    /// with all spending paths.
+    pub fn new(options: VhtlcOptions, network: Network) -> Result<Self, VhtlcError> {
+        options.validate()?;
+
+        let taproot_spend_info = options.build_taproot()?;
+
+        Ok(Self {
+            options,
+            taproot_spend_info,
+            network,
+        })
+    }
+
+    pub fn taproot_spend_info(&self) -> &TaprootSpendInfo {
+        &self.taproot_spend_info
+    }
+
+    pub fn script_pubkey(&self) -> ScriptBuf {
+        ScriptBuf::builder()
+            .push_opcode(OP_PUSHNUM_1)
+            .push_slice(self.taproot_spend_info.output_key().serialize())
+            .into_script()
+    }
+
+    pub fn address(&self) -> ArkAddress {
+        ArkAddress::new(
+            self.network,
+            self.options.server,
+            self.taproot_spend_info().output_key(),
+        )
+    }
+
+    /// Creates the claim script where receiver reveals the preimage
+    ///
+    /// Requires: preimage hash verification + receiver signature + server signature
+    pub fn claim_script(&self) -> ScriptBuf {
+        self.options.claim_script()
+    }
+
+    /// Creates the collaborative refund script
+    ///
+    /// Requires: sender + receiver + server signatures
+    pub fn refund_script(&self) -> ScriptBuf {
+        self.options.refund_script()
+    }
+
+    /// Creates the refund script when receiver is unavailable
+    ///
+    /// Requires: CLTV timeout + sender + server signatures
+    pub fn refund_without_receiver_script(&self) -> ScriptBuf {
+        self.options.refund_without_receiver_script()
+    }
+
+    /// Creates the unilateral claim script (no server cooperation needed)
+    ///
+    /// Requires: preimage hash verification + CSV delay + receiver signature
+    pub fn unilateral_claim_script(&self) -> ScriptBuf {
+        self.options.unilateral_claim_script()
+    }
+
+    /// Creates the unilateral refund script
+    ///
+    /// Requires: CSV delay + sender + receiver signatures
+    pub fn unilateral_refund_script(&self) -> ScriptBuf {
+        self.options.unilateral_refund_script()
+    }
+
+    /// Creates the unilateral refund script when receiver is unavailable
+    ///
+    /// Requires: CSV delay + sender signature
+    pub fn unilateral_refund_without_receiver_script(&self) -> ScriptBuf {
+        self.options.unilateral_refund_without_receiver_script()
+    }
+
+    pub fn get_script_map(&self) -> BTreeMap<String, ScriptBuf> {
+        let mut map = BTreeMap::new();
+        map.insert("claim".to_string(), self.claim_script());
+        map.insert("refund".to_string(), self.refund_script());
+        map.insert(
+            "refund_without_receiver".to_string(),
+            self.refund_without_receiver_script(),
+        );
+        map.insert(
+            "unilateral_claim".to_string(),
+            self.unilateral_claim_script(),
+        );
+        map.insert(
+            "unilateral_refund".to_string(),
+            self.unilateral_refund_script(),
+        );
+        map.insert(
+            "unilateral_refund_without_receiver".to_string(),
+            self.unilateral_refund_without_receiver_script(),
+        );
+        map
+    }
+
+    pub fn tapscripts(self) -> Vec<ScriptBuf> {
+        vec![
+            self.claim_script(),
+            self.refund_script(),
+            self.refund_without_receiver_script(),
+            self.unilateral_claim_script(),
+            self.unilateral_refund_script(),
+            self.unilateral_refund_without_receiver_script(),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hex::DisplayHex;
+    use bitcoin::hex::FromHex;
+    use bitcoin::Network;
+    use bitcoin::PublicKey;
+    use bitcoin::Sequence;
+    use bitcoin::XOnlyPublicKey;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::str::FromStr;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Fixtures {
+        valid: Vec<ValidTestCase>,
+        invalid: Vec<InvalidTestCase>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct ValidTestCase {
+        description: String,
+        #[serde(rename = "preimageHash")]
+        preimage_hash: String,
+        receiver: String,
+        sender: String,
+        server: String,
+        #[serde(rename = "refundLocktime")]
+        refund_locktime: u32,
+        #[serde(rename = "unilateralClaimDelay")]
+        unilateral_claim_delay: Delay,
+        #[serde(rename = "unilateralRefundDelay")]
+        unilateral_refund_delay: Delay,
+        #[serde(rename = "unilateralRefundWithoutReceiverDelay")]
+        unilateral_refund_without_receiver_delay: Delay,
+        expected: String,
+        scripts: ScriptHexes,
+        taproot: TaprootInfo,
+        #[serde(rename = "decodedScripts")]
+        decoded_scripts: HashMap<String, String>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct InvalidTestCase {
+        description: String,
+        #[serde(rename = "preimageHash")]
+        preimage_hash: String,
+        receiver: String,
+        sender: String,
+        server: String,
+        #[serde(rename = "refundLocktime")]
+        refund_locktime: u32,
+        #[serde(rename = "unilateralClaimDelay")]
+        unilateral_claim_delay: Delay,
+        #[serde(rename = "unilateralRefundDelay")]
+        unilateral_refund_delay: Delay,
+        #[serde(rename = "unilateralRefundWithoutReceiverDelay")]
+        unilateral_refund_without_receiver_delay: Delay,
+        error: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct ScriptHexes {
+        #[serde(rename = "claimScript")]
+        claim_script: String,
+        #[serde(rename = "refundScript")]
+        refund_script: String,
+        #[serde(rename = "refundWithoutReceiverScript")]
+        refund_without_receiver_script: String,
+        #[serde(rename = "unilateralClaimScript")]
+        unilateral_claim_script: String,
+        #[serde(rename = "unilateralRefundScript")]
+        unilateral_refund_script: String,
+        #[serde(rename = "unilateralRefundWithoutReceiverScript")]
+        unilateral_refund_without_receiver_script: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct TaprootInfo {
+        #[serde(rename = "tweakedPublicKey")]
+        tweaked_public_key: String,
+        #[serde(rename = "tapTree")]
+        tap_tree: String,
+        #[serde(rename = "internalKey")]
+        internal_key: String,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Delay {
+        #[serde(rename = "type")]
+        delay_type: String,
+        value: u32,
+    }
+
+    impl Delay {
+        fn to_sequence(&self) -> Result<Sequence, String> {
+            match self.delay_type.as_str() {
+                "blocks" => {
+                    if self.value == 0 {
+                        return Err("unilateral claim delay must greater than 0".to_string());
+                    }
+                    Ok(Sequence::from_height(self.value as u16))
+                }
+                "seconds" => {
+                    if self.value < 512 {
+                        return Err("seconds timelock must be greater or equal to 512".to_string());
+                    }
+                    if self.value % 512 != 0 {
+                        return Err("seconds timelock must be multiple of 512".to_string());
+                    }
+                    Sequence::from_seconds_ceil(self.value)
+                        .map_err(|e| format!("Invalid seconds value: {e}"))
+                }
+                _ => Err(format!("Unknown delay type: {}", self.delay_type)),
+            }
+        }
+    }
+
+    fn hex_to_bytes20(hex: &str) -> Result<[u8; 20], String> {
+        let bytes = Vec::from_hex(hex).map_err(|e| format!("Invalid hex: {e}"))?;
+        if bytes.len() != 20 {
+            return Err("preimage hash must be 20 bytes".to_string());
+        }
+        let mut arr = [0u8; 20];
+        arr.copy_from_slice(&bytes);
+        Ok(arr)
+    }
+
+    fn pubkey_to_xonly(pubkey_hex: &str) -> XOnlyPublicKey {
+        let pubkey = PublicKey::from_str(pubkey_hex).expect("valid public key");
+        XOnlyPublicKey::from(pubkey.inner)
+    }
+
+    #[test]
+    fn test_vhtlc_with_valid_fixtures() {
+        let fixtures_path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/vhtlc_fixtures/vhtlc.json");
+        let fixtures_json = fs::read_to_string(fixtures_path).expect("to read fixtures file");
+        let fixtures: Fixtures = serde_json::from_str(&fixtures_json).expect("to parse fixtures");
+
+        for test_case in fixtures.valid {
+            let preimage_hash =
+                ripemd160::Hash::from_str(&test_case.preimage_hash).expect("valid hash");
+
+            let sender = pubkey_to_xonly(&test_case.sender);
+            let receiver = pubkey_to_xonly(&test_case.receiver);
+            let server = pubkey_to_xonly(&test_case.server);
+
+            let options = VhtlcOptions {
+                sender,
+                receiver,
+                server,
+                preimage_hash,
+                refund_locktime: test_case.refund_locktime,
+                unilateral_claim_delay: test_case
+                    .unilateral_claim_delay
+                    .to_sequence()
+                    .expect("valid delay"),
+                unilateral_refund_delay: test_case
+                    .unilateral_refund_delay
+                    .to_sequence()
+                    .expect("valid delay"),
+                unilateral_refund_without_receiver_delay: test_case
+                    .unilateral_refund_without_receiver_delay
+                    .to_sequence()
+                    .expect("valid delay"),
+            };
+
+            let vhtlc = VhtlcScript::new(options, Network::Testnet).expect("to create VHTLC");
+
+            // Test 1: Verify all script hex encodings
+            let claim_hex = vhtlc.claim_script().as_bytes().to_lower_hex_string();
+            assert_eq!(
+                claim_hex, test_case.scripts.claim_script,
+                "Claim script hex mismatch for test case: {}",
+                test_case.description
+            );
+
+            let refund_hex = vhtlc.refund_script().as_bytes().to_lower_hex_string();
+            assert_eq!(
+                refund_hex, test_case.scripts.refund_script,
+                "Refund script hex mismatch for test case: {}",
+                test_case.description
+            );
+
+            let refund_without_receiver_hex = vhtlc
+                .refund_without_receiver_script()
+                .as_bytes()
+                .to_lower_hex_string();
+            assert_eq!(
+                refund_without_receiver_hex, test_case.scripts.refund_without_receiver_script,
+                "Refund without receiver script hex mismatch for test case: {}",
+                test_case.description
+            );
+
+            let unilateral_claim_hex = vhtlc
+                .unilateral_claim_script()
+                .as_bytes()
+                .to_lower_hex_string();
+            assert_eq!(
+                unilateral_claim_hex, test_case.scripts.unilateral_claim_script,
+                "Unilateral claim script hex mismatch for test case: {}",
+                test_case.description
+            );
+
+            let unilateral_refund_hex = vhtlc
+                .unilateral_refund_script()
+                .as_bytes()
+                .to_lower_hex_string();
+            assert_eq!(
+                unilateral_refund_hex, test_case.scripts.unilateral_refund_script,
+                "Unilateral refund script hex mismatch for test case: {}",
+                test_case.description
+            );
+
+            let unilateral_refund_without_receiver_hex = vhtlc
+                .unilateral_refund_without_receiver_script()
+                .as_bytes()
+                .to_lower_hex_string();
+
+            assert_eq!(
+            unilateral_refund_without_receiver_hex,
+            test_case.scripts.unilateral_refund_without_receiver_script,
+            "Unilateral refund without receiver script hex mismatch for test case: {}. Our impl includes CLTV locktime, fixture expects only CSV",
+            test_case.description
+        );
+
+            // Test 2: Verify taproot information
+            let taproot_info = vhtlc.taproot_spend_info();
+
+            let internal_key = taproot_info.internal_key();
+            let internal_key_hex = internal_key.serialize().to_lower_hex_string();
+
+            // The internal key in fixtures is prefixed with version byte
+            let pubkey = PublicKey::from_str(&test_case.taproot.internal_key)
+                .expect("valid internal key in fixture");
+            let expected_internal = XOnlyPublicKey::from(pubkey.inner)
+                .serialize()
+                .to_lower_hex_string();
+
+            assert_eq!(
+                internal_key_hex, expected_internal,
+                "Internal key mismatch for test case: {}",
+                test_case.description
+            );
+
+            let output_key = taproot_info.output_key();
+            let output_key_hex = output_key.serialize().to_lower_hex_string();
+
+            assert_eq!(
+                output_key_hex, test_case.taproot.tweaked_public_key,
+                "Tweaked public key mismatch for test case: {}",
+                test_case.description
+            );
+
+            // Test 3: Verify address generation
+            let addr = vhtlc.address();
+            let address_str = addr.encode();
+
+            assert_eq!(
+                address_str, test_case.expected,
+                "Address mismatch for test case: {}",
+                test_case.description
+            );
+        }
+    }
+
+    #[test]
+    fn test_vhtlc_with_invalid_fixtures() {
+        let fixtures_path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/vhtlc_fixtures/vhtlc.json");
+        let fixtures_json = fs::read_to_string(fixtures_path).expect("to read fixtures file");
+        let fixtures: Fixtures = serde_json::from_str(&fixtures_json).expect("to parse fixtures");
+
+        for test_case in fixtures.invalid {
+            // Try to parse preimage hash
+            let preimage_hash_result = hex_to_bytes20(&test_case.preimage_hash);
+
+            if let Err(e) = preimage_hash_result {
+                assert!(
+                    e.contains(&test_case.error),
+                    "Expected error containing '{}', got '{}' for test case: {}",
+                    test_case.error,
+                    e,
+                    test_case.description
+                );
+                continue;
+            }
+
+            // Check refund locktime
+            if test_case.refund_locktime == 0 {
+                assert!(
+                    test_case
+                        .error
+                        .contains("refund locktime must be greater than 0"),
+                    "Expected refund locktime error for test case: {}",
+                    test_case.description
+                );
+                continue;
+            }
+
+            // Try to convert delays
+            let claim_delay_result = test_case.unilateral_claim_delay.to_sequence();
+            if let Err(e) = claim_delay_result {
+                assert!(
+                    e.contains(&test_case.error),
+                    "Expected error containing '{}', got '{}' for claim delay in test case: {}",
+                    test_case.error,
+                    e,
+                    test_case.description
+                );
+                continue;
+            }
+
+            let refund_delay_result = test_case.unilateral_refund_delay.to_sequence();
+            if let Err(e) = refund_delay_result {
+                assert!(
+                    e.contains(&test_case.error),
+                    "Expected error containing '{}', got '{}' for refund delay in test case: {}",
+                    test_case.error,
+                    e,
+                    test_case.description
+                );
+                continue;
+            }
+
+            let refund_without_receiver_delay_result = test_case
+                .unilateral_refund_without_receiver_delay
+                .to_sequence();
+            if let Err(e) = refund_without_receiver_delay_result {
+                assert!(
+                e.contains(&test_case.error),
+                "Expected error containing '{}', got '{}' for refund without receiver delay in test case: {}",
+                test_case.error,
+                e,
+                test_case.description
+            );
+                continue;
+            }
+
+            // If we got here, all validations passed but they shouldn't have
+            panic!(
+                "Invalid test case '{}' didn't fail as expected",
+                test_case.description
+            );
+        }
+    }
+
+    #[test]
+    fn test_specific_script_encodings() {
+        // Test specific script encoding for the first valid case
+        let sender =
+            pubkey_to_xonly("030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4");
+        let receiver =
+            pubkey_to_xonly("021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b");
+        let server =
+            pubkey_to_xonly("03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88");
+        let preimage_hash =
+            ripemd160::Hash::from_str("4d487dd3753a89bc9fe98401d1196523058251fc").unwrap();
+
+        let options = VhtlcOptions {
+            sender,
+            receiver,
+            server,
+            preimage_hash,
+            refund_locktime: 265,
+            unilateral_claim_delay: Sequence::from_height(17),
+            unilateral_refund_delay: Sequence::from_height(144),
+            unilateral_refund_without_receiver_delay: Sequence::from_height(144),
+        };
+
+        let vhtlc = VhtlcScript::new(options, Network::Testnet).expect("to create VHTLC");
+
+        // Verify claim script
+        let claim_script = vhtlc.claim_script();
+        let claim_hex = claim_script.as_bytes().to_lower_hex_string();
+        let expected_claim = "a9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac";
+        assert_eq!(
+            claim_hex, expected_claim,
+            "Claim script should match fixture"
+        );
+
+        // Verify unilateral claim script (with CSV=17)
+        let unilateral_claim = vhtlc.unilateral_claim_script();
+        let unilateral_claim_hex = unilateral_claim.as_bytes().to_lower_hex_string();
+
+        // Check the CSV encoding for value 17
+        assert!(
+            unilateral_claim_hex.contains("0111"),
+            "Should contain CSV value 17 as 0x0111"
+        );
+
+        let expected_unilateral_claim = "a9144d487dd3753a89bc9fe98401d1196523058251fc87690111b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac";
+        assert_eq!(
+            unilateral_claim_hex, expected_unilateral_claim,
+            "Unilateral claim script should match fixture"
+        );
+    }
+}

--- a/ark-core/src/vhtlc_fixtures/vhtlc.json
+++ b/ark-core/src/vhtlc_fixtures/vhtlc.json
@@ -1,0 +1,258 @@
+{
+  "valid": [
+    {
+      "description": "CSV locktime > 16",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 17
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "expected": "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63",
+      "scripts": {
+        "claimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundScript": "200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundWithoutReceiverScript": "020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "unilateralClaimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc87690111b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundScript": "029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundWithoutReceiverScript": "029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac"
+      },
+      "taproot": {
+        "tweakedPublicKey": "866c65e77e6eeeb8177dfcdb68c9db38c52c35479c876f2722c1645069b1fb93",
+        "tapTree": "0601c05ca9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c066200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c049020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c03ea9144d487dd3753a89bc9fe98401d1196523058251fc87690111b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c049029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c027029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac",
+        "internalKey": "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+      },
+      "decodedScripts": {
+        "claimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundScript": "0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundWithoutReceiverScript": "0x0901 CHECKLOCKTIMEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "unilateralClaimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 0x11 CHECKSEQUENCEVERIFY DROP 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundScript": "0x9000 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundWithoutReceiverScript": "0x9000 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIG"
+      }
+    },
+    {
+      "description": "CSV locktime <= 16",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 16
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "expected": "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3vyn9exe9gjwcjp5ez0wfhhawvvg0xfenzztjmgp3ddrvkwhw04eztqjn6",
+      "scripts": {
+        "claimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundScript": "200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundWithoutReceiverScript": "020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "unilateralClaimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc876960b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundScript": "029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundWithoutReceiverScript": "029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac"
+      },
+      "taproot": {
+        "tweakedPublicKey": "b0932e4d92a24ec4834c89ee4defd73188799399884b96d018b5a3659d773eb9",
+        "tapTree": "0601c05ca9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c066200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c049020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c03da9144d487dd3753a89bc9fe98401d1196523058251fc876960b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c049029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c027029000b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac",
+        "internalKey": "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+      },
+      "decodedScripts": {
+        "claimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundScript": "0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundWithoutReceiverScript": "0x0901 CHECKLOCKTIMEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "unilateralClaimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 16 CHECKSEQUENCEVERIFY DROP 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundScript": "0x9000 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundWithoutReceiverScript": "0x9000 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIG"
+      }
+    },
+    {
+      "description": "with seconds CSV timelock",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "seconds",
+        "value": 512
+      },
+      "unilateralRefundDelay": {
+        "type": "seconds",
+        "value": 1024
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "seconds",
+        "value": 1536
+      },
+      "expected": "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3f354ncawvx3enha2ydyrmactc6fyuvqppsqpl5k63hzupmrl7ndmz8pnu",
+      "scripts": {
+        "claimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundScript": "200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "refundWithoutReceiverScript": "020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac",
+        "unilateralClaimScript": "a9144d487dd3753a89bc9fe98401d1196523058251fc876903010040b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundScript": "03020040b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac",
+        "unilateralRefundWithoutReceiverScript": "03030040b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac"
+      },
+      "taproot": {
+        "tweakedPublicKey": "a634acf1d730d1ccefd511a41efb85e34927180086000fe96d46e2e0763ffa6d",
+        "tapTree": "0601c05ca9144d487dd3753a89bc9fe98401d1196523058251fc8769201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c066200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c049020901b175200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad20aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88ac01c040a9144d487dd3753a89bc9fe98401d1196523058251fc876903010040b275201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c04a03020040b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ad201e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53bac01c02803030040b275200192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4ac",
+        "internalKey": "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+      },
+      "decodedScripts": {
+        "claimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundScript": "0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "refundWithoutReceiverScript": "0x0901 CHECKLOCKTIMEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0xaad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88 CHECKSIG",
+        "unilateralClaimScript": "HASH160 0x4d487dd3753a89bc9fe98401d1196523058251fc EQUAL VERIFY 0x010040 CHECKSEQUENCEVERIFY DROP 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundScript": "0x020040 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIGVERIFY 0x1e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b CHECKSIG",
+        "unilateralRefundWithoutReceiverScript": "0x030040 CHECKSEQUENCEVERIFY DROP 0x0192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4 CHECKSIG"
+      }
+    }
+  ],
+  "invalid": [
+    {
+      "description": "Invalid preimageHash length (too short)",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 17
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "error": "preimage hash must be 20 bytes"
+    },
+    {
+      "description": "Invalid preimageHash length (too long)",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc1234567890abcdef",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 17
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "error": "preimage hash must be 20 bytes"
+    },
+    {
+      "description": "Zero timelock value",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 0
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "error": "unilateral claim delay must greater than 0"
+    },
+    {
+      "description": "Invalid refund locktime (zero)",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 0,
+      "unilateralClaimDelay": {
+        "type": "blocks",
+        "value": 17
+      },
+      "unilateralRefundDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "blocks",
+        "value": 144
+      },
+      "error": "refund locktime must be greater than 0"
+    },
+    {
+      "description": "Invalid seconds timelock (not multiple of 512)",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "seconds",
+        "value": 1000
+      },
+      "unilateralRefundDelay": {
+        "type": "seconds",
+        "value": 1024
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "seconds",
+        "value": 1536
+      },
+      "error": "seconds timelock must be multiple of 512"
+    },
+    {
+      "description": "Invalid seconds timelock (less than 512)",
+      "preimageHash": "4d487dd3753a89bc9fe98401d1196523058251fc",
+      "receiver": "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+      "sender": "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+      "server": "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+      "refundLocktime": 265,
+      "unilateralClaimDelay": {
+        "type": "seconds",
+        "value": 512
+      },
+      "unilateralRefundDelay": {
+        "type": "seconds",
+        "value": 511
+      },
+      "unilateralRefundWithoutReceiverDelay": {
+        "type": "seconds",
+        "value": 1536
+      },
+      "error": "seconds timelock must be greater or equal to 512"
+    }
+  ]
+}

--- a/ark-rest/tests/wasm.rs
+++ b/ark-rest/tests/wasm.rs
@@ -43,11 +43,10 @@ async fn test_get_offchain_address() {
         .await
         .expect("to be able to retrieve server info");
 
-    let vtxo = Vtxo::new(
+    let vtxo = Vtxo::new_default(
         &secp,
-        server_info.pk.x_only_public_key().0,
-        pk.x_only_public_key().0,
-        vec![],
+        server_info.pk.into(),
+        pk.into(),
         server_info.unilateral_exit_delay,
         server_info.network,
     )

--- a/ark-sample/src/main.rs
+++ b/ark-sample/src/main.rs
@@ -129,7 +129,7 @@ impl FromStr for AddressesAndAmounts {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = input.split(',').collect();
 
-        if parts.len() % 2 != 0 {
+        if !parts.len().is_multiple_of(2) {
             bail!("invalid input: expected comma-separated pairs of <address,amount in sats>");
         }
 

--- a/e2e-tests/tests/boltz_reverse.rs
+++ b/e2e-tests/tests/boltz_reverse.rs
@@ -1,0 +1,47 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use std::sync::Arc;
+
+mod common;
+
+// TODO: Expand this test to call Lightning APIs directly.
+
+#[tokio::test]
+#[ignore]
+pub async fn reverse_swap() {
+    // This test requires even more setup than regular e2e tests, as well as manual intervention
+    // (for now).
+    //
+    // Follow the steps in
+    // https://github.com/ArkLabsHQ/fulmine/blob/6a4cd0b38a29732d03721b925f220b4f3717f379/docs/swaps.regtest.md
+    // to setup the environment including Boltz.
+
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+
+    let secp = Secp256k1::new();
+
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    let invoice_amount = Amount::from_sat(1_000);
+    let res = alice.get_ln_invoice(invoice_amount).await.unwrap();
+
+    tracing::info!(invoice = %res.invoice, swap_id = res.swap_id, "Generated Boltz reverse swap invoice");
+
+    // Manual intervention.
+    tracing::info!("Pay the invoice using a Lightning wallet: {}", res.invoice);
+
+    alice.wait_for_vhtlc(&res.swap_id).await.unwrap();
+
+    tracing::info!(swap_id = res.swap_id, "Lightning invoice paid");
+
+    wait_until_balance(&alice, Amount::ZERO, res.amount)
+        .await
+        .unwrap();
+}

--- a/e2e-tests/tests/boltz_submarine.rs
+++ b/e2e-tests/tests/boltz_submarine.rs
@@ -1,0 +1,58 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use ark_client::lightning_invoice::Bolt11Invoice;
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use rand::thread_rng;
+use std::sync::Arc;
+
+mod common;
+
+// TODO: Expand this test to call Lightning APIs directly.
+
+// Modify this constant _before_ running the test.
+const INVOICE: &str = "";
+
+#[tokio::test]
+#[ignore]
+pub async fn submarine_swap() {
+    // This test requires even more setup than regular e2e tests, as well as manual intervention
+    // (for now).
+    //
+    // Follow the steps in
+    // https://github.com/ArkLabsHQ/fulmine/blob/6a4cd0b38a29732d03721b925f220b4f3717f379/docs/swaps.regtest.md
+    // to setup the environment including Boltz.
+
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let invoice: Bolt11Invoice = INVOICE.parse().expect("valid BOLT11 invoice");
+
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    let alice_fund_amount = Amount::ONE_BTC;
+
+    nigiri
+        .faucet_fund(&alice.get_boarding_address().unwrap(), alice_fund_amount)
+        .await;
+
+    alice.settle(&mut rng, false).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    wait_until_balance(&alice, alice_fund_amount, Amount::ZERO)
+        .await
+        .unwrap();
+
+    let res = alice.pay_ln_invoice(invoice).await.unwrap();
+
+    wait_until_balance(&alice, Amount::ZERO, alice_fund_amount - res.amount)
+        .await
+        .unwrap();
+}

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -6,6 +6,7 @@ use ark_client::wallet::Persistence;
 use ark_client::Blockchain;
 use ark_client::Client;
 use ark_client::ExplorerUtxo;
+use ark_client::InMemorySwapStorage;
 use ark_client::OfflineClient;
 use ark_client::SpendStatus;
 use ark_core::BoardingOutput;
@@ -351,7 +352,10 @@ pub async fn set_up_client(
     name: String,
     nigiri: Arc<Nigiri>,
     secp: Secp256k1<All>,
-) -> (Client<Nigiri, Wallet<InMemoryDb>>, Arc<Wallet<InMemoryDb>>) {
+) -> (
+    Client<Nigiri, Wallet<InMemoryDb>, InMemorySwapStorage>,
+    Arc<Wallet<InMemoryDb>>,
+) {
     let mut rng = thread_rng();
 
     let sk = SecretKey::new(&mut rng);
@@ -367,6 +371,8 @@ pub async fn set_up_client(
         nigiri,
         wallet.clone(),
         "http://localhost:7070".to_string(),
+        Arc::new(InMemorySwapStorage::default()),
+        "http://localhost:9001".to_string(),
         Duration::from_secs(30),
     )
     .connect_with_retries(5)
@@ -378,7 +384,7 @@ pub async fn set_up_client(
 
 #[allow(unused)]
 pub async fn wait_until_balance(
-    client: &Client<Nigiri, Wallet<InMemoryDb>>,
+    client: &Client<Nigiri, Wallet<InMemoryDb>, InMemorySwapStorage>,
     confirmed_target: Amount,
     pending_target: Amount,
 ) -> Result<(), String> {


### PR DESCRIPTION
Notes:

- The tests added to `e2e-tests` aren't actually supposed to run on CI at this stage, because setting up the environment is hard enough locally. Furthermore, these are tests that require some manual intervention to run at this stage. With a more robust setup we can focus on executing Lightning-related commands within the tests themselves.
- Most (manual) testing has been conducted using the CLI client `ark-client-sample`.
- For now we have implemented two paths: the happy path, where the receiver claims the VHTLC; and the offchain refund after the timelock expires. The collaborative offchain refund is not yet implemented fully, because Boltz doesn't support it yet. Additionally, spending using any of the three on-chain unilateral paths has not been implemented yet.
- The API related to Boltz swaps is bound to change in future versions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Boltz-backed submarine & reverse swaps with LN invoice flows, VHTLC support, and pluggable swap storage (SQLite + in-memory).

- **CLI**
  - New commands to create/pay invoices and refund swaps: lightning-invoice, pay-invoice, refund-swap-collab, refund-swap.

- **Configuration**
  - New swap_storage_path and boltz_url configuration options in samples and README.

- **Improvements**
  - More robust error reporting, improved signing flows, and enhanced address/invoice handling.

- **Tests**
  - New end-to-end Boltz tests and VHTLC fixtures.

- **Chores**
  - .sqlite files ignored; CI adds clippy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->