### PR TITLE
Use consistent below-dust boundary

### DIFF
--- a/ark-core/src/batch.rs
+++ b/ark-core/src/batch.rs
@@ -693,7 +693,7 @@ pub fn prepare_delegate_psbts(
 
     for intent_input in intent_inputs.iter() {
         // Skip swept or sub-dust VTXOs - they cannot be forfeited.
-        if intent_input.is_swept() || intent_input.amount() <= dust {
+        if intent_input.is_swept() || intent_input.amount() < dust {
             continue;
         }
 


### PR DESCRIPTION
To address https://github.com/arkade-os/rust-sdk/pull/162#discussion_r2734628949. I merged the other PR hastily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the dust threshold comparison in forfeit transaction generation to properly include transactions with values exactly at the dust limit, improving handling of minimal-value transactions during forfeit operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->