### PR TITLE
feat: Send x-build-version header for every request

### DIFF
--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -69,13 +69,39 @@ use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use std::collections::HashMap;
+use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy)]
+struct VersionInterceptor;
+
+impl tonic::service::Interceptor for VersionInterceptor {
+    fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        req.metadata_mut().insert(
+            "x-build-version",
+            tonic::metadata::MetadataValue::from_static(env!("CARGO_PKG_VERSION")),
+        );
+        Ok(req)
+    }
+}
+
+type InterceptedChannel =
+    tonic::codegen::InterceptedService<tonic::transport::Channel, VersionInterceptor>;
+
+#[derive(Clone)]
 pub struct Client {
     url: String,
-    ark_client: Option<ArkServiceClient<tonic::transport::Channel>>,
-    indexer_client: Option<IndexerServiceClient<tonic::transport::Channel>>,
+    ark_client: Option<ArkServiceClient<InterceptedChannel>>,
+    indexer_client: Option<IndexerServiceClient<InterceptedChannel>>,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("url", &self.url)
+            .field("connected", &self.ark_client.is_some())
+            .finish()
+    }
 }
 
 impl Client {
@@ -88,12 +114,15 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
-        let ark_service_client = ArkServiceClient::connect(self.url.clone())
+        let channel = tonic::transport::Endpoint::from_shared(self.url.clone())
+            .map_err(Error::connect)?
+            .connect()
             .await
             .map_err(Error::connect)?;
-        let indexer_client = IndexerServiceClient::connect(self.url.clone())
-            .await
-            .map_err(Error::connect)?;
+
+        let ark_service_client =
+            ArkServiceClient::with_interceptor(channel.clone(), VersionInterceptor);
+        let indexer_client = IndexerServiceClient::with_interceptor(channel, VersionInterceptor);
 
         self.ark_client = Some(ark_service_client);
         self.indexer_client = Some(indexer_client);
@@ -602,11 +631,11 @@ impl Client {
         Ok(SignedAmount::from_sat(response.fee))
     }
 
-    fn ark_client(&self) -> Result<ArkServiceClient<tonic::transport::Channel>, Error> {
+    fn ark_client(&self) -> Result<ArkServiceClient<InterceptedChannel>, Error> {
         // Cloning an `ArkServiceClient<Channel>` is cheap.
         self.ark_client.clone().ok_or(Error::not_connected())
     }
-    fn indexer_client(&self) -> Result<IndexerServiceClient<tonic::transport::Channel>, Error> {
+    fn indexer_client(&self) -> Result<IndexerServiceClient<InterceptedChannel>, Error> {
         self.indexer_client.clone().ok_or(Error::not_connected())
     }
 }

--- a/ark-grpc/src/error.rs
+++ b/ark-grpc/src/error.rs
@@ -58,6 +58,18 @@ impl Error {
         Error::new(Kind::EventStream).with(source)
     }
 
+    /// Returns `true` if the server rejected the request because the SDK
+    /// version is too old.
+    pub fn is_version_mismatch(&self) -> bool {
+        if let Some(source) = &self.inner.source {
+            if let Some(status) = source.downcast_ref::<tonic::Status>() {
+                return status.code() == tonic::Code::FailedPrecondition
+                    && status.message().contains("BUILD_VERSION_TOO_OLD");
+            }
+        }
+        false
+    }
+
     fn description(&self) -> &str {
         match &self.inner.kind {
             Kind::Connect => "failed to connect to Ark server",
@@ -101,5 +113,43 @@ impl StdError for Error {
             .source
             .as_ref()
             .map(|source| &**source as &(dyn StdError + 'static))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_version_mismatch_true_for_matching_status() {
+        let status = tonic::Status::failed_precondition("BUILD_VERSION_TOO_OLD");
+        let err = Error::request(status);
+        assert!(err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_for_other_failed_precondition() {
+        let status = tonic::Status::failed_precondition("something else");
+        let err = Error::request(status);
+        assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_for_other_code() {
+        let status = tonic::Status::internal("BUILD_VERSION_TOO_OLD");
+        let err = Error::request(status);
+        assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_for_non_tonic_error() {
+        let err = Error::request("some string error");
+        assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_when_no_source() {
+        let err = Error::not_connected();
+        assert!(!err.is_version_mismatch());
     }
 }

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -53,13 +53,24 @@ pub struct ListVtxosResponse {
 }
 
 impl Client {
-    pub fn new(ark_server_url: String) -> Self {
+    pub fn new(ark_server_url: String) -> Result<Self, Error> {
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            "X-Build-Version",
+            reqwest::header::HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+        );
+        let client = reqwest::Client::builder()
+            .default_headers(default_headers)
+            .build()
+            .map_err(Error::request)?;
+
         let configuration = apis::configuration::Configuration {
             base_path: ark_server_url,
+            client,
             ..Default::default()
         };
 
-        Self { configuration }
+        Ok(Self { configuration })
     }
 
     pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {

--- a/ark-rest/src/error.rs
+++ b/ark-rest/src/error.rs
@@ -39,6 +39,15 @@ impl Error {
         Error::new(Kind::Conversion).with(source)
     }
 
+    /// Returns `true` if the server rejected the request because the SDK
+    /// version is too old.
+    pub fn is_version_mismatch(&self) -> bool {
+        if let Some(source) = &self.inner.source {
+            return source.to_string().contains("BUILD_VERSION_TOO_OLD");
+        }
+        false
+    }
+
     fn description(&self) -> &str {
         match &self.inner.kind {
             Kind::Request => "request failed",
@@ -79,5 +88,28 @@ impl StdError for Error {
 impl From<ConversionError> for Error {
     fn from(value: ConversionError) -> Self {
         Error::conversion(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_version_mismatch_true_when_source_contains_marker() {
+        let err = Error::request("BUILD_VERSION_TOO_OLD: upgrade your client");
+        assert!(err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_for_other_errors() {
+        let err = Error::request("connection refused");
+        assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_version_mismatch_false_when_no_source() {
+        let err = Error::new(Kind::Request);
+        assert!(!err.is_version_mismatch());
     }
 }

--- a/ark-rest/tests/wasm.rs
+++ b/ark-rest/tests/wasm.rs
@@ -13,7 +13,7 @@ async fn test_get_info() {
 
     let server_url = "http://localhost:7070".to_string();
 
-    let client = Client::new(server_url);
+    let client = Client::new(server_url).expect("failed to create client");
 
     match client.get_info().await {
         Ok(info) => {
@@ -39,7 +39,7 @@ async fn test_get_offchain_address() {
 
     let server_url = "http://localhost:7070".to_string();
 
-    let client = Client::new(server_url);
+    let client = Client::new(server_url).expect("failed to create client");
 
     let server_info = client
         .get_info()


### PR DESCRIPTION
We are sending x-build-version on every request and fail if the sdk version is too old

resolves #195