### PR TITLE
Use derived address to look for VHTLC

### DIFF
--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -359,7 +359,11 @@ where
         }
 
         let vhtlc_outpoint = {
-            let (vtxo_list, _) = self.list_vtxos().await?;
+            let virtual_tx_outpoints = self
+                .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
+                .await?;
+
+            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -626,7 +630,11 @@ where
         }
 
         let vhtlc_outpoint = {
-            let (vtxo_list, _) = self.list_vtxos().await?;
+            let virtual_tx_outpoints = self
+                .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
+                .await?;
+
+            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1099,7 +1107,11 @@ where
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
-            let (vtxo_list, _) = self.list_vtxos().await?;
+            let virtual_tx_outpoints = self
+                .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
+                .await?;
+
+            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1335,7 +1347,11 @@ where
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
-            let (vtxo_list, _) = self.list_vtxos().await?;
+            let virtual_tx_outpoints = self
+                .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
+                .await?;
+
+            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();


### PR DESCRIPTION
We cannot call `list_vtxos` on the underlying `ark_client::Client`, because that looks at regular, single-sig VTXO addresses, not VHTLCs.

Like we already did correctly for the new API `refund_expired_vhtlc_via_settlement`, we have to make a specific request to the Arkade server to fetch information about the specific VHTLC address we have reconstructed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal outpoint retrieval logic for improved efficiency in virtual transaction handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->