### PR TITLE
fix(ark-client-sample): correct esplora port 30000 → 3000

### DIFF
--- a/ark-client-sample/alice/ark.config.toml
+++ b/ark-client-sample/alice/ark.config.toml
@@ -1,7 +1,7 @@
 ark_server_url = "http://localhost:7070"
-esplora_url = "http://localhost:30000"
+esplora_url = "http://localhost:3000"
 swap_storage_path = "./alice/swap_storage.sqlite"
 boltz_url = "http://localhost:9001"
 
-# ark_server_url = "http://mutinynet.arkade.sh"
+# ark_server_url = "http://localhost:7070"
 # esplora_url = "https://mutinynet.com/api"

--- a/ark-client-sample/bob/ark.config.toml
+++ b/ark-client-sample/bob/ark.config.toml
@@ -1,4 +1,4 @@
 ark_server_url = "http://localhost:7070"
-esplora_url = "http://localhost:30000"
+esplora_url = "http://localhost:3000"
 swap_storage_path = "./bob/swap_storage.sqlite"
 boltz_url = "http://localhost:9001"


### PR DESCRIPTION
When using `nigiri`, which is the recommended tool for setting up the dev environment, esplora's API is on port 3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Esplora endpoint configuration in sample client setups to use port 3000 instead of port 30000.
  * Added example configuration comments for local development reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->