### PR TITLE
Disable fortify hardening in nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
       in
         {
           devShells.default = with pkgs; mkShell {
+            hardeningDisable = [ "fortify" ];
+
             # TODO: Trim these.
             buildInputs = [
               binaryen


### PR DESCRIPTION
_FORTIFY_SOURCE requires compilation with optimization (-O), which conflicts with Cargo's debug profile. This caused warnings from `secp256k1-sys` on every build.