### PR TITLE
Feat/simple 2of3 escrow e2e test and bug fix

### DIFF
--- a/ark-core/src/vtxo.rs
+++ b/ark-core/src/vtxo.rs
@@ -217,9 +217,13 @@ fn calculate_leaf_depths(n: usize) -> Vec<usize> {
     // Calculate the minimum depth required for n leaves
     let min_depth = (n as f64).log2().ceil() as usize;
 
-    // Calculate the number of nodes at the deepest level
-    let nodes_at_max_depth = n - (1 << (min_depth - 1)) + 1;
-    let nodes_at_min_depth = (1 << min_depth) - nodes_at_max_depth;
+    // Calculate the number of leaves at each level.
+    // We start with 2^(min_depth-1) slots at depth min_depth-1. Each of the
+    // (n - 2^(min_depth-1)) excess leaves requires splitting one slot into two
+    // children at depth min_depth.
+    let excess = n - (1 << (min_depth - 1));
+    let nodes_at_max_depth = 2 * excess;
+    let nodes_at_min_depth = n - nodes_at_max_depth;
 
     // Create the result vector with the appropriate depths
     let mut result = Vec::with_capacity(n);

--- a/e2e-tests/tests/e2e_2of3_escrow.rs
+++ b/e2e-tests/tests/e2e_2of3_escrow.rs
@@ -1,0 +1,309 @@
+#![allow(clippy::unwrap_used)]
+
+use ark_core::send;
+use ark_core::send::build_offchain_transactions;
+use ark_core::send::sign_ark_transaction;
+use ark_core::send::sign_checkpoint_transaction;
+use ark_core::server::GetVtxosRequest;
+use ark_core::Vtxo;
+use ark_core::VtxoList;
+use bitcoin::key::Keypair;
+use bitcoin::key::Secp256k1;
+use bitcoin::opcodes::all::OP_CHECKSIG;
+use bitcoin::opcodes::all::OP_CHECKSIGVERIFY;
+use bitcoin::opcodes::all::OP_CSV;
+use bitcoin::opcodes::all::OP_DROP;
+use bitcoin::psbt;
+use bitcoin::script::ScriptBuf;
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::schnorr;
+use bitcoin::Amount;
+use bitcoin::XOnlyPublicKey;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use rand::thread_rng;
+use std::sync::Arc;
+
+mod common;
+
+/// Test a 2-of-3 multisig VTXO flow using tapscript multisig:
+///
+/// 1. Alice funds herself via boarding + settle.
+/// 2. Alice sends to a shared VTXO with 3 tapscript leaf pairs (one per 2-of-3 combination:
+///    Alice+Bob, Alice+Carol, Bob+Carol). Each pair consists of a cooperative forfeit leaf (server
+///    + two signers) and a unilateral exit leaf (CSV + two signers).
+/// 3. Alice and Bob cooperatively sign an offchain transaction spending the shared VTXO to Bob's
+///    regular address using the Alice+Bob leaf. Carol is not involved in this spend.
+/// 4. Verify the shared VTXO is spent and Bob received the funds.
+#[tokio::test]
+#[ignore]
+pub async fn e2e_2of3_escrow() {
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    // Set up Alice (for funding and sending to multisig)
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    // Create keypairs for the 3 multisig participants
+    let alice_kp = Keypair::new(&secp, &mut rng);
+    let bob_kp = Keypair::new(&secp, &mut rng);
+    let carol_kp = Keypair::new(&secp, &mut rng);
+
+    let alice_pk = alice_kp.public_key().x_only_public_key().0;
+    let bob_pk = bob_kp.public_key().x_only_public_key().0;
+    let carol_pk = carol_kp.public_key().x_only_public_key().0;
+
+    let server_pk = alice.server_info.signer_pk.x_only_public_key().0;
+    let exit_delay = alice.server_info.unilateral_exit_delay;
+
+    // Fund Alice via boarding
+    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_fund_amount = Amount::ONE_BTC;
+
+    let alice_boarding_outpoint = nigiri
+        .faucet_fund(&alice_boarding_address, alice_fund_amount)
+        .await;
+
+    tracing::debug!(?alice_boarding_outpoint, "Funded Alice's boarding output");
+
+    alice.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let alice_starting_balance = alice.offchain_balance().await.unwrap();
+    tracing::info!(?alice_starting_balance, "Alice got confirmed VTXO");
+
+    assert_eq!(alice_starting_balance.confirmed(), alice_fund_amount);
+
+    // Build 6 tapscript leaves: 3 forfeit (server + pair) + 3 exit (CSV + pair)
+    let forfeit_ab = forfeit_multisig_script(server_pk, alice_pk, bob_pk);
+    let forfeit_ac = forfeit_multisig_script(server_pk, alice_pk, carol_pk);
+    let forfeit_bc = forfeit_multisig_script(server_pk, bob_pk, carol_pk);
+
+    let exit_ab = csv_multisig_script(exit_delay, alice_pk, bob_pk);
+    let exit_ac = csv_multisig_script(exit_delay, alice_pk, carol_pk);
+    let exit_bc = csv_multisig_script(exit_delay, bob_pk, carol_pk);
+
+    // Create the shared VTXO with custom scripts.
+    // The "owner" field is set to Alice's key (arbitrary — it's only used by
+    // `forfeit_spend_info` which we don't call for custom VTXOs).
+    let shared_vtxo = Vtxo::new_with_custom_scripts(
+        &secp,
+        server_pk,
+        alice_pk,
+        vec![
+            forfeit_ab.clone(),
+            forfeit_ac.clone(),
+            forfeit_bc.clone(),
+            exit_ab,
+            exit_ac,
+            exit_bc,
+        ],
+        exit_delay,
+        alice.server_info.network,
+    )
+    .unwrap();
+
+    // Alice sends to the shared multisig address
+    let msig_amount = Amount::from_sat(100_000);
+
+    let send_txid = alice
+        .send_vtxo(shared_vtxo.to_ark_address(), msig_amount)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    tracing::info!(%send_txid, "Alice funded shared 2-of-3 multisig VTXO");
+
+    // Look up the shared VTXO to get the outpoint
+    let mut grpc_client = ark_grpc::Client::new("http://localhost:7070".to_string());
+    grpc_client.connect().await.unwrap();
+
+    let request = GetVtxosRequest::new_for_addresses(std::iter::once(shared_vtxo.to_ark_address()));
+    let response = grpc_client.list_vtxos(request).await.unwrap();
+
+    let vtxo_list = VtxoList::new(alice.server_info.dust, response.vtxos);
+    let msig_vtxo = vtxo_list
+        .spendable_offchain()
+        .next()
+        .expect("shared VTXO should be spendable");
+
+    tracing::info!(
+        outpoint = %msig_vtxo.outpoint,
+        amount = %msig_vtxo.amount,
+        "Found shared 2-of-3 multisig VTXO"
+    );
+
+    // Bob's payout VTXO address
+    let bob_payout_vtxo = Vtxo::new_default(
+        &secp,
+        server_pk,
+        bob_pk,
+        exit_delay,
+        alice.server_info.network,
+    )
+    .unwrap();
+
+    // Check Bob's balance before the spend
+    let bob_balance_before = {
+        let request =
+            GetVtxosRequest::new_for_addresses(std::iter::once(bob_payout_vtxo.to_ark_address()));
+        let response = grpc_client.list_vtxos(request).await.unwrap();
+        let list = VtxoList::new(alice.server_info.dust, response.vtxos);
+        list.spendable_offchain()
+            .fold(Amount::ZERO, |acc, v| acc + v.amount)
+    };
+
+    assert_eq!(bob_balance_before, Amount::ZERO);
+
+    // Spend using the Alice+Bob forfeit leaf
+    let control_block = shared_vtxo.get_spend_info(forfeit_ab.clone()).unwrap();
+
+    let msig_input = send::VtxoInput::new(
+        forfeit_ab,
+        None,
+        control_block,
+        shared_vtxo.tapscripts(),
+        shared_vtxo.script_pubkey(),
+        msig_vtxo.amount,
+        msig_vtxo.outpoint,
+    );
+
+    let offchain_txs = build_offchain_transactions(
+        &[(&bob_payout_vtxo.to_ark_address(), msig_amount)],
+        None,
+        &[msig_input],
+        &alice.server_info,
+    )
+    .unwrap();
+
+    let send::OffchainTransactions {
+        ark_tx: mut virtual_tx,
+        checkpoint_txs,
+    } = offchain_txs;
+
+    let mut pre_signed_checkpoint = checkpoint_txs[0].clone();
+
+    // --- Sign the virtual TX (Alice + Bob) ---
+    {
+        let sign_fn =
+            |_: &mut psbt::Input,
+             msg: secp256k1::Message|
+             -> Result<Vec<(schnorr::Signature, XOnlyPublicKey)>, ark_core::Error> {
+                let secp = Secp256k1::new();
+                let alice_sig = secp.sign_schnorr_no_aux_rand(&msg, &alice_kp);
+                let bob_sig = secp.sign_schnorr_no_aux_rand(&msg, &bob_kp);
+                Ok(vec![(alice_sig, alice_pk), (bob_sig, bob_pk)])
+            };
+        sign_ark_transaction(sign_fn, &mut virtual_tx, 0).unwrap();
+    }
+
+    // --- Sign the checkpoint TX (Alice + Bob) ---
+    {
+        let sign_fn =
+            |_: &mut psbt::Input,
+             msg: secp256k1::Message|
+             -> Result<Vec<(schnorr::Signature, XOnlyPublicKey)>, ark_core::Error> {
+                let secp = Secp256k1::new();
+                let alice_sig = secp.sign_schnorr_no_aux_rand(&msg, &alice_kp);
+                let bob_sig = secp.sign_schnorr_no_aux_rand(&msg, &bob_kp);
+                Ok(vec![(alice_sig, alice_pk), (bob_sig, bob_pk)])
+            };
+        sign_checkpoint_transaction(sign_fn, &mut pre_signed_checkpoint).unwrap();
+    }
+
+    // Submit the signed virtual TX + unsigned checkpoint to the server
+    let virtual_txid = virtual_tx.unsigned_tx.compute_txid();
+
+    let res = grpc_client
+        .submit_offchain_transaction_request(virtual_tx, checkpoint_txs)
+        .await
+        .unwrap();
+
+    // Combine our pre-signed checkpoint with the server's signature
+    pre_signed_checkpoint
+        .combine(res.signed_checkpoint_txs[0].clone())
+        .unwrap();
+
+    // Finalize the offchain transaction
+    grpc_client
+        .finalize_offchain_transaction(virtual_txid, vec![pre_signed_checkpoint])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    tracing::info!(
+        %virtual_txid,
+        "Cooperatively spent 2-of-3 multisig VTXO to Bob's address (Alice+Bob signed)"
+    );
+
+    // Verify: shared VTXO is spent
+    let request = GetVtxosRequest::new_for_addresses(std::iter::once(shared_vtxo.to_ark_address()));
+    let response = grpc_client.list_vtxos(request).await.unwrap();
+    let vtxo_list = VtxoList::new(alice.server_info.dust, response.vtxos);
+
+    assert_eq!(
+        vtxo_list.spendable_offchain().count(),
+        0,
+        "shared VTXO should be spent"
+    );
+
+    // Verify: Bob's balance increased by the multisig amount
+    let bob_balance_after = {
+        let request =
+            GetVtxosRequest::new_for_addresses(std::iter::once(bob_payout_vtxo.to_ark_address()));
+        let response = grpc_client.list_vtxos(request).await.unwrap();
+        let list = VtxoList::new(alice.server_info.dust, response.vtxos);
+        list.spendable_offchain()
+            .fold(Amount::ZERO, |acc, v| acc + v.amount)
+    };
+
+    assert_eq!(
+        bob_balance_after - bob_balance_before,
+        msig_amount,
+        "Bob's balance should have increased by the multisig amount"
+    );
+
+    tracing::info!(
+        %bob_balance_before,
+        %bob_balance_after,
+        "Bob received funds from 2-of-3 multisig VTXO"
+    );
+}
+
+/// 3-of-3 forfeit script: server + two signers.
+fn forfeit_multisig_script(
+    server_pk: XOnlyPublicKey,
+    pk_a: XOnlyPublicKey,
+    pk_b: XOnlyPublicKey,
+) -> ScriptBuf {
+    ScriptBuf::builder()
+        .push_x_only_key(&server_pk)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_x_only_key(&pk_a)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_x_only_key(&pk_b)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}
+
+/// CSV + 2-of-2 exit script: timelock + two signers.
+fn csv_multisig_script(
+    locktime: bitcoin::Sequence,
+    pk_a: XOnlyPublicKey,
+    pk_b: XOnlyPublicKey,
+) -> ScriptBuf {
+    ScriptBuf::builder()
+        .push_int(locktime.to_consensus_u32() as i64)
+        .push_opcode(OP_CSV)
+        .push_opcode(OP_DROP)
+        .push_x_only_key(&pk_a)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_x_only_key(&pk_b)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}

--- a/e2e-tests/tests/e2e_multisig.rs
+++ b/e2e-tests/tests/e2e_multisig.rs
@@ -1,0 +1,401 @@
+#![allow(clippy::unwrap_used)]
+
+use ark_core::send;
+use ark_core::send::build_offchain_transactions;
+use ark_core::send::sign_ark_transaction;
+use ark_core::send::sign_checkpoint_transaction;
+use ark_core::server::GetVtxosRequest;
+use ark_core::Vtxo;
+use ark_core::VtxoList;
+use bitcoin::key::Keypair;
+use bitcoin::key::Secp256k1;
+use bitcoin::psbt;
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::schnorr;
+use bitcoin::Amount;
+use bitcoin::XOnlyPublicKey;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use rand::thread_rng;
+use rand::Rng;
+use std::sync::Arc;
+use zkp::musig::new_musig_nonce_pair;
+use zkp::musig::MusigAggNonce;
+use zkp::musig::MusigKeyAggCache;
+use zkp::musig::MusigSession;
+use zkp::musig::MusigSessionId;
+
+mod common;
+
+/// Test a normal 2-of-2 multisig VTXO flow using MuSig2:
+///
+/// 1. Alice funds herself via boarding + settle.
+/// 2. Alice sends to a shared VTXO owned by a MuSig2 aggregate key (Alice + Bob). The server
+///    doesn't even know this is a multisig.
+/// 3. Both parties cooperatively sign an offchain transaction spending the shared VTXO to Bob's
+///    regular address, using the `send` module (no delegates).
+/// 4. Verify the shared VTXO is spent and Bob received the funds.
+#[tokio::test]
+#[ignore]
+pub async fn e2e_multisig() {
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+
+    let secp = Secp256k1::new();
+    let zkp_secp = zkp::Secp256k1::new();
+    let mut rng = thread_rng();
+
+    // Set up Alice (for funding and sending to multisig)
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    // Create keypairs for the multisig participants
+    let alice_kp = Keypair::new(&secp, &mut rng);
+    let bob_kp = Keypair::new(&secp, &mut rng);
+
+    // Create MuSig2 aggregated key — the server sees a single pubkey
+    let musig_key_agg_cache = MusigKeyAggCache::new(
+        &zkp_secp,
+        &[
+            to_zkp_pk(alice_kp.public_key()),
+            to_zkp_pk(bob_kp.public_key()),
+        ],
+    );
+    let shared_pk = from_zkp_xonly(musig_key_agg_cache.agg_pk());
+
+    let server_pk = alice.server_info.signer_pk.x_only_public_key().0;
+
+    // Fund Alice via boarding
+    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_fund_amount = Amount::ONE_BTC;
+
+    let alice_boarding_outpoint = nigiri
+        .faucet_fund(&alice_boarding_address, alice_fund_amount)
+        .await;
+
+    tracing::debug!(?alice_boarding_outpoint, "Funded Alice's boarding output");
+
+    alice.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let alice_starting_balance = alice.offchain_balance().await.unwrap();
+    tracing::info!(?alice_starting_balance, "Alice got confirmed VTXO");
+
+    assert_eq!(alice_starting_balance.confirmed(), alice_fund_amount);
+
+    // Create a standard VTXO with the MuSig2 shared key as owner.
+    // This produces the same forfeit/redeem scripts as any normal VTXO:
+    //   forfeit: server_pk CHECKSIGVERIFY shared_pk CHECKSIG
+    //   redeem:  CSV shared_pk CHECKSIG
+    let shared_vtxo = Vtxo::new_default(
+        &secp,
+        server_pk,
+        shared_pk,
+        alice.server_info.unilateral_exit_delay,
+        alice.server_info.network,
+    )
+    .unwrap();
+
+    // Alice sends to the shared multisig address
+    let msig_amount = Amount::from_sat(100_000);
+
+    let send_txid = alice
+        .send_vtxo(shared_vtxo.to_ark_address(), msig_amount)
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    tracing::info!(%send_txid, "Alice funded shared multisig VTXO");
+
+    // Look up the shared VTXO to get the outpoint
+    let mut grpc_client = ark_grpc::Client::new("http://localhost:7070".to_string());
+    grpc_client.connect().await.unwrap();
+
+    let request = GetVtxosRequest::new_for_addresses(std::iter::once(shared_vtxo.to_ark_address()));
+    let response = grpc_client.list_vtxos(request).await.unwrap();
+
+    let vtxo_list = VtxoList::new(alice.server_info.dust, response.vtxos);
+    let msig_vtxo = vtxo_list
+        .spendable_offchain()
+        .next()
+        .expect("shared VTXO should be spendable");
+
+    tracing::info!(
+        outpoint = %msig_vtxo.outpoint,
+        amount = %msig_vtxo.amount,
+        "Found shared multisig VTXO"
+    );
+
+    // Bob's payout VTXO address
+    let bob_payout_vtxo = Vtxo::new_default(
+        &secp,
+        server_pk,
+        bob_kp.public_key().x_only_public_key().0,
+        alice.server_info.unilateral_exit_delay,
+        alice.server_info.network,
+    )
+    .unwrap();
+
+    // Check Bob's balance before the spend
+    let bob_balance_before = {
+        let request =
+            GetVtxosRequest::new_for_addresses(std::iter::once(bob_payout_vtxo.to_ark_address()));
+        let response = grpc_client.list_vtxos(request).await.unwrap();
+        let list = VtxoList::new(alice.server_info.dust, response.vtxos);
+        list.spendable_offchain()
+            .fold(Amount::ZERO, |acc, v| acc + v.amount)
+    };
+
+    assert_eq!(bob_balance_before, Amount::ZERO);
+
+    // Build the cooperative spend: shared VTXO → Bob's address
+    let (forfeit_script, control_block) = shared_vtxo.forfeit_spend_info().unwrap();
+
+    let msig_input = send::VtxoInput::new(
+        forfeit_script,
+        None,
+        control_block,
+        shared_vtxo.tapscripts(),
+        shared_vtxo.script_pubkey(),
+        msig_vtxo.amount,
+        msig_vtxo.outpoint,
+    );
+
+    let offchain_txs = build_offchain_transactions(
+        &[(&bob_payout_vtxo.to_ark_address(), msig_amount)],
+        None,
+        &[msig_input],
+        &alice.server_info,
+    )
+    .unwrap();
+
+    let send::OffchainTransactions {
+        ark_tx: mut virtual_tx,
+        checkpoint_txs,
+    } = offchain_txs;
+
+    let mut pre_signed_checkpoint = checkpoint_txs[0].clone();
+
+    // --- MuSig2 signing of the virtual TX ---
+    {
+        let (alice_musig_nonce, alice_musig_pub_nonce) = {
+            let session_id = MusigSessionId::new(&mut rng);
+            let extra_rand: [u8; 32] = rng.r#gen();
+            new_musig_nonce_pair(
+                &zkp_secp,
+                session_id,
+                None,
+                None,
+                to_zkp_pk(alice_kp.public_key()),
+                None,
+                Some(extra_rand),
+            )
+            .unwrap()
+        };
+
+        let (bob_musig_nonce, bob_musig_pub_nonce) = {
+            let session_id = MusigSessionId::new(&mut rng);
+            let extra_rand: [u8; 32] = rng.r#gen();
+            new_musig_nonce_pair(
+                &zkp_secp,
+                session_id,
+                None,
+                None,
+                to_zkp_pk(bob_kp.public_key()),
+                None,
+                Some(extra_rand),
+            )
+            .unwrap()
+        };
+
+        let sign_fn =
+            |_: &mut psbt::Input,
+             msg: secp256k1::Message|
+             -> Result<Vec<(schnorr::Signature, XOnlyPublicKey)>, ark_core::Error> {
+                let musig_agg_nonce =
+                    MusigAggNonce::new(&zkp_secp, &[alice_musig_pub_nonce, bob_musig_pub_nonce]);
+                let msg = zkp::Message::from_digest_slice(msg.as_ref())
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let session =
+                    MusigSession::new(&zkp_secp, &musig_key_agg_cache, musig_agg_nonce, msg);
+
+                let alice_zkp_kp =
+                    zkp::Keypair::from_seckey_slice(&zkp_secp, &alice_kp.secret_bytes())
+                        .map_err(ark_core::Error::ad_hoc)?;
+                let alice_sig = session
+                    .partial_sign(
+                        &zkp_secp,
+                        alice_musig_nonce,
+                        &alice_zkp_kp,
+                        &musig_key_agg_cache,
+                    )
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let bob_zkp_kp = zkp::Keypair::from_seckey_slice(&zkp_secp, &bob_kp.secret_bytes())
+                    .map_err(ark_core::Error::ad_hoc)?;
+                let bob_sig = session
+                    .partial_sign(
+                        &zkp_secp,
+                        bob_musig_nonce,
+                        &bob_zkp_kp,
+                        &musig_key_agg_cache,
+                    )
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let sig = session.partial_sig_agg(&[alice_sig, bob_sig]);
+                let sig = schnorr::Signature::from_slice(sig.as_ref())
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                Ok(vec![(sig, shared_pk)])
+            };
+
+        sign_ark_transaction(sign_fn, &mut virtual_tx, 0).unwrap();
+    }
+
+    // --- MuSig2 signing of the checkpoint TX (must be done before submitting) ---
+    {
+        let (alice_musig_nonce, alice_musig_pub_nonce) = {
+            let session_id = MusigSessionId::new(&mut rng);
+            let extra_rand: [u8; 32] = rng.r#gen();
+            new_musig_nonce_pair(
+                &zkp_secp,
+                session_id,
+                None,
+                None,
+                to_zkp_pk(alice_kp.public_key()),
+                None,
+                Some(extra_rand),
+            )
+            .unwrap()
+        };
+
+        let (bob_musig_nonce, bob_musig_pub_nonce) = {
+            let session_id = MusigSessionId::new(&mut rng);
+            let extra_rand: [u8; 32] = rng.r#gen();
+            new_musig_nonce_pair(
+                &zkp_secp,
+                session_id,
+                None,
+                None,
+                to_zkp_pk(bob_kp.public_key()),
+                None,
+                Some(extra_rand),
+            )
+            .unwrap()
+        };
+
+        let sign_fn =
+            |_: &mut psbt::Input,
+             msg: secp256k1::Message|
+             -> Result<Vec<(schnorr::Signature, XOnlyPublicKey)>, ark_core::Error> {
+                let musig_agg_nonce =
+                    MusigAggNonce::new(&zkp_secp, &[alice_musig_pub_nonce, bob_musig_pub_nonce]);
+                let msg = zkp::Message::from_digest_slice(msg.as_ref())
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let session =
+                    MusigSession::new(&zkp_secp, &musig_key_agg_cache, musig_agg_nonce, msg);
+
+                let alice_zkp_kp =
+                    zkp::Keypair::from_seckey_slice(&zkp_secp, &alice_kp.secret_bytes())
+                        .map_err(ark_core::Error::ad_hoc)?;
+                let alice_sig = session
+                    .partial_sign(
+                        &zkp_secp,
+                        alice_musig_nonce,
+                        &alice_zkp_kp,
+                        &musig_key_agg_cache,
+                    )
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let bob_zkp_kp = zkp::Keypair::from_seckey_slice(&zkp_secp, &bob_kp.secret_bytes())
+                    .map_err(ark_core::Error::ad_hoc)?;
+                let bob_sig = session
+                    .partial_sign(
+                        &zkp_secp,
+                        bob_musig_nonce,
+                        &bob_zkp_kp,
+                        &musig_key_agg_cache,
+                    )
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                let sig = session.partial_sig_agg(&[alice_sig, bob_sig]);
+                let sig = schnorr::Signature::from_slice(sig.as_ref())
+                    .map_err(ark_core::Error::ad_hoc)?;
+
+                Ok(vec![(sig, shared_pk)])
+            };
+
+        // For multisig VTXOs we must pre-sign the checkpoint before submitting,
+        // since the "owner" signature requires coordination between both parties.
+        sign_checkpoint_transaction(sign_fn, &mut pre_signed_checkpoint).unwrap();
+    }
+
+    // Submit the signed virtual TX + unsigned checkpoint to the server
+    let virtual_txid = virtual_tx.unsigned_tx.compute_txid();
+
+    let res = grpc_client
+        .submit_offchain_transaction_request(virtual_tx, checkpoint_txs)
+        .await
+        .unwrap();
+
+    // Combine our pre-signed checkpoint with the server's signature
+    pre_signed_checkpoint
+        .combine(res.signed_checkpoint_txs[0].clone())
+        .unwrap();
+
+    // Finalize the offchain transaction
+    grpc_client
+        .finalize_offchain_transaction(virtual_txid, vec![pre_signed_checkpoint])
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    tracing::info!(
+        %virtual_txid,
+        "Cooperatively spent multisig VTXO to Bob's address"
+    );
+
+    // Verify: shared VTXO is spent
+    let request = GetVtxosRequest::new_for_addresses(std::iter::once(shared_vtxo.to_ark_address()));
+    let response = grpc_client.list_vtxos(request).await.unwrap();
+    let vtxo_list = VtxoList::new(alice.server_info.dust, response.vtxos);
+
+    assert_eq!(
+        vtxo_list.spendable_offchain().count(),
+        0,
+        "shared VTXO should be spent"
+    );
+
+    // Verify: Bob's balance increased by the multisig amount
+    let bob_balance_after = {
+        let request =
+            GetVtxosRequest::new_for_addresses(std::iter::once(bob_payout_vtxo.to_ark_address()));
+        let response = grpc_client.list_vtxos(request).await.unwrap();
+        let list = VtxoList::new(alice.server_info.dust, response.vtxos);
+        list.spendable_offchain()
+            .fold(Amount::ZERO, |acc, v| acc + v.amount)
+    };
+
+    assert_eq!(
+        bob_balance_after - bob_balance_before,
+        msig_amount,
+        "Bob's balance should have increased by the multisig amount"
+    );
+
+    tracing::info!(
+        %bob_balance_before,
+        %bob_balance_after,
+        "Bob received funds from multisig VTXO"
+    );
+}
+
+fn to_zkp_pk(pk: secp256k1::PublicKey) -> zkp::PublicKey {
+    zkp::PublicKey::from_slice(&pk.serialize()).expect("valid conversion")
+}
+
+fn from_zkp_xonly(pk: zkp::XOnlyPublicKey) -> XOnlyPublicKey {
+    XOnlyPublicKey::from_slice(&pk.serialize()).expect("valid conversion")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for a 2-of-3 escrow flow with tapscript leaves and cooperative spend signing.
  * Added end-to-end coverage for a 2-of-2 MuSig2 multisig flow including key aggregation, two-phase signing, submission, and post-spend verification.

* **Refactor**
  * Reworked VTXO leaf-depth distribution to change how leaves are allocated across the two deepest depths without altering public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->