### PR TITLE
Add APIs and CLI commands to settle selectively

### DIFF
--- a/ark-client-sample/justfile
+++ b/ark-client-sample/justfile
@@ -59,3 +59,31 @@ refund-swap-collab actor swap_id:
 # Refund a submarine swap without the receiver
 refund-swap actor swap_id:
     cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed refund-swap-without-receiver {{ swap_id }}
+
+# List all VTXOs and boarding outputs for a given actor
+list-vtxos actor:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed list-vtxos
+
+# Settle specific VTXOs by outpoint for a given actor, e.g. just settle-vtxos alice "abc123:0,def456:1"
+settle-vtxos actor vtxos:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed settle-vtxos --vtxos {{ vtxos }}
+
+# Settle specific boarding outputs by outpoint for a given actor
+settle-boarding actor boarding:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed settle-vtxos --boarding {{ boarding }}
+
+# Settle specific VTXOs and boarding outputs by outpoint for a given actor
+settle-selected actor vtxos boarding:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed settle-vtxos --vtxos {{ vtxos }} --boarding {{ boarding }}
+
+# Settle all recoverable VTXOs for a given actor
+settle-recoverable actor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    outpoints=$(just list-vtxos {{ actor }} 2>/dev/null | jq -r '[.vtxos[] | select(.status == "recoverable") | .outpoint] | join(",")')
+    if [ -z "$outpoints" ]; then
+        echo '{"commitment_txid": null, "message": "No recoverable VTXOs found"}'
+    else
+        cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed settle-vtxos --vtxos "$outpoints"
+    fi
+


### PR DESCRIPTION
Before, settling using `ark-client` and `ark-client-sample` involved every single VTXO that could be settled.

Settling will eventually have a cost associated with it. Also, only certain types of VTXOs really need settlement: VTXOs which are close to expiry and pre-confirmed VTXOs (in some cases).

With this patch we introduce a `settle_vtxos` API in `ark-client` which allows consumers to specify which VTXOs to settle.

To demonstrate the usefulness of this change, we introduce CLI commands in `ark-client-sample` to list VTXOs (to identify good candidates for settlement) and to settle specific VTXOs.

Finally, we combine all this work into a single, self-explanatory justfile command:

```
just ark-sample settle-recoverable alice
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List VTXOs with creation/expiry timestamps and status details.
  * Settle selected VTXOs and boarding outputs by specifying outpoints.
  * Bulk recoverable settlement: discover recoverable VTXOs and either report none or settle collected outpoints.
  * Consistent JSON output for list and settle commands for easier integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->