### PR TITLE
fix checkpoint taproot tree

### DIFF
--- a/ark-core/src/send.rs
+++ b/ark-core/src/send.rs
@@ -211,20 +211,22 @@ pub fn build_offchain_transactions(
         let mut bytes = Vec::new();
 
         let script = &checkpoint_output.vtxo_spend_script;
-        write_compact_size_uint(&mut bytes, script.len() as u64).map_err(Error::transaction)?;
+        let scripts = vec![script.clone(), checkpoint_script.clone()];
 
-        // Write the depth (always 1). TODO: Support more depth.
-        bytes.push(1);
+        for script in scripts.iter() {
+            // Write the depth (always 1). TODO: Support more depth.
+            bytes.push(1);
 
-        // TODO: Support future leaf versions.
-        bytes.push(LeafVersion::TapScript.to_consensus());
+            // TODO: Support future leaf versions.
+            bytes.push(LeafVersion::TapScript.to_consensus());
 
-        let mut script_bytes = script.to_bytes();
+            let mut script_bytes = script.to_bytes();
 
-        write_compact_size_uint(&mut bytes, script_bytes.len() as u64)
-            .map_err(Error::transaction)?;
+            write_compact_size_uint(&mut bytes, script_bytes.len() as u64)
+                .map_err(Error::transaction)?;
 
-        bytes.append(&mut script_bytes);
+            bytes.append(&mut script_bytes);
+        }
 
         unsigned_ark_psbt.inputs[i].unknown.insert(
             psbt::raw::Key {


### PR DESCRIPTION
This PR includes two fixes to `build_offchain_transactions`.

**TaprootTree encoding**

Firstly, it fixes the taproot tree encoding by removing the extra `write_compact_size_uint` at the beginning of the serialization. That's something we introduced recently to be compliant with orignal taptree encoding: https://github.com/arkade-os/arkd/pull/717 (the PR also contains a fixture to unit test it).

**Add `checkpoint_script` to taproot tree**

While encoding the scripts added to the off chain transaction as `VTXO_TAPROOT_KEY` unknown field, the `checkpoint_script` must also be included. That's something we need to verify server-side (once https://github.com/arkade-os/arkd/pull/757 merged, it will fail if checkpoint_script is not included)

_Please forgive my Rust code_

@luckysori please review