### PR TITLE
refactor: remove BoardingWallet trait

### DIFF
--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1641,8 +1641,8 @@ where
                                     .wallet
                                     .sk_for_pk(pk)
                                     .map_err(|e| ark_core::Error::ad_hoc(e.to_string()))?;
-                                let secp = Secp256k1::new();
-                                Ok(secp.sign_schnorr_no_aux_rand(msg, &sk.keypair(&secp)))
+                                let secp = self.secp();
+                                Ok(secp.sign_schnorr_no_aux_rand(msg, &sk.keypair(secp)))
                             };
 
                             sign_commitment_psbt(

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -2,8 +2,8 @@ use crate::error::ErrorContext as _;
 use crate::swap_storage::SwapStorage;
 use crate::utils::sleep;
 use crate::utils::timeout_op;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Blockchain;
 use crate::Client;
 use crate::Error;
@@ -52,7 +52,7 @@ use std::collections::HashMap;
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: crate::KeyProvider,
 {
@@ -927,7 +927,7 @@ where
         &self,
     ) -> Result<(Vec<batch::OnChainInput>, Vec<intent::Input>, Amount), Error> {
         // Get all known boarding outputs.
-        let boarding_outputs = self.inner.wallet.get_boarding_outputs()?;
+        let boarding_outputs = self.inner.wallet.load_boarding_outputs()?;
 
         let mut boarding_inputs: Vec<batch::OnChainInput> = Vec::new();
         let mut total_amount = Amount::ZERO;
@@ -1162,11 +1162,13 @@ where
                     })?;
 
                 let owner_pk = onchain_input.boarding_output().owner_pk();
-                let sig = self
+                let sk = self
                     .inner
                     .wallet
-                    .sign_for_pk(&owner_pk, &msg)
+                    .sk_for_pk(&owner_pk)
                     .map_err(|e| ark_core::Error::ad_hoc(e.to_string()))?;
+                let secp = Secp256k1::new();
+                let sig = secp.sign_schnorr_no_aux_rand(&msg, &sk.keypair(&secp));
 
                 Ok((sig, owner_pk))
             };
