### PR TITLE
Update `arkd-wallet-run` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arkd-version: [ 'v0.8.11' ]
+        arkd-version: [ 'v0.9.0' ]
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        arkd-version: [ 'v0.8.11' ]
+        arkd-version: [ 'v0.9.0' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest ]
-        arkd-version: [ 'v0.8.11' ]
+        arkd-version: [ 'v0.9.0' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         arkd-version: [
           'master',
-          'v0.8.11'
+          'v0.9.0'
           # Add more versions as needed
         ]
 

--- a/justfile
+++ b/justfile
@@ -145,8 +145,8 @@ arkd-wallet-run:
 
     set -euxo pipefail
 
-    # Start up pgnbxplorer and nbxplorer
-    docker compose -f $ARKD_DIR/docker-compose.regtest.yml up -d pgnbxplorer nbxplorer
+    # Start up pg and nbxplorer
+    docker compose -f $ARKD_DIR/docker-compose.regtest.yml up -d pg nbxplorer
 
     just _wait-for-docker-log nbxplorer "Now listening on: http://0.0.0.0:32838" 30
 


### PR DESCRIPTION
The container `pgnbxplorer` is now called `pg`.

---

Needed to run against latest master of arkd (v9). No other changes needed, @bonomat!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Swapped one background service for a PostgreSQL service in the deployment setup to align runtime services.
* **Tests**
  * Updated CI test matrix to use arkd v0.9.0 across workflows to exercise the newer release in automated suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->