### PR TITLE
fix(wasm): use Date.now() for correct epoch timestamp in is_expired

### DIFF
--- a/ark-core/Cargo.toml
+++ b/ark-core/Cargo.toml
@@ -22,4 +22,5 @@ tracing = "0.1.37"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["wasm-bindgen", "js"] }
 getrandom2 = { package = "getrandom", version = "0.3.1", features = ["wasm_js"] }
+js-sys = "0.3"
 web-sys = { version = "0.3.77", features = ["Window", "Performance"] }

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -390,13 +390,7 @@ impl VirtualTxOutPoint {
             .as_secs() as i64;
 
         #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-        let current_timestamp = {
-            let window = web_sys::window().expect("should have a window in this context");
-            let performance = window
-                .performance()
-                .expect("performance should be available");
-            performance.now() as i64
-        };
+        let current_timestamp = (js_sys::Date::now() / 1000.0) as i64;
 
         current_timestamp > self.expires_at && !self.is_swept && !self.is_spent
     }


### PR DESCRIPTION
**Problem:** `performance.now()` returns milliseconds relative to page load — not a Unix epoch timestamp in seconds. This caused `is_expired()` to always evaluate incorrectly on WASM.

**Fix:** Replace with `js_sys::Date::now() / 1000` to get seconds since Unix epoch, matching the native `SystemTime` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for improved browser environment support.

* **Bug Fixes**
  * Fixed timestamp calculation for expiration checking in browser-based environments to ensure accurate time-based validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->