### PR TITLE
fix: strip SSE `data: ` prefix and handle heartbeat/stream_started events in REST client

### DIFF
--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -323,35 +323,44 @@ impl Client {
 
         // Create the SSE event stream
         let stream = stream::unfold(byte_stream, |mut byte_stream| async move {
-            match byte_stream.next().await {
-                Some(chunk_result) => {
-                    let result = match chunk_result {
-                        Ok(bytes) => {
-                            let event = String::from_utf8(bytes.to_vec());
-                            match event {
-                                Ok(event) => {
-                                    if let Ok(response) =
-                                        serde_json::from_str::<models::GetEventStreamResponse>(
-                                            &event,
-                                        )
-                                    {
-                                        match StreamEvent::try_from(response) {
-                                            Ok(stream_event) => Ok(stream_event),
-                                            Err(e) => Err(Error::conversion(e)),
+            loop {
+                match byte_stream.next().await {
+                    Some(chunk_result) => {
+                        let result = match chunk_result {
+                            Ok(bytes) => {
+                                let event = String::from_utf8(bytes.to_vec());
+                                match event {
+                                    Ok(event) => {
+                                        let event = event.trim();
+                                        // Skip empty lines and SSE comments
+                                        if event.is_empty() || event.starts_with(':') {
+                                            continue;
                                         }
-                                    } else {
-                                        // Handle parse error
-                                        Err(Error::conversion("Failed to parse JSON"))
+                                        // Strip SSE `data: ` prefix
+                                        let event = event.strip_prefix("data: ").unwrap_or(event);
+                                        if let Ok(response) =
+                                            serde_json::from_str::<models::GetEventStreamResponse>(
+                                                event,
+                                            )
+                                        {
+                                            match StreamEvent::try_from(response) {
+                                                Ok(stream_event) => Ok(stream_event),
+                                                Err(e) => Err(Error::conversion(e)),
+                                            }
+                                        } else {
+                                            // Handle parse error
+                                            Err(Error::conversion("Failed to parse JSON"))
+                                        }
                                     }
+                                    Err(error) => Err(Error::conversion(error)),
                                 }
-                                Err(error) => Err(Error::conversion(error)),
                             }
-                        }
-                        Err(e) => Err(Error::request(e)),
-                    };
-                    Some((result, byte_stream))
+                            Err(e) => Err(Error::request(e)),
+                        };
+                        return Some((result, byte_stream));
+                    }
+                    None => return None,
                 }
-                None => None,
             }
         });
 
@@ -546,10 +555,17 @@ impl Client {
                             Ok(bytes) => {
                                 let event = String::from_utf8(bytes.to_vec());
                                 match event {
-                                    Ok(event) if !event.trim().is_empty() => {
+                                    Ok(event) => {
+                                        let event = event.trim();
+                                        // Skip empty lines and SSE comments
+                                        if event.is_empty() || event.starts_with(':') {
+                                            continue;
+                                        }
+                                        // Strip SSE `data: ` prefix
+                                        let event = event.strip_prefix("data: ").unwrap_or(event);
                                         if let Ok(response) =
                                             serde_json::from_str::<models::GetSubscriptionResponse>(
-                                                &event,
+                                                event,
                                             )
                                         {
                                             match SubscriptionResponse::try_from(response) {
@@ -562,12 +578,6 @@ impl Client {
                                             // Handle parse error
                                             Err(Error::conversion("Failed to parse JSON"))
                                         }
-                                    }
-                                    Ok(_) => {
-                                        // Handle empty string case - skip and continue to next
-                                        // iteration
-                                        tracing::trace!("Ignoring empty response");
-                                        continue;
                                     }
                                     Err(error) => Err(Error::conversion(error)),
                                 }

--- a/ark-rest/src/conversions/stream.rs
+++ b/ark-rest/src/conversions/stream.rs
@@ -27,7 +27,13 @@ impl TryFrom<models::GetEventStreamResponse> for StreamEvent {
     type Error = ConversionError;
 
     fn try_from(response: models::GetEventStreamResponse) -> Result<Self, Self::Error> {
-        if let Some(batch_started) = response.batch_started {
+        if response.heartbeat.is_some() {
+            return Ok(StreamEvent::Heartbeat);
+        } else if let Some(stream_started) = response.stream_started {
+            return Ok(StreamEvent::StreamStarted(StreamStartedEvent {
+                id: stream_started.id.unwrap_or_default(),
+            }));
+        } else if let Some(batch_started) = response.batch_started {
             return Ok(StreamEvent::BatchStarted(batch_started.try_into()?));
         } else if let Some(batch_finalization) = response.batch_finalization {
             return Ok(StreamEvent::BatchFinalization(

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -13,7 +13,7 @@ ark-bdk-wallet = { path = "../ark-bdk-wallet" }
 ark-client = { path = "../ark-client", features = ["test-utils"] }
 ark-core = { path = "../ark-core" }
 ark-grpc = { path = "../ark-grpc", features = ["test-utils"] }
-# ark-rest = { path = "../ark-rest" }
+ark-rest = { path = "../ark-rest" }
 async-stream = "0.3"
 bdk_esplora = "0.19.0"
 bdk_wallet = "1.0.0-beta.5"

--- a/e2e-tests/tests/e2e_rest_client_get_info.rs
+++ b/e2e-tests/tests/e2e_rest_client_get_info.rs
@@ -1,30 +1,59 @@
-// use ark_rest::Client;
-// use std::time::Duration;
+#![allow(clippy::unwrap_used)]
 
-// #[tokio::test]
-// #[ignore]
-// async fn can_get_info_from_ark_server() {
-//     let client = Client::new("http://localhost:7070".to_string());
+use ark_rest::Client;
+use futures::StreamExt;
+use std::time::Duration;
 
-//     let mut n_retries = 0;
-//     while n_retries < 5 {
-//         let res = client.get_info().await;
+mod common;
 
-//         match res {
-//             Ok(_) => {
-//                 return;
-//             }
-//             Err(error) => {
-//                 tracing::warn!(?error, "Failed to get info, retrying");
+#[tokio::test]
+#[ignore]
+async fn can_get_info_from_ark_server() {
+    common::init_tracing();
 
-//                 tokio::time::sleep(Duration::from_secs(2)).await;
+    let client = Client::new("http://localhost:7070".to_string());
 
-//                 n_retries += 1;
+    let mut n_retries = 0;
+    while n_retries < 5 {
+        let res = client.get_info().await;
 
-//                 continue;
-//             }
-//         };
-//     }
+        match res {
+            Ok(info) => {
+                tracing::info!(?info, "Got info from ark server");
+                return;
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Failed to get info, retrying");
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                n_retries += 1;
+                continue;
+            }
+        };
+    }
 
-//     panic!("Failed to get info after several retries");
-// }
+    panic!("Failed to get info after several retries");
+}
+
+#[tokio::test]
+#[ignore]
+async fn can_receive_events_from_event_stream() {
+    common::init_tracing();
+
+    let client = Client::new("http://localhost:7070".to_string());
+
+    // First verify the server is reachable.
+    let info = client.get_info().await.unwrap();
+    tracing::info!(?info, "Connected to ark server");
+
+    // Subscribe to the event stream with no topic filters.
+    let mut event_stream = client.get_event_stream(vec![]).await.unwrap();
+
+    // Wait for the first successfully parsed event (typically a heartbeat).
+    let first_event = tokio::time::timeout(Duration::from_secs(65), event_stream.next())
+        .await
+        .expect("timed out waiting for first event from event stream")
+        .expect("event stream ended unexpectedly")
+        .expect("failed to parse event from stream");
+
+    tracing::info!(?first_event, "Received event — SSE parsing works correctly");
+}


### PR DESCRIPTION
The REST client was passing raw SSE frames directly to serde_json, causing all events to fail parsing. Additionally, the StreamEvent conversion was missing handlers for heartbeat and stream_started events.

Fixes #206

I guess we should add an e2e test for the rest client 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of event stream handling with better parsing of server-sent events, including proper handling of whitespace, empty lines, and comment lines.
  * Enhanced message prioritization in event streams to properly handle heartbeat and stream-start notifications.

* **Tests**
  * Enabled end-to-end tests for REST client functionality, including event stream subscription and server info retrieval with retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->