@@ -1635,10 +1637,13 @@ where
                                 schnorr::Signature,
                                 ark_core::Error,
                             > {
-                                self.inner
+                                let sk = self
+                                    .inner
                                     .wallet
-                                    .sign_for_pk(pk, msg)
-                                    .map_err(|e| ark_core::Error::ad_hoc(e.to_string()))
+                                    .sk_for_pk(pk)
+                                    .map_err(|e| ark_core::Error::ad_hoc(e.to_string()))?;
+                                let secp = Secp256k1::new();
+                                Ok(secp.sign_schnorr_no_aux_rand(msg, &sk.keypair(&secp)))
                             };
 
                             sign_commitment_psbt(

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1167,7 +1167,6 @@ where
                     .wallet
                     .sk_for_pk(&owner_pk)
                     .map_err(|e| ark_core::Error::ad_hoc(e.to_string()))?;
-                let secp = Secp256k1::new();
                 let sig = secp.sign_schnorr_no_aux_rand(&msg, &sk.keypair(&secp));
 
                 Ok((sig, owner_pk))

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -2,8 +2,8 @@ use crate::batch::BatchOutputType;
 use crate::error::ErrorContext as _;
 use crate::swap_storage::SwapStorage;
 use crate::timeout_op;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Blockchain;
 use crate::Client;
 use crate::Error;
@@ -73,7 +73,7 @@ pub struct ClaimVhtlcResult {
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: crate::KeyProvider,
 {

--- a/ark-client/src/coin_select.rs
+++ b/ark-client/src/coin_select.rs
@@ -1,6 +1,6 @@
 use crate::swap_storage::SwapStorage;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Blockchain;
 use crate::Client;
 use crate::Error;
@@ -34,11 +34,11 @@ pub async fn coin_select_for_onchain<B, W, S, K>(
 >
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: crate::KeyProvider,
 {
-    let boarding_outputs = client.inner.wallet.get_boarding_outputs()?;
+    let boarding_outputs = client.inner.wallet.load_boarding_outputs()?;
 
     let now = Timestamp::now();
 

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -1,8 +1,8 @@
 use crate::batch;
 use crate::batch::BatchOutputType;
 use crate::error::ErrorContext;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Client;
 use crate::Error;
 use crate::KeyProvider;
@@ -20,7 +20,7 @@ use rand::Rng;
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: crate::Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: KeyProvider,
 {

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -2,8 +2,8 @@ use crate::error::ErrorContext;
 use crate::key_provider::KeypairIndex;
 use crate::utils::sleep;
 use crate::utils::timeout_op;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use ark_core::build_anchor_tx;
 use ark_core::history;
 use ark_core::history::generate_incoming_vtxo_transaction_history;
@@ -85,11 +85,10 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// # use ark_client::{Blockchain, Client, Error, SpendStatus, TxStatus};
 /// # use ark_client::OfflineClient;
 /// # use bitcoin::key::Keypair;
-/// # use bitcoin::secp256k1::{Message, SecretKey};
+/// # use bitcoin::secp256k1::SecretKey;
 /// # use std::sync::Arc;
-/// # use bitcoin::{Address, Amount, FeeRate, Network, Psbt, Transaction, Txid, XOnlyPublicKey};
-/// # use bitcoin::secp256k1::schnorr::Signature;
-/// # use ark_client::wallet::{Balance, BoardingWallet, OnchainWallet, Persistence};
+/// # use bitcoin::{Address, Amount, FeeRate, Psbt, Transaction, Txid, XOnlyPublicKey};
+/// # use ark_client::wallet::{Balance, OnchainWallet, Persistence};
 /// # use ark_client::InMemorySwapStorage;
 /// # use ark_core::{BoardingOutput, UtxoCoinSelection, ExplorerUtxo};
 /// # use ark_client::StaticKeyProvider;
@@ -135,7 +134,7 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// # }
 ///
 /// struct MyWallet {}
-/// # impl OnchainWallet for MyWallet where {
+/// # impl OnchainWallet for MyWallet {
 /// #
 /// #     fn get_onchain_address(&self) -> Result<Address, Error> {
 /// #         unimplemented!("You can implement this function using your preferred client library such as bdk")
@@ -162,9 +161,7 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// #     }
 /// # }
 /// #
-///
-/// struct InMemoryDb {}
-/// # impl Persistence for InMemoryDb {
+/// # impl Persistence for MyWallet {
 /// #
 /// #     fn save_boarding_output(
 /// #         &self,
@@ -179,28 +176,6 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// #     }
 /// #
 /// #     fn sk_for_pk(&self, pk: &XOnlyPublicKey) -> Result<SecretKey, Error> {
-/// #         unimplemented!()
-/// #     }
-/// # }
-/// #
-/// #
-/// # impl BoardingWallet for MyWallet
-/// # where
-/// # {
-/// #     fn new_boarding_output(
-/// #         &self,
-/// #         server_pk: XOnlyPublicKey,
-/// #         exit_delay: bitcoin::Sequence,
-/// #         network: Network,
-/// #     ) -> Result<BoardingOutput, Error> {
-/// #         unimplemented!()
-/// #     }
-/// #
-/// #     fn get_boarding_outputs(&self) -> Result<Vec<BoardingOutput>, Error> {
-/// #         unimplemented!()
-/// #     }
-/// #
-/// #     fn sign_for_pk(&self, pk: &XOnlyPublicKey, msg: &Message) -> Result<Signature, Error> {
 /// #         unimplemented!()
 /// #     }
 /// # }
@@ -371,7 +346,7 @@ pub trait Blockchain {
 impl<B, W, S, K> OfflineClient<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
@@ -578,7 +553,7 @@ where
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
@@ -721,15 +696,27 @@ where
         Ok(discovered_count)
     }
 
-    // At the moment we are always generating the same address.
+    /// Get a boarding address for receiving funds on-chain that can later be settled into VTXOs.
+    ///
+    /// Creates a new boarding output using the current keypair and saves it to persistence.
     pub fn get_boarding_address(&self) -> Result<Address, Error> {
         let server_info = &self.server_info;
 
-        let boarding_output = self.inner.wallet.new_boarding_output(
+        let keypair = self.next_keypair(KeypairIndex::LastUnused)?;
+        let owner_pk = keypair.x_only_public_key().0;
+
+        let boarding_output = ark_core::BoardingOutput::new(
+            self.secp(),
             server_info.signer_pk.into(),
+            owner_pk,
             server_info.boarding_exit_delay,
             server_info.network,
         )?;
+
+        // Save the boarding output and its secret key for later signing
+        self.inner
+            .wallet
+            .save_boarding_output(keypair.secret_key(), boarding_output.clone())?;
 
         Ok(boarding_output.address().clone())
     }

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -1,8 +1,8 @@
 use crate::error::ErrorContext;
 use crate::swap_storage::SwapStorage;
 use crate::utils::timeout_op;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Blockchain;
 use crate::Client;
 use crate::Error;
@@ -27,7 +27,7 @@ use bitcoin::XOnlyPublicKey;
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: crate::KeyProvider,
 {

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -261,7 +261,7 @@ where
             Some(script) => {
                 let mut res = vec![];
                 let pks = extract_checksig_pubkeys(script);
-                let secp = Secp256k1::new();
+                let secp = self.secp();
 
                 for pk in pks {
                     if let Ok(keypair) = self.keypair_by_pk(&pk) {

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -4,8 +4,8 @@ use crate::error::ErrorContext;
 use crate::swap_storage::SwapStorage;
 use crate::utils::sleep;
 use crate::utils::timeout_op;
-use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
+use crate::wallet::Persistence;
 use crate::Blockchain;
 use crate::Client;
 use ark_core::build_unilateral_exit_tree_txids;
@@ -30,7 +30,7 @@ use std::collections::HashSet;
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
-    W: BoardingWallet + OnchainWallet,
+    W: OnchainWallet + Persistence,
     S: SwapStorage + 'static,
     K: crate::KeyProvider,
 {
@@ -261,15 +261,17 @@ where
             Some(script) => {
                 let mut res = vec![];
                 let pks = extract_checksig_pubkeys(script);
+                let secp = Secp256k1::new();
 
                 for pk in pks {
                     if let Ok(keypair) = self.keypair_by_pk(&pk) {
-                        let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, &keypair);
+                        let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
                         let pk = keypair.x_only_public_key().0;
                         res.push((sig, pk))
                     }
 
-                    if let Ok(sig) = self.inner.wallet.sign_for_pk(&pk, &msg) {
+                    if let Ok(sk) = self.inner.wallet.sk_for_pk(&pk) {
+                        let sig = secp.sign_schnorr_no_aux_rand(&msg, &sk.keypair(&secp));
                         res.push((sig, pk))
                     }
                 }

--- a/ark-client/src/wallet.rs
+++ b/ark-client/src/wallet.rs
@@ -1,33 +1,13 @@
 use crate::error::Error;
 use ark_core::BoardingOutput;
 use ark_core::UtxoCoinSelection;
-use bitcoin::secp256k1::schnorr::Signature;
-use bitcoin::secp256k1::Message;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::Address;
 use bitcoin::Amount;
 use bitcoin::FeeRate;
-use bitcoin::Network;
 use bitcoin::Psbt;
 use bitcoin::XOnlyPublicKey;
 use std::future::Future;
-
-// TODO: I think we should get rid of `BoardingWallet` and `OnchainWallet` and just use
-// `KeyProvider` for everything! Also, IMO this client doesn't benefit from having an "on-chain
-// wallet" within it.
-
-pub trait BoardingWallet {
-    fn new_boarding_output(
-        &self,
-        server_pubkey: XOnlyPublicKey,
-        exit_delay: bitcoin::Sequence,
-        network: Network,
-    ) -> Result<BoardingOutput, Error>;
-
-    fn get_boarding_outputs(&self) -> Result<Vec<BoardingOutput>, Error>;
-
-    fn sign_for_pk(&self, pk: &XOnlyPublicKey, msg: &Message) -> Result<Signature, Error>;
-}
 
 pub trait OnchainWallet {
     fn get_onchain_address(&self) -> Result<Address, Error>;


### PR DESCRIPTION
## Summary

Remove the `BoardingWallet` trait and use `KeyProvider` for signing-related behavior instead.

Closes #137

## Changes

- Remove `BoardingWallet` trait definition from `wallet.rs`
- Update trait bounds from `BoardingWallet + OnchainWallet` to `OnchainWallet + Persistence` across all impl blocks
- Replace `BoardingWallet::sign_for_pk` calls with `Persistence::sk_for_pk` + direct schnorr signing
- Replace `BoardingWallet::get_boarding_outputs` with `Persistence::load_boarding_outputs`
- Move `new_boarding_output` logic into `Client::get_boarding_address` using `KeyProvider` for keypair generation
- Update `ark-bdk-wallet` to implement `Persistence` instead of `BoardingWallet` (delegate to inner DB)
- Remove unused `kp` and `secp` fields from `ark-bdk-wallet::Wallet` struct
- Update doc examples to reflect the new trait structure

## Notes

The `OnchainWallet` trait is retained as it handles on-chain wallet operations which are a separate concern from Ark signing. The refactoring simplifies the SDK by using `KeyProvider` as the single abstraction for signing-related behavior, as suggested in the TODO comment in `wallet.rs`.

## Testing

- `cargo build` passes
- `cargo test --lib --package ark-client` passes
- `cargo test --lib --package ark-core` passes (18 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boarding outputs and their keys are now persisted to storage when created, improving recoverability.

* **Refactor**
  * Wallet/client interfaces updated so signing and boarding operations use persisted keys/outputs rather than in-memory state, streamlining key management and persistence across flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->