### PR TITLE
Add API to execute collaborative redeem with chosen VTXOs

### DIFF
--- a/ark-client-sample/justfile
+++ b/ark-client-sample/justfile
@@ -48,6 +48,10 @@ subscribe actor address:
 send-onchain actor address amount:
     cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed send-onchain {{ address }} {{ amount }}
 
+# Send coins to an Onchain address using specific VTXOs, e.g. just send-onchain-vtxo-selection alice "abc123:0,def456:1" bc1... 50000
+send-onchain-vtxo-selection actor vtxos address amount:
+    cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed send-onchain-with-vtxos --vtxos {{ vtxos }} {{ address }} {{ amount }}
+
 # Receive via lightning
 lightning-invoice actor amount:
     cargo run -p ark-client-sample -- --config ./{{ actor }}/ark.config.toml --seed ./{{ actor }}/ark.seed lightning-invoice {{ amount }}

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -130,10 +130,8 @@ where
         address: ArkAddress,
         amount: Amount,
     ) -> Result<Txid, Error> {
-        let (vtxo_list, script_pubkey_to_vtxo_map) = self
-            .list_vtxos()
-            .await
-            .context("failed to get spendable VTXOs")?;
+        let (vtxo_list, script_pubkey_to_vtxo_map) =
+            self.list_vtxos().await.context("failed to get VTXO list")?;
 
         // Get all spendable VTXOs for reference
         let all_spendable = vtxo_list


### PR DESCRIPTION
It's an advanced API that can be combined with `list_vtxos` to craft a settlement intent which consumes specific VTXOs. This can be helpful if you're trying to settle expired/recoverable VTXOs, for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI command to send on-chain coins with explicit VTXO selection, allowing users to specify which individual UTXOs are used for transactions along with destination address and amount parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->