### PR TITLE
Get rid of expired VTXO concept

### DIFF
--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -558,17 +558,6 @@ async fn main() -> Result<()> {
                 });
             }
 
-            // Collect expired VTXOs
-            for v in vtxo_list.expired() {
-                vtxo_entries.push(VtxoEntry {
-                    outpoint: v.outpoint.to_string(),
-                    amount_sats: v.amount.to_sat(),
-                    created_at: format_timestamp(v.created_at)?,
-                    expires_at: format_timestamp(v.expires_at)?,
-                    status: "expired".to_string(),
-                });
-            }
-
             // Collect recoverable VTXOs
             for v in vtxo_list.recoverable() {
                 vtxo_entries.push(VtxoEntry {

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -308,7 +308,6 @@ pub struct AddressVtxos {
 pub struct OffChainBalance {
     pre_confirmed: Amount,
     confirmed: Amount,
-    expired: Amount,
     recoverable: Amount,
 }
 
@@ -321,21 +320,13 @@ impl OffChainBalance {
         self.confirmed
     }
 
-    /// Balance which can only be settled, but requires a forfeit transaction per VTXO.
-    ///
-    /// Since the server's concept of now may differ slightly from the client's, this balance may
-    /// sometimes be incorrect.
-    pub fn expired(&self) -> Amount {
-        self.expired
-    }
-
     /// Balance which can only be settled, and does not require a forfeit transaction per VTXO.
     pub fn recoverable(&self) -> Amount {
         self.recoverable
     }
 
     pub fn total(&self) -> Amount {
-        self.pre_confirmed + self.confirmed + self.expired + self.recoverable
+        self.pre_confirmed + self.confirmed + self.recoverable
     }
 }
 
@@ -809,10 +800,6 @@ where
             .confirmed()
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
-        let expired = vtxo_list
-            .expired()
-            .fold(Amount::ZERO, |acc, x| acc + x.amount);
-
         let recoverable = vtxo_list
             .recoverable()
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
@@ -820,7 +807,6 @@ where
         Ok(OffChainBalance {
             pre_confirmed,
             confirmed,
-            expired,
             recoverable,
         })
     }

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -362,6 +362,19 @@ pub struct VirtualTxOutPoint {
 }
 
 impl VirtualTxOutPoint {
+    /// Check if a VTXO is recoverable.
+    ///
+    /// Recoverable VTXOs can be settled, but they cannot be sent in an offchain transaction. To
+    /// settle them, the original VTXO does not need to be forfeited, as the Arkade server already
+    /// controls it.
+    pub fn is_recoverable(&self, dust: Amount) -> bool {
+        if self.is_spent {
+            return false;
+        }
+
+        self.amount < dust || self.is_swept || self.is_expired()
+    }
+
     /// Check if a VTXO has expired.
     ///
     /// Expired VTXOs can be settled, but they cannot be sent in an offchain transaction. To settle
@@ -386,15 +399,6 @@ impl VirtualTxOutPoint {
         };
 
         current_timestamp > self.expires_at && !self.is_swept && !self.is_spent
-    }
-
-    /// Check if a VTXO is recoverable.
-    ///
-    /// Recoverable VTXOs can be settled, but they cannot be sent in an offchain transaction. To
-    /// settle them, the original VTXO does not need to be forfeited, as the Arkade server already
-    /// controls it.
-    pub fn is_recoverable(&self, dust: Amount) -> bool {
-        (self.amount < dust || self.is_swept) && !self.is_spent
     }
 }
 


### PR DESCRIPTION
It is useful to know if a VTXO has expired but has not been swept yet, so that we know to forfeit it when settling into a batch.

At the same time, it's not actually that helpful to model expired VTXOs explicitly. It just adds another category that can simply be
merged into "recoverable".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined VTXO recoverability logic to properly evaluate expiration status.
  * Updated balance calculations to exclude expired virtual transaction outputs.

* **Refactor**
  * Removed "expired" VTXO classification; outputs now more accurately categorized as pre-confirmed, confirmed, recoverable, or spent.
  * Improved consistency in how virtual transaction outputs are processed and reported across the client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->