### PR TITLE
Add support for Arkade script via the introspector

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,6 +12,11 @@ ARKD_DIR=${ARK_GO_DIR}/arkd
 # Alternatively, you can point to a different checkout of arkd:
 # ARKD_DIR=/path/to/arkd-repo
 
+# Optional dedicated checkout for the introspector repo used by
+# `just introspector-checkout <tag>`.
+INTROSPECTOR_GO_DIR=./introspector-go
+INTROSPECTOR_DIR=${INTROSPECTOR_GO_DIR}/introspector
+
 # Environment variables forwarded to arkd when setting up local
 # development environment.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}
-      introspector-version: latest
+      introspector-version: master
 
   wasm_ubuntu:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}
+      introspector-version: latest
 
   wasm_ubuntu:
     strategy:

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version of arkd to test against (git tag, version, hash)'
         required: true
         type: string
+      introspector-version:
+        description: 'Introspector image tag to test against'
+        required: false
+        default: 'latest'
+        type: string
 
 env:
   CARGO_INCREMENTAL: 0
@@ -125,11 +130,23 @@ jobs:
           # Wait for arkd to catch up with the chain
           sleep 10
 
+      - name: Run introspector
+        if: contains(matrix.test-binary, 'e2e_arkade_script')
+        env:
+          INTROSPECTOR_IMAGE: ghcr.io/arklabshq/introspector:${{ inputs.introspector-version }}
+        run: just introspector-docker-run
+
       - name: Run Test Binary
+        env:
+          INTROSPECTOR_URL: http://127.0.0.1:7073
         run: |
           test_name=$(basename ${{ matrix.test-binary }})
           echo "Running test: $test_name"
           ${{ matrix.test-binary }} --ignored --test-threads=1 --nocapture
+
+      - name: Cleanup introspector
+        if: always() && contains(matrix.test-binary, 'e2e_arkade_script')
+        run: just introspector-docker-kill
 
       - name: Cleanup Nigiri
         if: always()
@@ -155,4 +172,16 @@ jobs:
             echo "=== End of arkd.log ==="
           else
             echo "arkd.log file not found"
+          fi
+
+      - name: Print introspector logs on failure
+        if: failure() && contains(matrix.test-binary, 'e2e_arkade_script')
+        run: |
+          if [ -f introspector.log ]; then
+            echo "=== introspector.log contents ==="
+            cat introspector.log
+            echo "=== End of introspector.log ==="
+          else
+            echo "introspector.log file not found"
+            docker logs introspector || true
           fi

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: string
       introspector-version:
-        description: 'Introspector image tag to test against'
+        description: 'Version of introspector to test against (git tag, version, hash)'
         required: false
-        default: 'latest'
+        default: 'master'
         type: string
 
 env:
@@ -18,6 +18,8 @@ env:
   CARGO_TERM_COLOR: always
   ARK_GO_DIR: ./ark-go/
   ARKD_DIR: ./ark-go/arkd/
+  INTROSPECTOR_GO_DIR: ./introspector-go/
+  INTROSPECTOR_DIR: ./introspector-go/introspector/
   ARKD_LIVE_STORE_TYPE: inmemory
   ARKD_DB_TYPE: sqlite
   ARKD_EVENT_DB_TYPE: badger
@@ -130,10 +132,16 @@ jobs:
           # Wait for arkd to catch up with the chain
           sleep 10
 
+      - name: Checkout introspector `${{ inputs.introspector-version }}`
+        if: contains(matrix.test-binary, 'e2e_arkade_script')
+        run: just introspector-checkout ${{ inputs.introspector-version }}
+
+      - name: Build introspector docker image
+        if: contains(matrix.test-binary, 'e2e_arkade_script')
+        run: just introspector-docker-build
+
       - name: Run introspector
         if: contains(matrix.test-binary, 'e2e_arkade_script')
-        env:
-          INTROSPECTOR_IMAGE: ghcr.io/arklabshq/introspector:${{ inputs.introspector-version }}
         run: just introspector-docker-run
 
       - name: Run Test Binary

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,3 +19,4 @@ jobs:
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}
+      introspector-version: latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,4 +19,4 @@ jobs:
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}
-      introspector-version: latest
+      introspector-version: master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "ark-rest",
   "ark-bdk-wallet",
   "ark-script",
+  "ark-introspector-client",
   "e2e-tests",
   "ark-client-sample",
   "ark-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "ark-grpc",
   "ark-rest",
   "ark-bdk-wallet",
+  "ark-script",
   "e2e-tests",
   "ark-client-sample",
   "ark-rs",

--- a/ark-core/src/asset/packet.rs
+++ b/ark-core/src/asset/packet.rs
@@ -174,7 +174,9 @@ fn encode_metadata(buf: &mut Vec<u8>, metadata: &[(String, String)]) {
 /// the asset packet output before it.
 pub fn add_asset_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) -> Result<(), Error> {
     if packet.groups.is_empty() {
-        return Ok(());
+        return Err(Error::ad_hoc(
+            "asset packet must contain at least one group",
+        ));
     }
 
     crate::extension::add_packet_to_psbt(psbt, ASSET_PACKET_TYPE, &packet.encode())

--- a/ark-core/src/asset/packet.rs
+++ b/ark-core/src/asset/packet.rs
@@ -4,11 +4,8 @@
 //! The packet is embedded in a Bitcoin transaction via an OP_RETURN output.
 
 use crate::asset::AssetId;
-use bitcoin::ScriptBuf;
+use crate::Error;
 use bitcoin::TxOut;
-
-/// Magic bytes prefix: "ARK" (0x41524b).
-const MAGIC_BYTES: [u8; 3] = [0x41, 0x52, 0x4b];
 
 /// TLV type byte for the asset packet.
 const ASSET_PACKET_TYPE: u8 = 0x00;
@@ -39,27 +36,7 @@ impl Packet {
 
     /// Wrap this packet into an OP_RETURN TxOut with the ARK magic bytes and TLV envelope.
     pub fn to_txout(&self) -> TxOut {
-        let payload = self.encode();
-
-        let mut script_data = Vec::new();
-        // Magic bytes
-        script_data.extend_from_slice(&MAGIC_BYTES);
-        // TLV: Type
-        script_data.push(ASSET_PACKET_TYPE);
-        // TLV: Length (uvarint)
-        encode_uvarint(&mut script_data, payload.len() as u64);
-        // TLV: Value
-        script_data.extend_from_slice(&payload);
-
-        // Build OP_RETURN script
-        let mut script_bytes = Vec::new();
-        script_bytes.push(0x6a); // OP_RETURN
-        push_data(&mut script_bytes, &script_data);
-
-        TxOut {
-            value: bitcoin::Amount::ZERO,
-            script_pubkey: ScriptBuf::from_bytes(script_bytes),
-        }
+        crate::extension::packet_txout(ASSET_PACKET_TYPE, &self.encode())
     }
 }
 
@@ -191,49 +168,19 @@ fn encode_metadata(buf: &mut Vec<u8>, metadata: &[(String, String)]) {
     }
 }
 
-/// Push data onto a script with proper OP_PUSH prefix.
-fn push_data(script: &mut Vec<u8>, data: &[u8]) {
-    let len = data.len();
-    if len <= 75 {
-        script.push(len as u8);
-    } else if len <= 0xff {
-        script.push(0x4c); // OP_PUSHDATA1
-        script.push(len as u8);
-    } else if len <= 0xffff {
-        script.push(0x4d); // OP_PUSHDATA2
-        script.extend_from_slice(&(len as u16).to_le_bytes());
-    } else {
-        script.push(0x4e); // OP_PUSHDATA4
-        script.extend_from_slice(&(len as u32).to_le_bytes());
-    }
-    script.extend_from_slice(data);
-}
-
 /// Helper to add an asset packet as an OP_RETURN output to an existing PSBT.
 ///
 /// The P2A (anchor) output must remain the last output. This function inserts
 /// the asset packet output before it.
-pub fn add_asset_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) {
+pub fn add_asset_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) -> Result<(), Error> {
     if packet.groups.is_empty() {
-        return;
+        return Ok(());
     }
 
-    let op_return_txout = packet.to_txout();
+    crate::extension::add_packet_to_psbt(psbt, ASSET_PACKET_TYPE, &packet.encode())
+        .map_err(Error::ad_hoc)?;
 
-    let num_outputs = psbt.unsigned_tx.output.len();
-
-    // TODO: Is this actually possible?
-    if num_outputs == 0 {
-        psbt.unsigned_tx.output.push(op_return_txout);
-        psbt.outputs.push(bitcoin::psbt::Output::default());
-        return;
-    }
-
-    // Insert before the last output (P2A anchor).
-    let last_idx = num_outputs - 1;
-    psbt.unsigned_tx.output.insert(last_idx, op_return_txout);
-    psbt.outputs
-        .insert(last_idx, bitcoin::psbt::Output::default());
+    Ok(())
 }
 
 /// Encode a uvarint (LEB128 unsigned variable-length integer).
@@ -364,7 +311,10 @@ mod tests {
         // After push byte, should have ARK magic
         // push_len byte, then 0x41 0x52 0x4b
         let data_start = 2; // 0x6a + push_len
-        assert_eq!(&script_bytes[data_start..data_start + 3], &MAGIC_BYTES);
+        assert_eq!(
+            &script_bytes[data_start..data_start + 3],
+            &crate::extension::MAGIC_BYTES
+        );
     }
 
     #[test]

--- a/ark-core/src/extension.rs
+++ b/ark-core/src/extension.rs
@@ -1,0 +1,242 @@
+use bitcoin::opcodes::all::OP_RETURN;
+use bitcoin::script::Instruction;
+use bitcoin::Amount;
+use bitcoin::Script;
+use bitcoin::ScriptBuf;
+use bitcoin::TxOut;
+
+pub const MAGIC_BYTES: [u8; 3] = [0x41, 0x52, 0x4b];
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionError {
+    #[error("extension payload length overflows")]
+    PayloadLengthOverflow,
+    #[error("truncated extension packet type")]
+    TruncatedPacketType,
+    #[error("truncated extension packet length")]
+    TruncatedPacketLength,
+    #[error("truncated extension packet payload, expected {expected} bytes got {got}")]
+    TruncatedPacketPayload { expected: usize, got: usize },
+    #[error("duplicate extension packet type {0}")]
+    DuplicatePacketType(u8),
+}
+
+pub fn encode_uvarint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn decode_uvarint(data: &[u8], offset: &mut usize) -> Result<u64, ExtensionError> {
+    let mut value = 0_u64;
+    for shift in (0..64).step_by(7) {
+        let Some(byte) = data.get(*offset) else {
+            return Err(ExtensionError::TruncatedPacketLength);
+        };
+        *offset += 1;
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(ExtensionError::PayloadLengthOverflow)
+}
+
+pub fn is_extension(script: &Script) -> bool {
+    extension_payload(script).is_some()
+}
+
+pub fn extension_payload(script: &Script) -> Option<&[u8]> {
+    let mut instructions = script.instructions();
+    if !matches!(instructions.next(), Some(Ok(Instruction::Op(OP_RETURN)))) {
+        return None;
+    }
+    let Some(Ok(Instruction::PushBytes(bytes))) = instructions.next() else {
+        return None;
+    };
+    let bytes = bytes.as_bytes();
+    (bytes.len() >= MAGIC_BYTES.len() && bytes[..MAGIC_BYTES.len()] == MAGIC_BYTES).then_some(bytes)
+}
+
+pub fn iter_packets(payload: &[u8]) -> Result<Vec<(u8, &[u8])>, ExtensionError> {
+    let mut packets = Vec::new();
+    let mut offset = MAGIC_BYTES.len();
+
+    while offset < payload.len() {
+        let Some(packet_type) = payload.get(offset).copied() else {
+            return Err(ExtensionError::TruncatedPacketType);
+        };
+        offset += 1;
+
+        let packet_len = decode_uvarint(payload, &mut offset)? as usize;
+        let end = offset
+            .checked_add(packet_len)
+            .ok_or(ExtensionError::PayloadLengthOverflow)?;
+        if end > payload.len() {
+            return Err(ExtensionError::TruncatedPacketPayload {
+                expected: end,
+                got: payload.len(),
+            });
+        }
+
+        packets.push((packet_type, &payload[offset..end]));
+        offset = end;
+    }
+
+    Ok(packets)
+}
+
+pub fn find_packet_payload(
+    tx: &bitcoin::Transaction,
+    packet_type: u8,
+) -> Result<Option<&[u8]>, ExtensionError> {
+    for output in &tx.output {
+        let Some(payload) = extension_payload(&output.script_pubkey) else {
+            continue;
+        };
+        for (current_type, current_payload) in iter_packets(payload)? {
+            if current_type == packet_type {
+                return Ok(Some(current_payload));
+            }
+        }
+        return Ok(None);
+    }
+
+    Ok(None)
+}
+
+pub fn packet_txout(packet_type: u8, packet_payload: &[u8]) -> TxOut {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&MAGIC_BYTES);
+    push_packet(&mut payload, packet_type, packet_payload);
+
+    TxOut {
+        value: Amount::ZERO,
+        script_pubkey: op_return_script(&payload),
+    }
+}
+
+pub fn add_packet_to_psbt(
+    psbt: &mut bitcoin::Psbt,
+    packet_type: u8,
+    packet_payload: &[u8],
+) -> Result<(), ExtensionError> {
+    let mut encoded_packet = Vec::new();
+    push_packet(&mut encoded_packet, packet_type, packet_payload);
+
+    for output in &mut psbt.unsigned_tx.output {
+        let Some(existing_payload) = extension_payload(&output.script_pubkey) else {
+            continue;
+        };
+
+        for (existing_type, _) in iter_packets(existing_payload)? {
+            if existing_type == packet_type {
+                return Err(ExtensionError::DuplicatePacketType(packet_type));
+            }
+        }
+
+        let mut payload = existing_payload.to_vec();
+        payload.extend_from_slice(&encoded_packet);
+        output.script_pubkey = op_return_script(&payload);
+        return Ok(());
+    }
+
+    let txout = packet_txout(packet_type, packet_payload);
+    let len = psbt.unsigned_tx.output.len();
+
+    if len == 0 {
+        psbt.unsigned_tx.output.push(txout);
+        psbt.outputs.push(bitcoin::psbt::Output::default());
+        return Ok(());
+    }
+
+    let anchor_index = len - 1;
+    psbt.unsigned_tx.output.insert(anchor_index, txout);
+    psbt.outputs
+        .insert(anchor_index, bitcoin::psbt::Output::default());
+    Ok(())
+}
+
+fn push_packet(payload: &mut Vec<u8>, packet_type: u8, packet_payload: &[u8]) {
+    payload.push(packet_type);
+    encode_uvarint(payload, packet_payload.len() as u64);
+    payload.extend_from_slice(packet_payload);
+}
+
+fn op_return_script(data: &[u8]) -> ScriptBuf {
+    let mut script = Vec::new();
+    script.push(OP_RETURN.to_u8());
+    push_data(&mut script, data);
+    ScriptBuf::from_bytes(script)
+}
+
+fn push_data(script: &mut Vec<u8>, data: &[u8]) {
+    let len = data.len();
+    if len <= 75 {
+        script.push(len as u8);
+    } else if len <= 0xff {
+        script.push(0x4c);
+        script.push(len as u8);
+    } else if len <= 0xffff {
+        script.push(0x4d);
+        script.extend_from_slice(&(len as u16).to_le_bytes());
+    } else {
+        script.push(0x4e);
+        script.extend_from_slice(&(len as u32).to_le_bytes());
+    }
+    script.extend_from_slice(data);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::absolute;
+    use bitcoin::transaction;
+    use bitcoin::TxIn;
+
+    #[test]
+    fn encodes_go_uvarint_packet_lengths() {
+        let txout = packet_txout(0x01, &[0; 136]);
+        let payload = extension_payload(&txout.script_pubkey).unwrap();
+        assert_eq!(&payload[..5], &[0x41, 0x52, 0x4b, 0x01, 0x88]);
+        assert_eq!(payload[5], 0x01);
+    }
+
+    #[test]
+    fn appends_to_existing_extension_output() {
+        let mut psbt = bitcoin::Psbt::from_unsigned_tx(bitcoin::Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: packet_txout(0x00, &[0xaa]).script_pubkey,
+                },
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: ScriptBuf::new(),
+                },
+            ],
+        })
+        .unwrap();
+
+        add_packet_to_psbt(&mut psbt, 0x01, &[0xbb, 0xcc]).unwrap();
+
+        assert_eq!(psbt.unsigned_tx.output.len(), 2);
+        let payload = extension_payload(&psbt.unsigned_tx.output[0].script_pubkey).unwrap();
+        let packets = iter_packets(payload).unwrap();
+        assert_eq!(
+            packets,
+            vec![(0x00, &[0xaa][..]), (0x01, &[0xbb, 0xcc][..])]
+        );
+    }
+}

--- a/ark-core/src/introspector.rs
+++ b/ark-core/src/introspector.rs
@@ -1,0 +1,1 @@
+pub mod packet;

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -229,6 +229,12 @@ impl Packet {
     }
 }
 
+/// Add an introspector packet OP_RETURN output to a PSBT.
+///
+/// If the PSBT already has outputs, this inserts the packet before the last
+/// output. Arkade transactions are expected to keep the anchor output last, so
+/// callers must only use this helper with PSBTs that either have no outputs or
+/// whose final output is the anchor.
 pub fn add_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) -> Result<(), PacketError> {
     let txout = packet.to_txout()?;
     let len = psbt.unsigned_tx.output.len();

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -53,6 +53,10 @@ pub enum PacketError {
     Decode(encode::Error),
     #[error("failed to read packet: {0}")]
     Read(std::io::Error),
+    #[error("introspector payload length overflows")]
+    PayloadLengthOverflow,
+    #[error("truncated introspector payload, expected {expected} bytes got {got}")]
+    TruncatedPayload { expected: usize, got: usize },
     #[error("unexpected {0} trailing bytes")]
     TrailingBytes(usize),
     #[error("failed to build OP_RETURN script: {0}")]
@@ -263,10 +267,19 @@ pub fn find_packet(tx: &Transaction) -> Result<Option<Packet>, PacketError> {
             .map_err(PacketError::Decode)?
             .0 as usize;
         let offset = 4 + reader.position() as usize;
-        if bytes.len() < offset + payload_len {
-            return Err(PacketError::TrailingBytes(0));
+        let end = offset
+            .checked_add(payload_len)
+            .ok_or(PacketError::PayloadLengthOverflow)?;
+        if bytes.len() < end {
+            return Err(PacketError::TruncatedPayload {
+                expected: end,
+                got: bytes.len(),
+            });
         }
-        return Packet::decode(&bytes[offset..offset + payload_len]).map(Some);
+        if bytes.len() > end {
+            return Err(PacketError::TrailingBytes(bytes.len() - end));
+        }
+        return Packet::decode(&bytes[offset..end]).map(Some);
     }
 
     Ok(None)
@@ -288,6 +301,22 @@ mod tests {
                 .map(|item| Vec::from_hex(item).unwrap())
                 .collect::<Vec<_>>(),
         )
+    }
+
+    fn tx_with_op_return_payload(payload: Vec<u8>) -> Transaction {
+        let push_bytes = PushBytesBuf::try_from(payload).unwrap();
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::ZERO,
+                script_pubkey: ScriptBuf::builder()
+                    .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+                    .push_slice(push_bytes)
+                    .into_script(),
+            }],
+        }
     }
 
     #[test]
@@ -343,6 +372,30 @@ mod tests {
         assert!(matches!(
             Packet::decode(&Vec::from_hex("01000001510200ff").unwrap()),
             Err(PacketError::TrailingBytes(1))
+        ));
+    }
+
+    #[test]
+    fn find_packet_rejects_invalid_payload_lengths() {
+        let tx = tx_with_op_return_payload(Vec::from_hex("41524b010200").unwrap());
+        assert!(matches!(
+            find_packet(&tx),
+            Err(PacketError::TruncatedPayload {
+                expected: 7,
+                got: 6,
+            })
+        ));
+
+        let tx = tx_with_op_return_payload(Vec::from_hex("41524b010100ff").unwrap());
+        assert!(matches!(
+            find_packet(&tx),
+            Err(PacketError::TrailingBytes(1))
+        ));
+
+        let tx = tx_with_op_return_payload(Vec::from_hex("41524b01ffffffffffffffffff").unwrap());
+        assert!(matches!(
+            find_packet(&tx),
+            Err(PacketError::PayloadLengthOverflow)
         ));
     }
 

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -70,6 +70,7 @@ impl Packet {
         if self.entries.is_empty() {
             return Err(PacketError::EmptyPacket);
         }
+
         if self.entries.len() > MAX_ENTRY_COUNT {
             return Err(PacketError::EntryCountExceeded {
                 max: MAX_ENTRY_COUNT,
@@ -82,6 +83,15 @@ impl Packet {
             if entry.script.is_empty() {
                 return Err(PacketError::EmptyScript(index));
             }
+
+            let script_len = entry.script.as_bytes().len();
+            if script_len > MAX_SCRIPT_LENGTH {
+                return Err(PacketError::ScriptLengthExceeded {
+                    max: MAX_SCRIPT_LENGTH,
+                    got: script_len,
+                });
+            }
+
             if !seen.insert(entry.vin) {
                 return Err(PacketError::DuplicateVin {
                     vin: entry.vin,

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -1,9 +1,8 @@
+use crate::extension;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
 use bitcoin::consensus::encode::{self};
 use bitcoin::io;
-use bitcoin::script::PushBytesBuf;
-use bitcoin::Amount;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
 use bitcoin::TxOut;
@@ -13,7 +12,6 @@ use std::collections::BTreeSet;
 use std::io::Cursor;
 use std::io::Read;
 
-const MAGIC_BYTES: [u8; 3] = [0x41, 0x52, 0x4b];
 const PACKET_TYPE: u8 = 0x01;
 const MAX_ENTRY_COUNT: usize = 1_000;
 const MAX_SCRIPT_LENGTH: usize = 10_000;
@@ -59,8 +57,8 @@ pub enum PacketError {
     TruncatedPayload { expected: usize, got: usize },
     #[error("unexpected {0} trailing bytes")]
     TrailingBytes(usize),
-    #[error("failed to build OP_RETURN script: {0}")]
-    Script(#[from] bitcoin::script::PushBytesError),
+    #[error("failed to process extension packet: {0}")]
+    Extension(#[from] extension::ExtensionError),
 }
 
 impl Packet {
@@ -207,25 +205,9 @@ impl Packet {
     }
 
     pub fn to_txout(&self) -> Result<TxOut, PacketError> {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&MAGIC_BYTES);
-        payload.push(PACKET_TYPE);
-        let encoded = self.encode()?;
-        VarInt(encoded.len() as u64)
-            .consensus_encode(&mut payload)
-            .map_err(PacketError::Encode)?;
-        payload.extend_from_slice(&encoded);
+        let packet = self.encode()?;
 
-        let push_bytes = PushBytesBuf::try_from(payload)?;
-        let script_pubkey = ScriptBuf::builder()
-            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
-            .push_slice(push_bytes)
-            .into_script();
-
-        Ok(TxOut {
-            value: Amount::ZERO,
-            script_pubkey,
-        })
+        Ok(extension::packet_txout(PACKET_TYPE, &packet))
     }
 }
 
@@ -236,59 +218,19 @@ impl Packet {
 /// callers must only use this helper with PSBTs that either have no outputs or
 /// whose final output is the anchor.
 pub fn add_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) -> Result<(), PacketError> {
-    let txout = packet.to_txout()?;
-    let len = psbt.unsigned_tx.output.len();
+    let packet = packet.encode()?;
 
-    if len == 0 {
-        psbt.unsigned_tx.output.push(txout);
-        psbt.outputs.push(bitcoin::psbt::Output::default());
-        return Ok(());
-    }
+    extension::add_packet_to_psbt(psbt, PACKET_TYPE, &packet)?;
 
-    let anchor_index = len - 1;
-    psbt.unsigned_tx.output.insert(anchor_index, txout);
-    psbt.outputs
-        .insert(anchor_index, bitcoin::psbt::Output::default());
     Ok(())
 }
 
 pub fn find_packet(tx: &Transaction) -> Result<Option<Packet>, PacketError> {
-    for output in &tx.output {
-        let mut instructions = output.script_pubkey.instructions();
-        let Some(Ok(bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_RETURN))) =
-            instructions.next()
-        else {
-            continue;
-        };
-        let Some(Ok(bitcoin::script::Instruction::PushBytes(bytes))) = instructions.next() else {
-            continue;
-        };
-        let bytes = bytes.as_bytes();
-        if bytes.len() < 4 || bytes[..3] != MAGIC_BYTES || bytes[3] != PACKET_TYPE {
-            continue;
-        }
+    let Some(payload) = extension::find_packet_payload(tx, PACKET_TYPE)? else {
+        return Ok(None);
+    };
 
-        let mut reader = Cursor::new(&bytes[4..]);
-        let payload_len = VarInt::consensus_decode(&mut reader)
-            .map_err(PacketError::Decode)?
-            .0 as usize;
-        let offset = 4 + reader.position() as usize;
-        let end = offset
-            .checked_add(payload_len)
-            .ok_or(PacketError::PayloadLengthOverflow)?;
-        if bytes.len() < end {
-            return Err(PacketError::TruncatedPayload {
-                expected: end,
-                got: bytes.len(),
-            });
-        }
-        if bytes.len() > end {
-            return Err(PacketError::TrailingBytes(bytes.len() - end));
-        }
-        return Packet::decode(&bytes[offset..end]).map(Some);
-    }
-
-    Ok(None)
+    Packet::decode(payload).map(Some)
 }
 
 #[cfg(test)]
@@ -297,7 +239,9 @@ mod tests {
     use bitcoin::absolute;
     use bitcoin::hex::DisplayHex;
     use bitcoin::hex::FromHex;
+    use bitcoin::script::PushBytesBuf;
     use bitcoin::transaction;
+    use bitcoin::Amount;
     use bitcoin::TxIn;
 
     fn witness(items: &[&str]) -> Witness {
@@ -382,26 +326,32 @@ mod tests {
     }
 
     #[test]
-    fn find_packet_rejects_invalid_payload_lengths() {
+    fn find_packet_rejects_invalid_extension_payload_lengths() {
         let tx = tx_with_op_return_payload(Vec::from_hex("41524b010200").unwrap());
         assert!(matches!(
             find_packet(&tx),
-            Err(PacketError::TruncatedPayload {
-                expected: 7,
-                got: 6,
-            })
+            Err(PacketError::Extension(
+                extension::ExtensionError::TruncatedPacketPayload {
+                    expected: 7,
+                    got: 6,
+                }
+            ))
         ));
 
         let tx = tx_with_op_return_payload(Vec::from_hex("41524b010100ff").unwrap());
         assert!(matches!(
             find_packet(&tx),
-            Err(PacketError::TrailingBytes(1))
+            Err(PacketError::Extension(
+                extension::ExtensionError::TruncatedPacketLength
+            ))
         ));
 
         let tx = tx_with_op_return_payload(Vec::from_hex("41524b01ffffffffffffffffff").unwrap());
         assert!(matches!(
             find_packet(&tx),
-            Err(PacketError::PayloadLengthOverflow)
+            Err(PacketError::Extension(
+                extension::ExtensionError::TruncatedPacketLength
+            ))
         ));
     }
 

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -180,8 +180,12 @@ impl Packet {
             reader
                 .read_exact(&mut witness_bytes)
                 .map_err(PacketError::Read)?;
-            let witness = Witness::consensus_decode(&mut witness_bytes.as_slice())
+            let mut witness_reader = witness_bytes.as_slice();
+            let witness = Witness::consensus_decode(&mut witness_reader)
                 .map_err(PacketError::WitnessDecode)?;
+            if !witness_reader.is_empty() {
+                return Err(PacketError::TrailingBytes(witness_reader.len()));
+            }
 
             entries.push(IntrospectorEntry {
                 vin,
@@ -335,6 +339,10 @@ mod tests {
         assert!(matches!(
             Packet::decode(&Vec::from_hex("010000fd1127").unwrap()),
             Err(PacketError::ScriptLengthExceeded { .. })
+        ));
+        assert!(matches!(
+            Packet::decode(&Vec::from_hex("01000001510200ff").unwrap()),
+            Err(PacketError::TrailingBytes(1))
         ));
     }
 

--- a/ark-core/src/introspector/packet.rs
+++ b/ark-core/src/introspector/packet.rs
@@ -1,0 +1,385 @@
+use bitcoin::consensus::encode::Decodable;
+use bitcoin::consensus::encode::Encodable;
+use bitcoin::consensus::encode::{self};
+use bitcoin::io;
+use bitcoin::script::PushBytesBuf;
+use bitcoin::Amount;
+use bitcoin::ScriptBuf;
+use bitcoin::Transaction;
+use bitcoin::TxOut;
+use bitcoin::VarInt;
+use bitcoin::Witness;
+use std::collections::BTreeSet;
+use std::io::Cursor;
+use std::io::Read;
+
+const MAGIC_BYTES: [u8; 3] = [0x41, 0x52, 0x4b];
+const PACKET_TYPE: u8 = 0x01;
+const MAX_ENTRY_COUNT: usize = 1_000;
+const MAX_SCRIPT_LENGTH: usize = 10_000;
+const MAX_WITNESS_LENGTH: usize = 1_000_000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntrospectorEntry {
+    pub vin: u16,
+    pub script: ScriptBuf,
+    pub witness: Witness,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Packet {
+    pub entries: Vec<IntrospectorEntry>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PacketError {
+    #[error("empty packet")]
+    EmptyPacket,
+    #[error("max introspector entry count exceeded, max={max} got={got}")]
+    EntryCountExceeded { max: usize, got: usize },
+    #[error("empty script at entry {0}")]
+    EmptyScript(usize),
+    #[error("duplicate vin {vin} at entry {entry}")]
+    DuplicateVin { vin: u16, entry: usize },
+    #[error("max introspector script length exceeded, max={max} got={got}")]
+    ScriptLengthExceeded { max: usize, got: usize },
+    #[error("max introspector witness length exceeded, max={max} got={got}")]
+    WitnessLengthExceeded { max: usize, got: usize },
+    #[error("failed to encode packet: {0}")]
+    Encode(io::Error),
+    #[error("failed to decode witness: {0}")]
+    WitnessDecode(encode::Error),
+    #[error("failed to decode packet: {0}")]
+    Decode(encode::Error),
+    #[error("failed to read packet: {0}")]
+    Read(std::io::Error),
+    #[error("unexpected {0} trailing bytes")]
+    TrailingBytes(usize),
+    #[error("failed to build OP_RETURN script: {0}")]
+    Script(#[from] bitcoin::script::PushBytesError),
+}
+
+impl Packet {
+    pub fn new(entries: Vec<IntrospectorEntry>) -> Result<Self, PacketError> {
+        let packet = Self { entries };
+        packet.validate()?;
+        Ok(packet)
+    }
+
+    pub fn validate(&self) -> Result<(), PacketError> {
+        if self.entries.is_empty() {
+            return Err(PacketError::EmptyPacket);
+        }
+        if self.entries.len() > MAX_ENTRY_COUNT {
+            return Err(PacketError::EntryCountExceeded {
+                max: MAX_ENTRY_COUNT,
+                got: self.entries.len(),
+            });
+        }
+
+        let mut seen = BTreeSet::new();
+        for (index, entry) in self.entries.iter().enumerate() {
+            if entry.script.is_empty() {
+                return Err(PacketError::EmptyScript(index));
+            }
+            if !seen.insert(entry.vin) {
+                return Err(PacketError::DuplicateVin {
+                    vin: entry.vin,
+                    entry: index,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, PacketError> {
+        self.validate()?;
+
+        let mut bytes = Vec::new();
+        VarInt(self.entries.len() as u64)
+            .consensus_encode(&mut bytes)
+            .map_err(PacketError::Encode)?;
+
+        for entry in &self.entries {
+            bytes.extend_from_slice(&entry.vin.to_le_bytes());
+
+            let script = entry.script.as_bytes();
+            VarInt(script.len() as u64)
+                .consensus_encode(&mut bytes)
+                .map_err(PacketError::Encode)?;
+            bytes.extend_from_slice(script);
+
+            let witness = encode::serialize(&entry.witness);
+            if witness.len() > MAX_WITNESS_LENGTH {
+                return Err(PacketError::WitnessLengthExceeded {
+                    max: MAX_WITNESS_LENGTH,
+                    got: witness.len(),
+                });
+            }
+            VarInt(witness.len() as u64)
+                .consensus_encode(&mut bytes)
+                .map_err(PacketError::Encode)?;
+            bytes.extend_from_slice(&witness);
+        }
+
+        Ok(bytes)
+    }
+
+    pub fn decode(data: &[u8]) -> Result<Self, PacketError> {
+        let mut reader = Cursor::new(data);
+        let entry_count = VarInt::consensus_decode(&mut reader)
+            .map_err(PacketError::Decode)?
+            .0 as usize;
+
+        if entry_count > MAX_ENTRY_COUNT {
+            return Err(PacketError::EntryCountExceeded {
+                max: MAX_ENTRY_COUNT,
+                got: entry_count,
+            });
+        }
+
+        let mut entries = Vec::with_capacity(entry_count);
+        for _ in 0..entry_count {
+            let mut vin = [0_u8; 2];
+            reader.read_exact(&mut vin).map_err(PacketError::Read)?;
+            let vin = u16::from_le_bytes(vin);
+
+            let script_len = VarInt::consensus_decode(&mut reader)
+                .map_err(PacketError::Decode)?
+                .0 as usize;
+            if script_len > MAX_SCRIPT_LENGTH {
+                return Err(PacketError::ScriptLengthExceeded {
+                    max: MAX_SCRIPT_LENGTH,
+                    got: script_len,
+                });
+            }
+            let mut script = vec![0_u8; script_len];
+            reader.read_exact(&mut script).map_err(PacketError::Read)?;
+
+            let witness_len = VarInt::consensus_decode(&mut reader)
+                .map_err(PacketError::Decode)?
+                .0 as usize;
+            if witness_len > MAX_WITNESS_LENGTH {
+                return Err(PacketError::WitnessLengthExceeded {
+                    max: MAX_WITNESS_LENGTH,
+                    got: witness_len,
+                });
+            }
+            let mut witness_bytes = vec![0_u8; witness_len];
+            reader
+                .read_exact(&mut witness_bytes)
+                .map_err(PacketError::Read)?;
+            let witness = Witness::consensus_decode(&mut witness_bytes.as_slice())
+                .map_err(PacketError::WitnessDecode)?;
+
+            entries.push(IntrospectorEntry {
+                vin,
+                script: ScriptBuf::from_bytes(script),
+                witness,
+            });
+        }
+
+        let remaining = data.len() - reader.position() as usize;
+        if remaining != 0 {
+            return Err(PacketError::TrailingBytes(remaining));
+        }
+
+        Self::new(entries)
+    }
+
+    pub fn to_txout(&self) -> Result<TxOut, PacketError> {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&MAGIC_BYTES);
+        payload.push(PACKET_TYPE);
+        let encoded = self.encode()?;
+        VarInt(encoded.len() as u64)
+            .consensus_encode(&mut payload)
+            .map_err(PacketError::Encode)?;
+        payload.extend_from_slice(&encoded);
+
+        let push_bytes = PushBytesBuf::try_from(payload)?;
+        let script_pubkey = ScriptBuf::builder()
+            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+            .push_slice(push_bytes)
+            .into_script();
+
+        Ok(TxOut {
+            value: Amount::ZERO,
+            script_pubkey,
+        })
+    }
+}
+
+pub fn add_packet_to_psbt(psbt: &mut bitcoin::Psbt, packet: &Packet) -> Result<(), PacketError> {
+    let txout = packet.to_txout()?;
+    let len = psbt.unsigned_tx.output.len();
+
+    if len == 0 {
+        psbt.unsigned_tx.output.push(txout);
+        psbt.outputs.push(bitcoin::psbt::Output::default());
+        return Ok(());
+    }
+
+    let anchor_index = len - 1;
+    psbt.unsigned_tx.output.insert(anchor_index, txout);
+    psbt.outputs
+        .insert(anchor_index, bitcoin::psbt::Output::default());
+    Ok(())
+}
+
+pub fn find_packet(tx: &Transaction) -> Result<Option<Packet>, PacketError> {
+    for output in &tx.output {
+        let mut instructions = output.script_pubkey.instructions();
+        let Some(Ok(bitcoin::script::Instruction::Op(bitcoin::opcodes::all::OP_RETURN))) =
+            instructions.next()
+        else {
+            continue;
+        };
+        let Some(Ok(bitcoin::script::Instruction::PushBytes(bytes))) = instructions.next() else {
+            continue;
+        };
+        let bytes = bytes.as_bytes();
+        if bytes.len() < 4 || bytes[..3] != MAGIC_BYTES || bytes[3] != PACKET_TYPE {
+            continue;
+        }
+
+        let mut reader = Cursor::new(&bytes[4..]);
+        let payload_len = VarInt::consensus_decode(&mut reader)
+            .map_err(PacketError::Decode)?
+            .0 as usize;
+        let offset = 4 + reader.position() as usize;
+        if bytes.len() < offset + payload_len {
+            return Err(PacketError::TrailingBytes(0));
+        }
+        return Packet::decode(&bytes[offset..offset + payload_len]).map(Some);
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::absolute;
+    use bitcoin::hex::DisplayHex;
+    use bitcoin::hex::FromHex;
+    use bitcoin::transaction;
+    use bitcoin::TxIn;
+
+    fn witness(items: &[&str]) -> Witness {
+        Witness::from_slice(
+            &items
+                .iter()
+                .map(|item| Vec::from_hex(item).unwrap())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn matches_go_vectors() {
+        let packet = Packet::new(vec![IntrospectorEntry {
+            vin: 0,
+            script: ScriptBuf::from_bytes(Vec::from_hex("010203").unwrap()),
+            witness: witness(&["0405"]),
+        }])
+        .unwrap();
+
+        assert_eq!(
+            packet.encode().unwrap().to_lower_hex_string(),
+            "010000030102030401020405"
+        );
+
+        let packet = Packet::new(vec![
+            IntrospectorEntry {
+                vin: 0,
+                script: ScriptBuf::from_bytes(Vec::from_hex("01").unwrap()),
+                witness: witness(&["02"]),
+            },
+            IntrospectorEntry {
+                vin: 1,
+                script: ScriptBuf::from_bytes(Vec::from_hex("0304").unwrap()),
+                witness: witness(&["05", "06"]),
+            },
+            IntrospectorEntry {
+                vin: 5,
+                script: ScriptBuf::from_bytes(Vec::from_hex("07").unwrap()),
+                witness: Witness::default(),
+            },
+        ])
+        .unwrap();
+
+        assert_eq!(
+            packet.encode().unwrap().to_lower_hex_string(),
+            "0300000101030101020100020304050201050106050001070100"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_invalid_packets() {
+        assert!(matches!(Packet::new(vec![]), Err(PacketError::EmptyPacket)));
+        assert!(matches!(
+            Packet::decode(&Vec::from_hex("0000000101ff").unwrap()),
+            Err(PacketError::TrailingBytes(5))
+        ));
+        assert!(matches!(
+            Packet::decode(&Vec::from_hex("010000fd1127").unwrap()),
+            Err(PacketError::ScriptLengthExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn add_and_find_packet() {
+        let packet = Packet::new(vec![IntrospectorEntry {
+            vin: 0,
+            script: ScriptBuf::from_bytes(Vec::from_hex("51").unwrap()),
+            witness: Witness::default(),
+        }])
+        .unwrap();
+
+        let mut psbt = bitcoin::Psbt::from_unsigned_tx(Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: ScriptBuf::new(),
+                },
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: ScriptBuf::new(),
+                },
+            ],
+        })
+        .unwrap();
+
+        add_packet_to_psbt(&mut psbt, &packet).unwrap();
+        assert_eq!(psbt.unsigned_tx.output.len(), 3);
+
+        let found = find_packet(&psbt.unsigned_tx).unwrap().unwrap();
+        assert_eq!(found, packet);
+    }
+
+    #[test]
+    fn duplicate_vins_are_rejected() {
+        let err = Packet::new(vec![
+            IntrospectorEntry {
+                vin: 1,
+                script: ScriptBuf::from_bytes(vec![0x51]),
+                witness: Witness::default(),
+            },
+            IntrospectorEntry {
+                vin: 1,
+                script: ScriptBuf::from_bytes(vec![0x52]),
+                witness: Witness::default(),
+            },
+        ])
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            PacketError::DuplicateVin { vin: 1, entry: 1 }
+        ));
+    }
+}

--- a/ark-core/src/lib.rs
+++ b/ark-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod coin_select;
 pub mod conversions;
 pub mod history;
 pub mod intent;
+pub mod introspector;
 pub mod script;
 pub mod send;
 pub mod server;

--- a/ark-core/src/lib.rs
+++ b/ark-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod batch;
 pub mod boarding_output;
 pub mod coin_select;
 pub mod conversions;
+pub mod extension;
 pub mod history;
 pub mod intent;
 pub mod introspector;

--- a/ark-core/src/send.rs
+++ b/ark-core/src/send.rs
@@ -603,7 +603,7 @@ pub fn build_asset_send_transactions(
         build_offchain_transactions(receivers, change_address, vtxo_inputs, server_info)?;
 
     if let Some(packet) = create_send_packet(vtxo_inputs, receivers, &offchain.ark_tx)? {
-        add_asset_packet_to_psbt(&mut offchain.ark_tx, &packet);
+        add_asset_packet_to_psbt(&mut offchain.ark_tx, &packet)?;
     }
 
     Ok(offchain)
@@ -642,7 +642,7 @@ pub fn build_asset_burn_transactions(
     if let Some(packet) =
         create_burn_packet(vtxo_inputs, burn_asset_id, burn_amount, &offchain.ark_tx)?
     {
-        add_asset_packet_to_psbt(&mut offchain.ark_tx, &packet);
+        add_asset_packet_to_psbt(&mut offchain.ark_tx, &packet)?;
     }
 
     Ok(offchain)

--- a/ark-core/src/send/issue_asset.rs
+++ b/ark-core/src/send/issue_asset.rs
@@ -89,7 +89,7 @@ pub fn build_self_asset_issuance_transactions(
         control_asset_config.as_ref(),
         metadata.as_ref(),
     )?;
-    add_asset_packet_to_psbt(&mut ark_tx, &packet);
+    add_asset_packet_to_psbt(&mut ark_tx, &packet)?;
 
     let asset_ids = derive_issued_asset_ids(
         ark_tx.unsigned_tx.compute_txid(),

--- a/ark-core/src/send/reissue_asset.rs
+++ b/ark-core/src/send/reissue_asset.rs
@@ -85,7 +85,7 @@ pub fn build_asset_reissuance_transactions(
         server_info,
     )?;
 
-    add_asset_packet_to_psbt(&mut ark_tx, &packet);
+    add_asset_packet_to_psbt(&mut ark_tx, &packet)?;
 
     Ok(AssetReissuanceTransactions {
         ark_tx,

--- a/ark-core/src/vtxo.rs
+++ b/ark-core/src/vtxo.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 pub struct Vtxo {
     server_forfeit: XOnlyPublicKey,
     owner: XOnlyPublicKey,
+    owner_unilateral_exit: XOnlyPublicKey,
     /// The delegator's public key, if this VTXO has a delegate spending path.
     delegator: Option<XOnlyPublicKey>,
     spend_info: TaprootSpendInfo,
@@ -48,6 +49,31 @@ impl Vtxo {
         server_forfeit: XOnlyPublicKey,
         owner: XOnlyPublicKey,
         // TODO: Verify the validity of these scripts before constructing the `Vtxo`.
+        scripts: Vec<ScriptBuf>,
+        exit_delay: bitcoin::Sequence,
+        network: Network,
+    ) -> Result<Self, Error>
+    where
+        C: Verification,
+    {
+        let vtxo = Self::new_with_custom_scripts_and_split_owner_keys(
+            secp,
+            server_forfeit,
+            owner,
+            owner,
+            scripts,
+            exit_delay,
+            network,
+        )?;
+
+        Ok(vtxo)
+    }
+
+    pub fn new_with_custom_scripts_and_split_owner_keys<C>(
+        secp: &Secp256k1<C>,
+        server_forfeit: XOnlyPublicKey,
+        owner: XOnlyPublicKey,
+        owner_unilateral_exit: XOnlyPublicKey,
         scripts: Vec<ScriptBuf>,
         exit_delay: bitcoin::Sequence,
         network: Network,
@@ -82,6 +108,7 @@ impl Vtxo {
         Ok(Self {
             server_forfeit,
             owner,
+            owner_unilateral_exit,
             delegator: None,
             spend_info,
             tapscripts: scripts,
@@ -212,7 +239,7 @@ impl Vtxo {
     /// This method can fail because [`Vtxo`]s constructed with the method
     /// [`Vtxo::new_with_custom_scripts`] may not contain this script exactly.
     pub fn exit_spend_info(&self) -> Result<(ScriptBuf, taproot::ControlBlock), Error> {
-        let exit_script = csv_sig_script(self.exit_delay, self.owner);
+        let exit_script = csv_sig_script(self.exit_delay, self.owner_unilateral_exit);
 
         let control_block = self
             .get_spend_info(exit_script.clone())

--- a/ark-introspector-client/Cargo.toml
+++ b/ark-introspector-client/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 bitcoin = { version = "0.32.7", features = ["base64", "serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/ark-introspector-client/Cargo.toml
+++ b/ark-introspector-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ark-introspector-client"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = "1.86"
+description = "Client for the Ark introspector service"
+
+[lints]
+workspace = true
+
+[dependencies]
+bitcoin = { version = "0.32.7", features = ["base64", "serde"] }
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.41.0", features = ["full"] }

--- a/ark-introspector-client/src/lib.rs
+++ b/ark-introspector-client/src/lib.rs
@@ -5,6 +5,9 @@ use bitcoin::PublicKey;
 use bitcoin::XOnlyPublicKey;
 use serde::Deserialize;
 use serde::Serialize;
+use std::time::Duration;
+
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -71,7 +74,10 @@ impl IntrospectorClient {
     pub fn new(base_url: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into().trim_end_matches('/').to_owned(),
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .timeout(DEFAULT_HTTP_TIMEOUT)
+                .build()
+                .expect("building reqwest client with default timeout"),
         }
     }
 

--- a/ark-introspector-client/src/lib.rs
+++ b/ark-introspector-client/src/lib.rs
@@ -1,0 +1,300 @@
+use bitcoin::base64;
+use bitcoin::base64::Engine;
+use bitcoin::Psbt;
+use bitcoin::PublicKey;
+use bitcoin::XOnlyPublicKey;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+    #[error("invalid signer public key: {0}")]
+    InvalidSignerPubkey(#[source] bitcoin::key::ParsePublicKeyError),
+    #[error("psbt error: {0}")]
+    Psbt(#[from] bitcoin::psbt::Error),
+}
+
+#[derive(Clone, Debug)]
+pub struct Info {
+    pub version: String,
+    pub signer_pubkey: PublicKey,
+}
+
+impl Info {
+    pub fn signer_xonly(&self) -> XOnlyPublicKey {
+        self.signer_pubkey.inner.x_only_public_key().0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmitTxResponse {
+    pub signed_ark_tx: Psbt,
+    pub signed_checkpoint_txs: Vec<Psbt>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmitOnchainTxResponse {
+    pub signed_tx: Psbt,
+}
+
+#[derive(Clone, Debug)]
+pub struct Intent {
+    pub proof: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TxTreeNode {
+    pub txid: String,
+    pub tx: String,
+    pub children: std::collections::BTreeMap<u32, String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct IntrospectorClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl IntrospectorClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_http_client(base_url: impl Into<String>, http: reqwest::Client) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            http,
+        }
+    }
+
+    pub async fn get_info(&self) -> Result<Info, Error> {
+        let response: GetInfoResponse = self
+            .http
+            .get(format!("{}/v1/info", self.base_url))
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(Info {
+            version: response.version,
+            signer_pubkey: response
+                .signer_pubkey
+                .parse()
+                .map_err(Error::InvalidSignerPubkey)?,
+        })
+    }
+
+    pub async fn submit_tx(
+        &self,
+        ark_tx: &Psbt,
+        checkpoint_txs: &[Psbt],
+    ) -> Result<SubmitTxResponse, Error> {
+        let response: SubmitTxResponseWire = self
+            .http
+            .post(format!("{}/v1/tx", self.base_url))
+            .json(&SubmitTxRequest {
+                ark_tx: encode_psbt(ark_tx),
+                checkpoint_txs: checkpoint_txs.iter().map(encode_psbt).collect(),
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(SubmitTxResponse {
+            signed_ark_tx: decode_psbt(&response.signed_ark_tx)?,
+            signed_checkpoint_txs: response
+                .signed_checkpoint_txs
+                .iter()
+                .map(|tx| decode_psbt(tx))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+
+    pub async fn submit_intent(&self, intent: &Intent) -> Result<String, Error> {
+        let response: SubmitIntentResponse = self
+            .http
+            .post(format!("{}/v1/intent", self.base_url))
+            .json(&SubmitIntentRequest {
+                intent: IntentWire {
+                    proof: intent.proof.clone(),
+                    message: intent.message.clone(),
+                },
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(response.signed_proof)
+    }
+
+    pub async fn submit_finalization(
+        &self,
+        signed_intent: &Intent,
+        forfeits: &[String],
+        connector_tree: &[TxTreeNode],
+        commitment_tx: &str,
+    ) -> Result<SubmitFinalizationResponse, Error> {
+        let response: SubmitFinalizationResponse = self
+            .http
+            .post(format!("{}/v1/finalization", self.base_url))
+            .json(&SubmitFinalizationRequest {
+                signed_intent: IntentWire {
+                    proof: signed_intent.proof.clone(),
+                    message: signed_intent.message.clone(),
+                },
+                forfeits: forfeits.to_vec(),
+                connector_tree: connector_tree
+                    .iter()
+                    .map(|node| TxTreeNodeWire {
+                        txid: node.txid.clone(),
+                        tx: node.tx.clone(),
+                        children: node.children.clone(),
+                    })
+                    .collect(),
+                commitment_tx: commitment_tx.to_owned(),
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(response)
+    }
+
+    pub async fn submit_onchain_tx(&self, tx: &Psbt) -> Result<SubmitOnchainTxResponse, Error> {
+        let response: SubmitOnchainTxResponseWire = self
+            .http
+            .post(format!("{}/v1/onchain-tx", self.base_url))
+            .json(&SubmitOnchainTxRequest {
+                tx: encode_psbt(tx),
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+
+        Ok(SubmitOnchainTxResponse {
+            signed_tx: decode_psbt(&response.signed_tx)?,
+        })
+    }
+}
+
+fn base64_engine() -> base64::engine::GeneralPurpose {
+    base64::engine::GeneralPurpose::new(
+        &base64::alphabet::STANDARD,
+        base64::engine::GeneralPurposeConfig::new(),
+    )
+}
+
+fn encode_psbt(psbt: &Psbt) -> String {
+    base64_engine().encode(psbt.serialize())
+}
+
+fn decode_psbt(psbt: &str) -> Result<Psbt, Error> {
+    let bytes = base64_engine().decode(psbt)?;
+    Ok(Psbt::deserialize(&bytes)?)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetInfoResponse {
+    version: String,
+    signer_pubkey: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitTxRequest {
+    ark_tx: String,
+    checkpoint_txs: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitTxResponseWire {
+    signed_ark_tx: String,
+    signed_checkpoint_txs: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitIntentRequest {
+    intent: IntentWire,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IntentWire {
+    proof: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitIntentResponse {
+    signed_proof: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitFinalizationRequest {
+    signed_intent: IntentWire,
+    forfeits: Vec<String>,
+    connector_tree: Vec<TxTreeNodeWire>,
+    commitment_tx: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TxTreeNodeWire {
+    txid: String,
+    tx: String,
+    children: std::collections::BTreeMap<u32, String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitFinalizationResponse {
+    pub signed_forfeits: Vec<String>,
+    pub signed_commitment_tx: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitOnchainTxRequest {
+    tx: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitOnchainTxResponseWire {
+    signed_tx: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn get_info() {
+        let client = IntrospectorClient::new("http://localhost:7073");
+        let info = client.get_info().await.unwrap();
+    }
+}

--- a/ark-introspector-client/src/lib.rs
+++ b/ark-introspector-client/src/lib.rs
@@ -10,6 +10,13 @@ use serde::Serialize;
 pub enum Error {
     #[error(transparent)]
     Http(#[from] reqwest::Error),
+    #[error("http {status}: {body}")]
+    HttpStatus {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     #[error(transparent)]
     Base64(#[from] base64::DecodeError),
     #[error("invalid signer public key: {0}")]
@@ -76,14 +83,13 @@ impl IntrospectorClient {
     }
 
     pub async fn get_info(&self) -> Result<Info, Error> {
-        let response: GetInfoResponse = self
-            .http
-            .get(format!("{}/v1/info", self.base_url))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let response: GetInfoResponse = send_json(
+            self.http
+                .get(format!("{}/v1/info", self.base_url))
+                .send()
+                .await?,
+        )
+        .await?;
 
         Ok(Info {
             version: response.version,
@@ -99,18 +105,17 @@ impl IntrospectorClient {
         ark_tx: &Psbt,
         checkpoint_txs: &[Psbt],
     ) -> Result<SubmitTxResponse, Error> {
-        let response: SubmitTxResponseWire = self
-            .http
-            .post(format!("{}/v1/tx", self.base_url))
-            .json(&SubmitTxRequest {
-                ark_tx: encode_psbt(ark_tx),
-                checkpoint_txs: checkpoint_txs.iter().map(encode_psbt).collect(),
-            })
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let response: SubmitTxResponseWire = send_json(
+            self.http
+                .post(format!("{}/v1/tx", self.base_url))
+                .json(&SubmitTxRequest {
+                    ark_tx: encode_psbt(ark_tx),
+                    checkpoint_txs: checkpoint_txs.iter().map(encode_psbt).collect(),
+                })
+                .send()
+                .await?,
+        )
+        .await?;
 
         Ok(SubmitTxResponse {
             signed_ark_tx: decode_psbt(&response.signed_ark_tx)?,
@@ -123,20 +128,19 @@ impl IntrospectorClient {
     }
 
     pub async fn submit_intent(&self, intent: &Intent) -> Result<String, Error> {
-        let response: SubmitIntentResponse = self
-            .http
-            .post(format!("{}/v1/intent", self.base_url))
-            .json(&SubmitIntentRequest {
-                intent: IntentWire {
-                    proof: intent.proof.clone(),
-                    message: intent.message.clone(),
-                },
-            })
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let response: SubmitIntentResponse = send_json(
+            self.http
+                .post(format!("{}/v1/intent", self.base_url))
+                .json(&SubmitIntentRequest {
+                    intent: IntentWire {
+                        proof: intent.proof.clone(),
+                        message: intent.message.clone(),
+                    },
+                })
+                .send()
+                .await?,
+        )
+        .await?;
 
         Ok(response.signed_proof)
     }
@@ -148,51 +152,62 @@ impl IntrospectorClient {
         connector_tree: &[TxTreeNode],
         commitment_tx: &str,
     ) -> Result<SubmitFinalizationResponse, Error> {
-        let response: SubmitFinalizationResponse = self
-            .http
-            .post(format!("{}/v1/finalization", self.base_url))
-            .json(&SubmitFinalizationRequest {
-                signed_intent: IntentWire {
-                    proof: signed_intent.proof.clone(),
-                    message: signed_intent.message.clone(),
-                },
-                forfeits: forfeits.to_vec(),
-                connector_tree: connector_tree
-                    .iter()
-                    .map(|node| TxTreeNodeWire {
-                        txid: node.txid.clone(),
-                        tx: node.tx.clone(),
-                        children: node.children.clone(),
-                    })
-                    .collect(),
-                commitment_tx: commitment_tx.to_owned(),
-            })
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let response: SubmitFinalizationResponse = send_json(
+            self.http
+                .post(format!("{}/v1/finalization", self.base_url))
+                .json(&SubmitFinalizationRequest {
+                    signed_intent: IntentWire {
+                        proof: signed_intent.proof.clone(),
+                        message: signed_intent.message.clone(),
+                    },
+                    forfeits: forfeits.to_vec(),
+                    connector_tree: connector_tree
+                        .iter()
+                        .map(|node| TxTreeNodeWire {
+                            txid: node.txid.clone(),
+                            tx: node.tx.clone(),
+                            children: node.children.clone(),
+                        })
+                        .collect(),
+                    commitment_tx: commitment_tx.to_owned(),
+                })
+                .send()
+                .await?,
+        )
+        .await?;
 
         Ok(response)
     }
 
     pub async fn submit_onchain_tx(&self, tx: &Psbt) -> Result<SubmitOnchainTxResponse, Error> {
-        let response: SubmitOnchainTxResponseWire = self
-            .http
-            .post(format!("{}/v1/onchain-tx", self.base_url))
-            .json(&SubmitOnchainTxRequest {
-                tx: encode_psbt(tx),
-            })
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let response: SubmitOnchainTxResponseWire = send_json(
+            self.http
+                .post(format!("{}/v1/onchain-tx", self.base_url))
+                .json(&SubmitOnchainTxRequest {
+                    tx: encode_psbt(tx),
+                })
+                .send()
+                .await?,
+        )
+        .await?;
 
         Ok(SubmitOnchainTxResponse {
             signed_tx: decode_psbt(&response.signed_tx)?,
         })
     }
+}
+
+async fn send_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, Error> {
+    let status = response.status();
+    let body = response.text().await?;
+
+    if !status.is_success() {
+        return Err(Error::HttpStatus { status, body });
+    }
+
+    Ok(serde_json::from_str(&body)?)
 }
 
 fn base64_engine() -> base64::engine::GeneralPurpose {
@@ -295,6 +310,6 @@ mod tests {
     #[ignore]
     async fn get_info() {
         let client = IntrospectorClient::new("http://localhost:7073");
-        let info = client.get_info().await.unwrap();
+        let _info = client.get_info().await.unwrap();
     }
 }

--- a/ark-script/Cargo.toml
+++ b/ark-script/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ark-script"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = "1.86"
+description = "Arkade script extension: opcodes, key tweaking, and taproot leaf helpers"
+
+[lints]
+workspace = true
+
+[dependencies]
+bitcoin = { version = "0.32.7", features = ["serde"] }
+hex = "0.4"
+thiserror = "1.0"

--- a/ark-script/src/lib.rs
+++ b/ark-script/src/lib.rs
@@ -30,3 +30,13 @@ pub use tweak::compute_arkade_script_public_key;
 pub use tweak::ArkadeScriptHash;
 pub use tweak::ArkadeWitnessHash;
 pub use tweak::TweakError;
+
+pub mod tapscript;
+pub mod vtxo_script;
+
+pub use tapscript::ArkadeTapscript;
+pub use tapscript::TapscriptError;
+pub use vtxo_script::ArkadeLeaf;
+pub use vtxo_script::ArkadeVtxoInput;
+pub use vtxo_script::ArkadeVtxoScript;
+pub use vtxo_script::VtxoScriptError;

--- a/ark-script/src/lib.rs
+++ b/ark-script/src/lib.rs
@@ -11,3 +11,15 @@
 //!
 //! The crate depends on `ark-core` for types but is opt-in — consumers
 //! who only need standard Ark functionality don't pay for it.
+
+pub mod opcodes;
+pub mod script;
+
+pub use opcodes::op;
+pub use opcodes::opcode_from_name;
+pub use opcodes::opcode_name;
+pub use opcodes::ARKADE_OPCODES;
+pub use script::bytes_to_asm;
+pub use script::from_asm;
+pub use script::to_asm;
+pub use script::AsmError;

--- a/ark-script/src/lib.rs
+++ b/ark-script/src/lib.rs
@@ -1,0 +1,13 @@
+//! Arkade script extension support.
+//!
+//! Arkade is a scripting extension layered on top of standard Bitcoin
+//! script. This crate provides the pieces needed to build and sign
+//! arkade-enhanced VTXOs:
+//!
+//! - Arkade extension opcode constants and ASM conversion
+//! - BIP-340 tagged hashes used to derive introspector-bound public keys
+//! - Helpers for assembling arkade tapscript leaves
+//! - PSBT fields for carrying arkade scripts alongside a spend
+//!
+//! The crate depends on `ark-core` for types but is opt-in — consumers
+//! who only need standard Ark functionality don't pay for it.

--- a/ark-script/src/lib.rs
+++ b/ark-script/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod opcodes;
 pub mod script;
+pub mod tweak;
 
 pub use opcodes::op;
 pub use opcodes::opcode_from_name;
@@ -23,3 +24,9 @@ pub use script::bytes_to_asm;
 pub use script::from_asm;
 pub use script::to_asm;
 pub use script::AsmError;
+pub use tweak::arkade_script_hash;
+pub use tweak::arkade_witness_hash;
+pub use tweak::compute_arkade_script_public_key;
+pub use tweak::ArkadeScriptHash;
+pub use tweak::ArkadeWitnessHash;
+pub use tweak::TweakError;

--- a/ark-script/src/opcodes.rs
+++ b/ark-script/src/opcodes.rs
@@ -1,0 +1,314 @@
+//! Arkade extension opcode constants and name lookup.
+//!
+//! Arkade opcodes occupy byte values `0xb3` (repurposed NOP4) and `0xc4..=0xf3`,
+//! which overlap with Bitcoin's `OP_NOP4` and `OP_RETURN_*` opcodes. When these
+//! bytes appear in an arkade context they carry the extension semantics instead.
+
+use bitcoin::Opcode;
+
+/// Arkade extension opcodes, aliased to the matching `bitcoin` crate opcode
+/// by byte value (arkade repurposes `OP_NOP4` and `OP_RETURN_196..=OP_RETURN_243`).
+///
+/// Use these with [`bitcoin::script::Builder::push_opcode`] to build
+/// arkade-aware scripts.
+pub mod op {
+    use bitcoin::opcodes::all::*;
+    use bitcoin::Opcode;
+
+    // Merkle Branch Verification (0xb3 — repurposed NOP4 slot).
+    pub const MERKLEBRANCHVERIFY: Opcode = OP_NOP4;
+
+    // SHA256 streaming (0xc4..=0xc6).
+    pub const SHA256INITIALIZE: Opcode = OP_RETURN_196;
+    pub const SHA256UPDATE: Opcode = OP_RETURN_197;
+    pub const SHA256FINALIZE: Opcode = OP_RETURN_198;
+
+    // Input introspection (0xc7..=0xcb).
+    pub const INSPECTINPUTOUTPOINT: Opcode = OP_RETURN_199;
+    pub const INSPECTINPUTARKADESCRIPTHASH: Opcode = OP_RETURN_200;
+    pub const INSPECTINPUTVALUE: Opcode = OP_RETURN_201;
+    pub const INSPECTINPUTSCRIPTPUBKEY: Opcode = OP_RETURN_202;
+    pub const INSPECTINPUTSEQUENCE: Opcode = OP_RETURN_203;
+
+    // Signatures (0xcc..=0xcd).
+    pub const CHECKSIGFROMSTACK: Opcode = OP_RETURN_204;
+    pub const PUSHCURRENTINPUTINDEX: Opcode = OP_RETURN_205;
+
+    // Input arkade witness introspection (0xce).
+    pub const INSPECTINPUTARKADEWITNESSHASH: Opcode = OP_RETURN_206;
+
+    // Output introspection (0xcf, 0xd1).
+    pub const INSPECTOUTPUTVALUE: Opcode = OP_RETURN_207;
+    pub const INSPECTOUTPUTSCRIPTPUBKEY: Opcode = OP_RETURN_209;
+
+    // Transaction introspection (0xd2..=0xd6).
+    pub const INSPECTVERSION: Opcode = OP_RETURN_210;
+    pub const INSPECTLOCKTIME: Opcode = OP_RETURN_211;
+    pub const INSPECTNUMINPUTS: Opcode = OP_RETURN_212;
+    pub const INSPECTNUMOUTPUTS: Opcode = OP_RETURN_213;
+    pub const TXWEIGHT: Opcode = OP_RETURN_214;
+
+    // 64-bit arithmetic (0xd7..=0xdf).
+    pub const ADD64: Opcode = OP_RETURN_215;
+    pub const SUB64: Opcode = OP_RETURN_216;
+    pub const MUL64: Opcode = OP_RETURN_217;
+    pub const DIV64: Opcode = OP_RETURN_218;
+    pub const NEG64: Opcode = OP_RETURN_219;
+    pub const LESSTHAN64: Opcode = OP_RETURN_220;
+    pub const LESSTHANOREQUAL64: Opcode = OP_RETURN_221;
+    pub const GREATERTHAN64: Opcode = OP_RETURN_222;
+    pub const GREATERTHANOREQUAL64: Opcode = OP_RETURN_223;
+
+    // Conversion (0xe0..=0xe2).
+    pub const SCRIPTNUMTOLE64: Opcode = OP_RETURN_224;
+    pub const LE64TOSCRIPTNUM: Opcode = OP_RETURN_225;
+    pub const LE32TOLE64: Opcode = OP_RETURN_226;
+
+    // EC operations (0xe3..=0xe4).
+    pub const ECMULSCALARVERIFY: Opcode = OP_RETURN_227;
+    pub const TWEAKVERIFY: Opcode = OP_RETURN_228;
+
+    // Asset groups (0xe5..=0xf2).
+    pub const INSPECTNUMASSETGROUPS: Opcode = OP_RETURN_229;
+    pub const INSPECTASSETGROUPASSETID: Opcode = OP_RETURN_230;
+    pub const INSPECTASSETGROUPCTRL: Opcode = OP_RETURN_231;
+    pub const FINDASSETGROUPBYASSETID: Opcode = OP_RETURN_232;
+    pub const INSPECTASSETGROUPMETADATAHASH: Opcode = OP_RETURN_233;
+    pub const INSPECTASSETGROUPNUM: Opcode = OP_RETURN_234;
+    pub const INSPECTASSETGROUP: Opcode = OP_RETURN_235;
+    pub const INSPECTASSETGROUPSUM: Opcode = OP_RETURN_236;
+    pub const INSPECTOUTASSETCOUNT: Opcode = OP_RETURN_237;
+    pub const INSPECTOUTASSETAT: Opcode = OP_RETURN_238;
+    pub const INSPECTOUTASSETLOOKUP: Opcode = OP_RETURN_239;
+    pub const INSPECTINASSETCOUNT: Opcode = OP_RETURN_240;
+    pub const INSPECTINASSETAT: Opcode = OP_RETURN_241;
+    pub const INSPECTINASSETLOOKUP: Opcode = OP_RETURN_242;
+
+    // Transaction ID (0xf3).
+    pub const TXID: Opcode = OP_RETURN_243;
+}
+
+/// Arkade extension opcode byte → arkade-specific name (no `OP_` prefix).
+///
+/// When an opcode byte is also a standard Bitcoin opcode (e.g. `OP_NOP4`
+/// shares `0xb3` with `MERKLEBRANCHVERIFY`), the arkade name wins in
+/// arkade contexts.
+const ARKADE_NAMES: &[(u8, &str)] = &[
+    (0xb3, "MERKLEBRANCHVERIFY"),
+    (0xc4, "SHA256INITIALIZE"),
+    (0xc5, "SHA256UPDATE"),
+    (0xc6, "SHA256FINALIZE"),
+    (0xc7, "INSPECTINPUTOUTPOINT"),
+    (0xc8, "INSPECTINPUTARKADESCRIPTHASH"),
+    (0xc9, "INSPECTINPUTVALUE"),
+    (0xca, "INSPECTINPUTSCRIPTPUBKEY"),
+    (0xcb, "INSPECTINPUTSEQUENCE"),
+    (0xcc, "CHECKSIGFROMSTACK"),
+    (0xcd, "PUSHCURRENTINPUTINDEX"),
+    (0xce, "INSPECTINPUTARKADEWITNESSHASH"),
+    (0xcf, "INSPECTOUTPUTVALUE"),
+    (0xd1, "INSPECTOUTPUTSCRIPTPUBKEY"),
+    (0xd2, "INSPECTVERSION"),
+    (0xd3, "INSPECTLOCKTIME"),
+    (0xd4, "INSPECTNUMINPUTS"),
+    (0xd5, "INSPECTNUMOUTPUTS"),
+    (0xd6, "TXWEIGHT"),
+    (0xd7, "ADD64"),
+    (0xd8, "SUB64"),
+    (0xd9, "MUL64"),
+    (0xda, "DIV64"),
+    (0xdb, "NEG64"),
+    (0xdc, "LESSTHAN64"),
+    (0xdd, "LESSTHANOREQUAL64"),
+    (0xde, "GREATERTHAN64"),
+    (0xdf, "GREATERTHANOREQUAL64"),
+    (0xe0, "SCRIPTNUMTOLE64"),
+    (0xe1, "LE64TOSCRIPTNUM"),
+    (0xe2, "LE32TOLE64"),
+    (0xe3, "ECMULSCALARVERIFY"),
+    (0xe4, "TWEAKVERIFY"),
+    (0xe5, "INSPECTNUMASSETGROUPS"),
+    (0xe6, "INSPECTASSETGROUPASSETID"),
+    (0xe7, "INSPECTASSETGROUPCTRL"),
+    (0xe8, "FINDASSETGROUPBYASSETID"),
+    (0xe9, "INSPECTASSETGROUPMETADATAHASH"),
+    (0xea, "INSPECTASSETGROUPNUM"),
+    (0xeb, "INSPECTASSETGROUP"),
+    (0xec, "INSPECTASSETGROUPSUM"),
+    (0xed, "INSPECTOUTASSETCOUNT"),
+    (0xee, "INSPECTOUTASSETAT"),
+    (0xef, "INSPECTOUTASSETLOOKUP"),
+    (0xf0, "INSPECTINASSETCOUNT"),
+    (0xf1, "INSPECTINASSETAT"),
+    (0xf2, "INSPECTINASSETLOOKUP"),
+    (0xf3, "TXID"),
+];
+
+/// All arkade extension opcode byte values.
+pub const ARKADE_OPCODES: &[u8] = &[
+    0xb3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd1, 0xd2, 0xd3,
+    0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3,
+    0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3,
+];
+
+/// Returns the opcode name (with `OP_` prefix) for the given byte, preferring
+/// arkade-specific names over Bitcoin names where they collide.
+///
+/// Data push opcodes `0x01..=0x4b` are rendered as `OP_DATA_N`.
+pub fn opcode_name(byte: u8) -> Option<String> {
+    if (0x01..=0x4b).contains(&byte) {
+        return Some(format!("OP_DATA_{byte}"));
+    }
+
+    if let Some((_, name)) = ARKADE_NAMES.iter().find(|(b, _)| *b == byte) {
+        return Some(format!("OP_{name}"));
+    }
+
+    bitcoin_opcode_name(byte)
+}
+
+/// Returns the opcode byte for the given name. Accepts names with or without
+/// the `OP_` prefix, and recognises the `OP_DATA_N` pattern used for data
+/// push opcodes.
+pub fn opcode_from_name(name: &str) -> Option<u8> {
+    let stripped = name.strip_prefix("OP_").unwrap_or(name);
+
+    if let Some(rest) = stripped.strip_prefix("DATA_") {
+        let n: u16 = rest.parse().ok()?;
+        if (1..=0x4b).contains(&n) {
+            return Some(n as u8);
+        }
+        return None;
+    }
+
+    if let Some((byte, _)) = ARKADE_NAMES.iter().find(|(_, n)| *n == stripped) {
+        return Some(*byte);
+    }
+
+    bitcoin_opcode_byte(stripped)
+}
+
+fn bitcoin_opcode_name(byte: u8) -> Option<String> {
+    // Reuse the bitcoin crate's Display impl, which renders as `OP_NAME`.
+    let op = Opcode::from(byte);
+    let name = format!("{op}");
+    // The bitcoin crate prints unknown opcodes as a hex byte rather than a
+    // name; filter those out so callers can detect unknown bytes.
+    if name.starts_with("OP_") {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+fn bitcoin_opcode_byte(stripped: &str) -> Option<u8> {
+    // There is no public name → opcode lookup in the `bitcoin` crate, so we
+    // round-trip via Display: try every byte until one prints to the target
+    // name. The table is 256 entries so this is cheap and avoids maintaining
+    // a second copy of the opcode list in sync with the upstream crate.
+    //
+    // Also handle a few aliases the Display impl doesn't emit.
+    match stripped {
+        "0" | "FALSE" => return Some(0x00),
+        "TRUE" => return Some(0x51),
+        "1NEGATE" => return Some(0x4f),
+        _ => {}
+    }
+
+    // `OP_1`..`OP_16` alias `OP_PUSHNUM_1`..`OP_PUSHNUM_16`.
+    if let Some(rest) = stripped.strip_prefix("PUSHNUM_") {
+        if let Ok(n) = rest.parse::<u8>() {
+            if (1..=16).contains(&n) {
+                return Some(0x50 + n);
+            }
+        }
+    }
+    if let Ok(n) = stripped.parse::<u8>() {
+        if (1..=16).contains(&n) {
+            return Some(0x50 + n);
+        }
+    }
+
+    for byte in 0u8..=255 {
+        let name = format!("{}", Opcode::from(byte));
+        if let Some(n) = name.strip_prefix("OP_") {
+            if n == stripped {
+                return Some(byte);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arkade_opcode_values() {
+        assert_eq!(op::MERKLEBRANCHVERIFY.to_u8(), 0xb3);
+        assert_eq!(op::SHA256INITIALIZE.to_u8(), 0xc4);
+        assert_eq!(op::ADD64.to_u8(), 0xd7);
+        assert_eq!(op::TWEAKVERIFY.to_u8(), 0xe4);
+        assert_eq!(op::INSPECTINASSETLOOKUP.to_u8(), 0xf2);
+        assert_eq!(op::TXID.to_u8(), 0xf3);
+    }
+
+    #[test]
+    fn opcode_name_prefers_arkade() {
+        // 0xb3 is NOP4 in standard Bitcoin — arkade wins.
+        assert_eq!(opcode_name(0xb3).as_deref(), Some("OP_MERKLEBRANCHVERIFY"));
+        // 0xc4 is OP_RETURN_196 in standard Bitcoin — arkade wins.
+        assert_eq!(opcode_name(0xc4).as_deref(), Some("OP_SHA256INITIALIZE"));
+    }
+
+    #[test]
+    fn opcode_name_standard_bitcoin() {
+        assert_eq!(opcode_name(0x76).as_deref(), Some("OP_DUP"));
+        assert_eq!(opcode_name(0xa9).as_deref(), Some("OP_HASH160"));
+        assert_eq!(opcode_name(0x88).as_deref(), Some("OP_EQUALVERIFY"));
+    }
+
+    #[test]
+    fn opcode_name_data_push() {
+        assert_eq!(opcode_name(0x14).as_deref(), Some("OP_DATA_20"));
+        assert_eq!(opcode_name(0x01).as_deref(), Some("OP_DATA_1"));
+        assert_eq!(opcode_name(0x4b).as_deref(), Some("OP_DATA_75"));
+    }
+
+    #[test]
+    fn opcode_from_name_round_trip() {
+        for &(byte, _) in ARKADE_NAMES {
+            let name = opcode_name(byte).unwrap();
+            assert_eq!(opcode_from_name(&name), Some(byte));
+            let without_prefix = name.strip_prefix("OP_").unwrap();
+            assert_eq!(opcode_from_name(without_prefix), Some(byte));
+        }
+    }
+
+    #[test]
+    fn opcode_from_name_bitcoin() {
+        assert_eq!(opcode_from_name("OP_DUP"), Some(0x76));
+        assert_eq!(opcode_from_name("DUP"), Some(0x76));
+        assert_eq!(opcode_from_name("OP_CHECKSIG"), Some(0xac));
+        assert_eq!(opcode_from_name("OP_0"), Some(0x00));
+        assert_eq!(opcode_from_name("OP_FALSE"), Some(0x00));
+        assert_eq!(opcode_from_name("OP_TRUE"), Some(0x51));
+        assert_eq!(opcode_from_name("OP_1"), Some(0x51));
+        assert_eq!(opcode_from_name("OP_16"), Some(0x60));
+    }
+
+    #[test]
+    fn opcode_from_name_data_push() {
+        assert_eq!(opcode_from_name("OP_DATA_20"), Some(0x14));
+        assert_eq!(opcode_from_name("OP_DATA_75"), Some(0x4b));
+        // Out of range:
+        assert_eq!(opcode_from_name("OP_DATA_76"), None);
+        assert_eq!(opcode_from_name("OP_DATA_0"), None);
+    }
+
+    #[test]
+    fn opcode_from_name_unknown() {
+        assert_eq!(opcode_from_name("NOTAREALOPCODE"), None);
+    }
+}

--- a/ark-script/src/opcodes.rs
+++ b/ark-script/src/opcodes.rs
@@ -1,13 +1,13 @@
 //! Arkade extension opcode constants and name lookup.
 //!
-//! Arkade opcodes occupy byte values `0xb3` (repurposed NOP4) and `0xc4..=0xf3`,
+//! Arkade opcodes occupy byte values `0xb3` (repurposed NOP4) and `0xc4..=0xf5`,
 //! which overlap with Bitcoin's `OP_NOP4` and `OP_RETURN_*` opcodes. When these
 //! bytes appear in an arkade context they carry the extension semantics instead.
 
 use bitcoin::Opcode;
 
 /// Arkade extension opcodes, aliased to the matching `bitcoin` crate opcode
-/// by byte value (arkade repurposes `OP_NOP4` and `OP_RETURN_196..=OP_RETURN_243`).
+/// by byte value (arkade repurposes `OP_NOP4` and `OP_RETURN_196..=OP_RETURN_245`).
 ///
 /// Use these with [`bitcoin::script::Builder::push_opcode`] to build
 /// arkade-aware scripts.
@@ -48,21 +48,9 @@ pub mod op {
     pub const INSPECTNUMOUTPUTS: Opcode = OP_RETURN_213;
     pub const TXWEIGHT: Opcode = OP_RETURN_214;
 
-    // 64-bit arithmetic (0xd7..=0xdf).
-    pub const ADD64: Opcode = OP_RETURN_215;
-    pub const SUB64: Opcode = OP_RETURN_216;
-    pub const MUL64: Opcode = OP_RETURN_217;
-    pub const DIV64: Opcode = OP_RETURN_218;
-    pub const NEG64: Opcode = OP_RETURN_219;
-    pub const LESSTHAN64: Opcode = OP_RETURN_220;
-    pub const LESSTHANOREQUAL64: Opcode = OP_RETURN_221;
-    pub const GREATERTHAN64: Opcode = OP_RETURN_222;
-    pub const GREATERTHANOREQUAL64: Opcode = OP_RETURN_223;
-
-    // Conversion (0xe0..=0xe2).
-    pub const SCRIPTNUMTOLE64: Opcode = OP_RETURN_224;
-    pub const LE64TOSCRIPTNUM: Opcode = OP_RETURN_225;
-    pub const LE32TOLE64: Opcode = OP_RETURN_226;
+    // Conversion (0xd7..=0xd8).
+    pub const NUM2BIN: Opcode = OP_RETURN_215;
+    pub const BIN2NUM: Opcode = OP_RETURN_216;
 
     // EC operations (0xe3..=0xe4).
     pub const ECMULSCALARVERIFY: Opcode = OP_RETURN_227;
@@ -86,6 +74,10 @@ pub mod op {
 
     // Transaction ID (0xf3).
     pub const TXID: Opcode = OP_RETURN_243;
+
+    // Packet introspection (0xf4..=0xf5).
+    pub const INSPECTPACKET: Opcode = OP_RETURN_244;
+    pub const INSPECTINPUTPACKET: Opcode = OP_RETURN_245;
 }
 
 /// Arkade extension opcode byte → arkade-specific name (no `OP_` prefix).
@@ -113,18 +105,8 @@ const ARKADE_NAMES: &[(u8, &str)] = &[
     (0xd4, "INSPECTNUMINPUTS"),
     (0xd5, "INSPECTNUMOUTPUTS"),
     (0xd6, "TXWEIGHT"),
-    (0xd7, "ADD64"),
-    (0xd8, "SUB64"),
-    (0xd9, "MUL64"),
-    (0xda, "DIV64"),
-    (0xdb, "NEG64"),
-    (0xdc, "LESSTHAN64"),
-    (0xdd, "LESSTHANOREQUAL64"),
-    (0xde, "GREATERTHAN64"),
-    (0xdf, "GREATERTHANOREQUAL64"),
-    (0xe0, "SCRIPTNUMTOLE64"),
-    (0xe1, "LE64TOSCRIPTNUM"),
-    (0xe2, "LE32TOLE64"),
+    (0xd7, "NUM2BIN"),
+    (0xd8, "BIN2NUM"),
     (0xe3, "ECMULSCALARVERIFY"),
     (0xe4, "TWEAKVERIFY"),
     (0xe5, "INSPECTNUMASSETGROUPS"),
@@ -142,13 +124,15 @@ const ARKADE_NAMES: &[(u8, &str)] = &[
     (0xf1, "INSPECTINASSETAT"),
     (0xf2, "INSPECTINASSETLOOKUP"),
     (0xf3, "TXID"),
+    (0xf4, "INSPECTPACKET"),
+    (0xf5, "INSPECTINPUTPACKET"),
 ];
 
 /// All arkade extension opcode byte values.
 pub const ARKADE_OPCODES: &[u8] = &[
     0xb3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf, 0xd1, 0xd2, 0xd3,
-    0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf, 0xe0, 0xe1, 0xe2, 0xe3,
-    0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3,
+    0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed,
+    0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5,
 ];
 
 /// Returns the opcode name (with `OP_` prefix) for the given byte, preferring
@@ -248,10 +232,12 @@ mod tests {
     fn arkade_opcode_values() {
         assert_eq!(op::MERKLEBRANCHVERIFY.to_u8(), 0xb3);
         assert_eq!(op::SHA256INITIALIZE.to_u8(), 0xc4);
-        assert_eq!(op::ADD64.to_u8(), 0xd7);
+        assert_eq!(op::NUM2BIN.to_u8(), 0xd7);
         assert_eq!(op::TWEAKVERIFY.to_u8(), 0xe4);
         assert_eq!(op::INSPECTINASSETLOOKUP.to_u8(), 0xf2);
         assert_eq!(op::TXID.to_u8(), 0xf3);
+        assert_eq!(op::INSPECTPACKET.to_u8(), 0xf4);
+        assert_eq!(op::INSPECTINPUTPACKET.to_u8(), 0xf5);
     }
 
     #[test]

--- a/ark-script/src/script.rs
+++ b/ark-script/src/script.rs
@@ -154,12 +154,12 @@ mod tests {
     fn to_asm_arkade_opcodes() {
         let script = Builder::new()
             .push_opcode(op::SHA256INITIALIZE)
-            .push_opcode(op::ADD64)
+            .push_opcode(op::NUM2BIN)
             .push_opcode(op::TWEAKVERIFY)
             .into_script();
         assert_eq!(
             to_asm(&script).unwrap(),
-            "OP_SHA256INITIALIZE OP_ADD64 OP_TWEAKVERIFY"
+            "OP_SHA256INITIALIZE OP_NUM2BIN OP_TWEAKVERIFY"
         );
     }
 
@@ -235,12 +235,12 @@ mod tests {
 
     #[test]
     fn from_asm_arkade() {
-        let script = from_asm("OP_SHA256INITIALIZE OP_ADD64 OP_TWEAKVERIFY").unwrap();
+        let script = from_asm("OP_SHA256INITIALIZE OP_NUM2BIN OP_TWEAKVERIFY").unwrap();
         assert_eq!(
             script,
             Builder::new()
                 .push_opcode(op::SHA256INITIALIZE)
-                .push_opcode(op::ADD64)
+                .push_opcode(op::NUM2BIN)
                 .push_opcode(op::TWEAKVERIFY)
                 .into_script()
         );
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn round_trip_arkade() {
-        let original = "OP_INSPECTNUMASSETGROUPS OP_ADD64 deadbeef OP_EQUAL";
+        let original = "OP_INSPECTNUMASSETGROUPS OP_NUM2BIN deadbeef OP_EQUAL";
         let script = from_asm(original).unwrap();
         assert_eq!(to_asm(&script).unwrap(), original);
     }

--- a/ark-script/src/script.rs
+++ b/ark-script/src/script.rs
@@ -104,6 +104,18 @@ fn append_token(builder: Builder, token: &str) -> Result<Builder, AsmError> {
         return Ok(builder.push_opcode(Opcode::from(byte)));
     }
 
+    if let Some(rest) = token.strip_prefix("OP_UNKNOWN_") {
+        if rest.len() != 2 {
+            return Err(AsmError::InvalidToken(token.to_string()));
+        }
+        let byte =
+            u8::from_str_radix(rest, 16).map_err(|_| AsmError::InvalidToken(token.to_string()))?;
+        if (0x01..=0x4b).contains(&byte) {
+            return Err(AsmError::InvalidToken(token.to_string()));
+        }
+        return Ok(builder.push_opcode(Opcode::from(byte)));
+    }
+
     if is_hex(token) {
         let bytes = hex::decode(token).map_err(|e| AsmError::InvalidHex(token.to_string(), e))?;
         let push: &PushBytes = bytes
@@ -266,5 +278,28 @@ mod tests {
         let original = "OP_INSPECTNUMASSETGROUPS OP_ADD64 deadbeef OP_EQUAL";
         let script = from_asm(original).unwrap();
         assert_eq!(to_asm(&script).unwrap(), original);
+    }
+
+    #[test]
+    fn round_trip_unknown_opcode() {
+        let original = ScriptBuf::from_bytes(vec![0xff]);
+        let unknown = from_asm("OP_UNKNOWN_ff").unwrap();
+        assert_eq!(unknown, original);
+
+        let asm = to_asm(&unknown).unwrap();
+        assert_eq!(from_asm(&asm).unwrap(), original);
+    }
+
+    #[test]
+    fn from_asm_rejects_invalid_unknown_opcode_tokens() {
+        for token in [
+            "OP_UNKNOWN_f",
+            "OP_UNKNOWN_fff",
+            "OP_UNKNOWN_gg",
+            "OP_UNKNOWN_01",
+        ] {
+            let err = from_asm(token).unwrap_err();
+            assert!(matches!(err, AsmError::InvalidToken(_)));
+        }
     }
 }

--- a/ark-script/src/script.rs
+++ b/ark-script/src/script.rs
@@ -1,0 +1,270 @@
+//! ASM (assembly) conversion that understands both standard Bitcoin and
+//! Arkade extension opcodes.
+
+use super::opcodes::opcode_from_name;
+use super::opcodes::opcode_name;
+use bitcoin::opcodes::all::OP_PUSHBYTES_0;
+use bitcoin::opcodes::all::OP_PUSHNUM_1;
+use bitcoin::opcodes::all::OP_PUSHNUM_16;
+use bitcoin::script::Builder;
+use bitcoin::script::Instruction;
+use bitcoin::script::PushBytes;
+use bitcoin::Opcode;
+use bitcoin::Script;
+use bitcoin::ScriptBuf;
+
+/// Errors returned when parsing ASM.
+#[derive(Debug, thiserror::Error)]
+pub enum AsmError {
+    #[error("invalid ASM token: {0}")]
+    InvalidToken(String),
+    #[error("failed to decode hex token {0:?}: {1}")]
+    InvalidHex(String, hex::FromHexError),
+    #[error("push payload exceeds maximum size")]
+    PushTooLarge,
+    #[error("failed to decode script: {0}")]
+    ScriptDecode(bitcoin::script::Error),
+}
+
+/// Convert a script to ASM format. Standard Bitcoin opcodes and Arkade
+/// extension opcodes are rendered by name (with `OP_` prefix); data pushes
+/// are rendered as lowercase hex.
+///
+/// Returns [`AsmError::ScriptDecode`] if the script contains a malformed push.
+pub fn to_asm(script: &Script) -> Result<String, AsmError> {
+    let mut parts: Vec<String> = Vec::new();
+
+    for instruction in script.instructions() {
+        match instruction.map_err(AsmError::ScriptDecode)? {
+            Instruction::Op(op) => {
+                let name = opcode_name(op.to_u8())
+                    .unwrap_or_else(|| format!("OP_UNKNOWN_{:02x}", op.to_u8()));
+                parts.push(name);
+            }
+            Instruction::PushBytes(bytes) => {
+                if bytes.is_empty() {
+                    parts.push("OP_0".to_string());
+                } else {
+                    parts.push(hex::encode(bytes.as_bytes()));
+                }
+            }
+        }
+    }
+
+    Ok(parts.join(" "))
+}
+
+/// Convert raw script bytes to ASM.
+pub fn bytes_to_asm(bytes: &[u8]) -> Result<String, AsmError> {
+    to_asm(Script::from_bytes(bytes))
+}
+
+/// Parse ASM into script bytes.
+///
+/// Supported tokens:
+/// - `OP_NAME` / `NAME` — any standard Bitcoin or Arkade opcode name
+/// - `OP_0` / `OP_FALSE` — push the empty byte array
+/// - `OP_1`..`OP_16` / `OP_TRUE` — numeric push opcodes
+/// - hex strings — pushed as data
+pub fn from_asm(asm: &str) -> Result<ScriptBuf, AsmError> {
+    let mut builder = Builder::new();
+
+    for token in asm.split_whitespace() {
+        builder = append_token(builder, token)?;
+    }
+
+    Ok(builder.into_script())
+}
+
+fn append_token(builder: Builder, token: &str) -> Result<Builder, AsmError> {
+    if token == "OP_0" || token == "OP_FALSE" {
+        return Ok(builder.push_opcode(OP_PUSHBYTES_0));
+    }
+    if token == "OP_TRUE" {
+        return Ok(builder.push_opcode(OP_PUSHNUM_1));
+    }
+
+    if let Some(rest) = token.strip_prefix("OP_") {
+        if let Ok(n) = rest.parse::<u8>() {
+            if (1..=16).contains(&n) {
+                let op = Opcode::from(OP_PUSHNUM_1.to_u8() + n - 1);
+                debug_assert!(op.to_u8() <= OP_PUSHNUM_16.to_u8());
+                return Ok(builder.push_opcode(op));
+            }
+        }
+    }
+
+    if let Some(byte) = opcode_from_name(token) {
+        if (0x01..=0x4b).contains(&byte) {
+            // Bare data-push opcodes (e.g. `OP_DATA_20`) aren't meaningful
+            // without a payload — reject rather than silently emit a
+            // malformed script.
+            return Err(AsmError::InvalidToken(token.to_string()));
+        }
+        return Ok(builder.push_opcode(Opcode::from(byte)));
+    }
+
+    if is_hex(token) {
+        let bytes = hex::decode(token).map_err(|e| AsmError::InvalidHex(token.to_string(), e))?;
+        let push: &PushBytes = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| AsmError::PushTooLarge)?;
+        return Ok(builder.push_slice(push));
+    }
+
+    Err(AsmError::InvalidToken(token.to_string()))
+}
+
+fn is_hex(token: &str) -> bool {
+    !token.is_empty() && token.len() % 2 == 0 && token.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op;
+    use bitcoin::opcodes::all::OP_CHECKSIG;
+    use bitcoin::opcodes::all::OP_DUP;
+    use bitcoin::opcodes::all::OP_EQUALVERIFY;
+    use bitcoin::opcodes::all::OP_HASH160;
+
+    #[test]
+    fn to_asm_standard_opcodes() {
+        let script = Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .into_script();
+        assert_eq!(to_asm(&script).unwrap(), "OP_DUP OP_HASH160");
+    }
+
+    #[test]
+    fn to_asm_arkade_opcodes() {
+        let script = Builder::new()
+            .push_opcode(op::SHA256INITIALIZE)
+            .push_opcode(op::ADD64)
+            .push_opcode(op::TWEAKVERIFY)
+            .into_script();
+        assert_eq!(
+            to_asm(&script).unwrap(),
+            "OP_SHA256INITIALIZE OP_ADD64 OP_TWEAKVERIFY"
+        );
+    }
+
+    #[test]
+    fn to_asm_mixed() {
+        let pubkey_hash = hex::decode("1234567890abcdef1234567890abcdef12345678").unwrap();
+        let push: &PushBytes = pubkey_hash.as_slice().try_into().unwrap();
+        let script = Builder::new()
+            .push_opcode(OP_DUP)
+            .push_opcode(OP_HASH160)
+            .push_slice(push)
+            .push_opcode(OP_EQUALVERIFY)
+            .push_opcode(OP_CHECKSIG)
+            .into_script();
+        assert_eq!(
+            to_asm(&script).unwrap(),
+            "OP_DUP OP_HASH160 1234567890abcdef1234567890abcdef12345678 OP_EQUALVERIFY OP_CHECKSIG"
+        );
+    }
+
+    #[test]
+    fn to_asm_merklebranchverify_and_txid() {
+        let script = Builder::new()
+            .push_opcode(op::MERKLEBRANCHVERIFY)
+            .push_opcode(op::TXID)
+            .into_script();
+        assert_eq!(to_asm(&script).unwrap(), "OP_MERKLEBRANCHVERIFY OP_TXID");
+    }
+
+    #[test]
+    fn to_asm_empty_push_is_op_0() {
+        let script = Builder::new().push_opcode(OP_PUSHBYTES_0).into_script();
+        assert_eq!(to_asm(&script).unwrap(), "OP_0");
+    }
+
+    #[test]
+    fn from_asm_standard_opcodes() {
+        let script = from_asm("OP_DUP OP_HASH160").unwrap();
+        assert_eq!(
+            script,
+            Builder::new()
+                .push_opcode(OP_DUP)
+                .push_opcode(OP_HASH160)
+                .into_script()
+        );
+    }
+
+    #[test]
+    fn from_asm_without_op_prefix() {
+        let script = from_asm("DUP HASH160").unwrap();
+        assert_eq!(
+            script,
+            Builder::new()
+                .push_opcode(OP_DUP)
+                .push_opcode(OP_HASH160)
+                .into_script()
+        );
+    }
+
+    #[test]
+    fn from_asm_hex_data() {
+        let script = from_asm("OP_DUP aabbccdd OP_EQUALVERIFY").unwrap();
+        let payload: &PushBytes = [0xaa, 0xbb, 0xcc, 0xdd].as_slice().try_into().unwrap();
+        assert_eq!(
+            script,
+            Builder::new()
+                .push_opcode(OP_DUP)
+                .push_slice(payload)
+                .push_opcode(OP_EQUALVERIFY)
+                .into_script()
+        );
+    }
+
+    #[test]
+    fn from_asm_arkade() {
+        let script = from_asm("OP_SHA256INITIALIZE OP_ADD64 OP_TWEAKVERIFY").unwrap();
+        assert_eq!(
+            script,
+            Builder::new()
+                .push_opcode(op::SHA256INITIALIZE)
+                .push_opcode(op::ADD64)
+                .push_opcode(op::TWEAKVERIFY)
+                .into_script()
+        );
+    }
+
+    #[test]
+    fn from_asm_op_0_and_numeric() {
+        let script = from_asm("OP_0 OP_1 OP_16").unwrap();
+        assert_eq!(
+            script,
+            Builder::new()
+                .push_opcode(OP_PUSHBYTES_0)
+                .push_opcode(OP_PUSHNUM_1)
+                .push_opcode(OP_PUSHNUM_16)
+                .into_script()
+        );
+    }
+
+    #[test]
+    fn from_asm_invalid_token() {
+        let err = from_asm("NOTAREALOPCODE").unwrap_err();
+        assert!(matches!(err, AsmError::InvalidToken(_)));
+    }
+
+    #[test]
+    fn round_trip() {
+        let original =
+            "OP_DUP OP_HASH160 1234567890abcdef1234567890abcdef12345678 OP_EQUALVERIFY OP_CHECKSIG";
+        let script = from_asm(original).unwrap();
+        assert_eq!(to_asm(&script).unwrap(), original);
+    }
+
+    #[test]
+    fn round_trip_arkade() {
+        let original = "OP_INSPECTNUMASSETGROUPS OP_ADD64 deadbeef OP_EQUAL";
+        let script = from_asm(original).unwrap();
+        assert_eq!(to_asm(&script).unwrap(), original);
+    }
+}

--- a/ark-script/src/tapscript.rs
+++ b/ark-script/src/tapscript.rs
@@ -1,0 +1,280 @@
+//! Tapscript encoders used by arkade VTXO leaves.
+//!
+//! Only the shapes consumed by the arkade flow are implemented:
+//!
+//! - [`ArkadeTapscript::Multisig`] — n-of-n checksig chain (`<pk1> CHECKSIGVERIFY ... <pkN>
+//!   CHECKSIG`).
+//! - [`ArkadeTapscript::CsvMultisig`] — same, prefixed with a relative timelock (`<seq>
+//!   CHECKSEQUENCEVERIFY DROP ...`).
+//!
+//! Other shapes (`CLTVMultisig`, `ConditionMultisig`, `ConditionCSVMultisig`
+//! in the TS SDK) land when a downstream layer needs them.
+
+use bitcoin::opcodes::all::OP_CHECKSIG;
+use bitcoin::opcodes::all::OP_CHECKSIGVERIFY;
+use bitcoin::opcodes::all::OP_CSV;
+use bitcoin::opcodes::all::OP_DROP;
+use bitcoin::script::Builder;
+use bitcoin::ScriptBuf;
+use bitcoin::Sequence;
+use bitcoin::XOnlyPublicKey;
+
+/// Errors produced when encoding an [`ArkadeTapscript`].
+#[derive(Debug, thiserror::Error)]
+pub enum TapscriptError {
+    #[error("tapscript requires at least one pubkey")]
+    NoPubkeys,
+}
+
+/// Subset of tapscript leaf shapes used by arkade flows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArkadeTapscript {
+    /// `<pk1> CHECKSIGVERIFY <pk2> CHECKSIGVERIFY ... <pkN> CHECKSIG`
+    Multisig { pubkeys: Vec<XOnlyPublicKey> },
+    /// `<seq> CHECKSEQUENCEVERIFY DROP <pk1> CHECKSIGVERIFY ... <pkN> CHECKSIG`
+    CsvMultisig {
+        timelock: Sequence,
+        pubkeys: Vec<XOnlyPublicKey>,
+    },
+}
+
+impl ArkadeTapscript {
+    /// Serialise this tapscript to its canonical byte encoding.
+    pub fn encode(&self) -> Result<ScriptBuf, TapscriptError> {
+        match self {
+            Self::Multisig { pubkeys } => encode_multisig(pubkeys),
+            Self::CsvMultisig { timelock, pubkeys } => encode_csv_multisig(*timelock, pubkeys),
+        }
+    }
+
+    /// Return a new tapscript with `extra` keys appended to its pubkey set.
+    ///
+    /// Used by the arkade flow to tack tweaked introspector keys onto an
+    /// existing multisig leaf.
+    pub fn with_additional_pubkeys(&self, extra: impl IntoIterator<Item = XOnlyPublicKey>) -> Self {
+        match self {
+            Self::Multisig { pubkeys } => {
+                let mut pubkeys = pubkeys.clone();
+                pubkeys.extend(extra);
+                Self::Multisig { pubkeys }
+            }
+            Self::CsvMultisig { timelock, pubkeys } => {
+                let mut pubkeys = pubkeys.clone();
+                pubkeys.extend(extra);
+                Self::CsvMultisig {
+                    timelock: *timelock,
+                    pubkeys,
+                }
+            }
+        }
+    }
+
+    /// All signer pubkeys in this tapscript, in order.
+    pub fn pubkeys(&self) -> &[XOnlyPublicKey] {
+        match self {
+            Self::Multisig { pubkeys } | Self::CsvMultisig { pubkeys, .. } => pubkeys,
+        }
+    }
+}
+
+fn encode_multisig(pubkeys: &[XOnlyPublicKey]) -> Result<ScriptBuf, TapscriptError> {
+    if pubkeys.is_empty() {
+        return Err(TapscriptError::NoPubkeys);
+    }
+
+    let mut builder = Builder::new();
+    let last = pubkeys.len() - 1;
+    for (i, pk) in pubkeys.iter().enumerate() {
+        builder = builder.push_x_only_key(pk);
+        builder = if i == last {
+            builder.push_opcode(OP_CHECKSIG)
+        } else {
+            builder.push_opcode(OP_CHECKSIGVERIFY)
+        };
+    }
+    Ok(builder.into_script())
+}
+
+fn encode_csv_multisig(
+    timelock: Sequence,
+    pubkeys: &[XOnlyPublicKey],
+) -> Result<ScriptBuf, TapscriptError> {
+    let multisig = encode_multisig(pubkeys)?;
+
+    let prefix = Builder::new()
+        .push_int(timelock.to_consensus_u32() as i64)
+        .push_opcode(OP_CSV)
+        .push_opcode(OP_DROP)
+        .into_script();
+
+    let mut bytes = prefix.into_bytes();
+    bytes.extend_from_slice(multisig.as_bytes());
+    Ok(ScriptBuf::from_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pk(byte: u8) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    // Vectors from ts-sdk @ arkade-script-final:
+    // `MultisigTapscript.encode({ pubkeys }).script` and
+    // `CSVMultisigTapscript.encode({ timelock, pubkeys }).script`.
+    const MULTISIG_CHECKSIG_2: &str = concat!(
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ac",
+    );
+    const MULTISIG_CHECKSIG_3: &str = concat!(
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ad",
+        "20",
+        "0707070707070707070707070707070707070707070707070707070707070707",
+        "ac",
+    );
+    const CSV_BLOCKS_5120: &str = concat!(
+        "020014",
+        "b2",
+        "75",
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ac",
+    );
+    const CSV_SECONDS_512: &str = concat!(
+        "03010040",
+        "b2",
+        "75",
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ac",
+    );
+    const CSV_BLOCKS_10_SINGLE: &str = concat!(
+        "5a",
+        "b2",
+        "75",
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ac",
+    );
+
+    #[test]
+    fn multisig_two_pubkeys_matches_ts() {
+        let script = ArkadeTapscript::Multisig {
+            pubkeys: vec![pk(0x01), pk(0x02)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(hex::encode(script.as_bytes()), MULTISIG_CHECKSIG_2);
+    }
+
+    #[test]
+    fn multisig_three_pubkeys_matches_ts() {
+        let script = ArkadeTapscript::Multisig {
+            pubkeys: vec![pk(0x01), pk(0x02), pk(0x07)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(hex::encode(script.as_bytes()), MULTISIG_CHECKSIG_3);
+    }
+
+    #[test]
+    fn multisig_single_pubkey_uses_checksig_only() {
+        let script = ArkadeTapscript::Multisig {
+            pubkeys: vec![pk(0x01)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(
+            hex::encode(script.as_bytes()),
+            concat!(
+                "20",
+                "0101010101010101010101010101010101010101010101010101010101010101",
+                "ac"
+            )
+        );
+    }
+
+    #[test]
+    fn multisig_empty_pubkeys_errors() {
+        let err = ArkadeTapscript::Multisig { pubkeys: vec![] }
+            .encode()
+            .unwrap_err();
+        assert!(matches!(err, TapscriptError::NoPubkeys));
+    }
+
+    #[test]
+    fn csv_blocks_matches_ts() {
+        let script = ArkadeTapscript::CsvMultisig {
+            timelock: Sequence::from_height(5120),
+            pubkeys: vec![pk(0x01), pk(0x02)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(hex::encode(script.as_bytes()), CSV_BLOCKS_5120);
+    }
+
+    #[test]
+    fn csv_seconds_matches_ts() {
+        let script = ArkadeTapscript::CsvMultisig {
+            timelock: Sequence::from_seconds_floor(512).unwrap(),
+            pubkeys: vec![pk(0x01), pk(0x02)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(hex::encode(script.as_bytes()), CSV_SECONDS_512);
+    }
+
+    #[test]
+    fn csv_small_block_count_uses_pushnum_matches_ts() {
+        let script = ArkadeTapscript::CsvMultisig {
+            timelock: Sequence::from_height(10),
+            pubkeys: vec![pk(0x01)],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(hex::encode(script.as_bytes()), CSV_BLOCKS_10_SINGLE);
+    }
+
+    #[test]
+    fn with_additional_pubkeys_appends() {
+        let base = ArkadeTapscript::Multisig {
+            pubkeys: vec![pk(0x01), pk(0x02)],
+        };
+        let augmented = base.with_additional_pubkeys([pk(0x07)]);
+        let pubkeys = augmented.pubkeys();
+        assert_eq!(pubkeys.len(), 3);
+        assert_eq!(pubkeys[2], pk(0x07));
+    }
+
+    #[test]
+    fn with_additional_pubkeys_preserves_timelock() {
+        let base = ArkadeTapscript::CsvMultisig {
+            timelock: Sequence::from_height(100),
+            pubkeys: vec![pk(0x01)],
+        };
+        let augmented = base.with_additional_pubkeys([pk(0x02)]);
+        match augmented {
+            ArkadeTapscript::CsvMultisig { timelock, pubkeys } => {
+                assert_eq!(timelock, Sequence::from_height(100));
+                assert_eq!(pubkeys.len(), 2);
+            }
+            _ => panic!("expected CsvMultisig"),
+        }
+    }
+}

--- a/ark-script/src/tweak.rs
+++ b/ark-script/src/tweak.rs
@@ -1,0 +1,207 @@
+//! Arkade script key tweaking.
+//!
+//! The introspector co-signing service binds a base public key `P` to an
+//! arkade script by deriving
+//!
+//! ```text
+//! P' = P + taggedHash("ArkScriptHash", script) * G
+//! ```
+//!
+//! This is **not** BIP-341 taproot tweaking — it is a plain elliptic-curve
+//! point addition. The input `P` is an x-only public key (even-Y is
+//! enforced, matching the introspector's Go implementation which
+//! round-trips through `schnorr.SerializePubKey`).
+
+use bitcoin::hashes::sha256t_hash_newtype;
+use bitcoin::hashes::Hash;
+use bitcoin::key::Parity;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::Scalar;
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::Script;
+use bitcoin::XOnlyPublicKey;
+
+sha256t_hash_newtype! {
+    pub struct ArkScriptHashTag = hash_str("ArkScriptHash");
+
+    /// BIP-340 tagged hash of an arkade script, used to tweak introspector
+    /// public keys.
+    #[hash_newtype(forward)]
+    pub struct ArkadeScriptHash(_);
+
+    pub struct ArkWitnessHashTag = hash_str("ArkWitnessHash");
+
+    /// BIP-340 tagged hash of an arkade witness.
+    #[hash_newtype(forward)]
+    pub struct ArkadeWitnessHash(_);
+}
+
+/// Errors returned by [`compute_arkade_script_public_key`].
+#[derive(Debug, thiserror::Error)]
+pub enum TweakError {
+    #[error("arkade script hash is zero")]
+    ZeroHash,
+    #[error("arkade script hash is greater than or equal to the curve order")]
+    HashOutOfRange,
+    #[error("tweak resulted in the point at infinity")]
+    Identity,
+}
+
+/// BIP-340 tagged hash of an arkade script with tag `"ArkScriptHash"`.
+pub fn arkade_script_hash(script: &Script) -> [u8; 32] {
+    ArkadeScriptHash::hash(script.as_bytes()).to_byte_array()
+}
+
+/// BIP-340 tagged hash of an arkade witness with tag `"ArkWitnessHash"`.
+///
+/// Returns all zeros for an empty witness, matching the Go introspector's
+/// sentinel for "no witness".
+pub fn arkade_witness_hash(witness: &[u8]) -> [u8; 32] {
+    if witness.is_empty() {
+        return [0u8; 32];
+    }
+    ArkadeWitnessHash::hash(witness).to_byte_array()
+}
+
+/// Compute the introspector-bound public key for an arkade script:
+///
+/// ```text
+/// P' = P + ArkScriptHash(script) * G
+/// ```
+///
+/// `P` is x-only so even-Y is enforced on both inputs and output.
+///
+/// The hash is interpreted as a big-endian scalar. The astronomically
+/// unlikely pathological cases (`hash == 0`, `hash >= n`, or `P' == ∞`) all
+/// surface as errors rather than silently substituting another value, so
+/// the result either matches the TS implementation exactly or fails
+/// visibly.
+pub fn compute_arkade_script_public_key(
+    pubkey: &XOnlyPublicKey,
+    script: &Script,
+) -> Result<XOnlyPublicKey, TweakError> {
+    let secp = Secp256k1::verification_only();
+
+    let hash = arkade_script_hash(script);
+    let scalar = Scalar::from_be_bytes(hash).map_err(|_| TweakError::HashOutOfRange)?;
+    if scalar == Scalar::ZERO {
+        return Err(TweakError::ZeroHash);
+    }
+
+    let base = PublicKey::from_x_only_public_key(*pubkey, Parity::Even);
+    let tweaked = base
+        .add_exp_tweak(&secp, &scalar)
+        .map_err(|_| TweakError::Identity)?;
+
+    Ok(tweaked.x_only_public_key().0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::ScriptBuf;
+
+    // Vectors generated with @noble/curves/secp256k1 matching the TS
+    // implementation at ts-sdk/src/arkade/tweak.ts on branch
+    // arkade-script-final.
+    const SCRIPT_00AC: &str = "00ac";
+    const SCRIPT_P2PKH: &str = "76a9141234567890abcdef1234567890abcdef1234567888ac";
+
+    const EXPECTED_SCRIPT_HASH_00AC: &str =
+        "daaf1b35c7f10014d37ef3c977a713de7ccb70a79df1e5fd875f453a5fe5ab40";
+    const EXPECTED_SCRIPT_HASH_P2PKH: &str =
+        "98f61ad1b41b1774de27ae8729815fb924094c697493d5a7ac188b47ab6c42ae";
+    const EXPECTED_WITNESS_HASH_010203: &str =
+        "de2847a382fb70acc89784a30206854f2d698bfaab5ba18d8b1af907d3bd6ea7";
+
+    // x-coordinate of secp256k1 generator point G.
+    const GEN_X: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const ONES_32: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+    const EXPECTED_TWEAK_G_00AC: &str =
+        "fda5affba44d470c8f0975c685cb27e5d3aabb41fbeace50dfac741d5fdc5fd8";
+    const EXPECTED_TWEAK_G_P2PKH: &str =
+        "7663e8781d6e04bad4d277234e2223d3702e0a78dcd1ec24d0e06302aec1d0d5";
+    const EXPECTED_TWEAK_ONES_00AC: &str =
+        "d088cce863079f12d66b64b265dc36bfb6429ecf0962877d94a4df85061e2bf6";
+
+    fn decode_hex(s: &str) -> Vec<u8> {
+        hex::decode(s).unwrap()
+    }
+
+    fn script(hex_bytes: &str) -> ScriptBuf {
+        ScriptBuf::from_bytes(decode_hex(hex_bytes))
+    }
+
+    fn xonly(hex_bytes: &str) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_slice(&decode_hex(hex_bytes)).unwrap()
+    }
+
+    #[test]
+    fn script_hash_matches_ts_vector() {
+        assert_eq!(
+            hex::encode(arkade_script_hash(&script(SCRIPT_00AC))),
+            EXPECTED_SCRIPT_HASH_00AC
+        );
+        assert_eq!(
+            hex::encode(arkade_script_hash(&script(SCRIPT_P2PKH))),
+            EXPECTED_SCRIPT_HASH_P2PKH
+        );
+    }
+
+    #[test]
+    fn witness_hash_empty_is_zero() {
+        assert_eq!(arkade_witness_hash(&[]), [0u8; 32]);
+    }
+
+    #[test]
+    fn witness_hash_matches_ts_vector() {
+        assert_eq!(
+            hex::encode(arkade_witness_hash(&[0x01, 0x02, 0x03])),
+            EXPECTED_WITNESS_HASH_010203
+        );
+    }
+
+    #[test]
+    fn witness_hash_differs_between_inputs() {
+        let a = arkade_witness_hash(&[0x01]);
+        let b = arkade_witness_hash(&[0x02]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn witness_hash_differs_from_script_hash_for_same_bytes() {
+        let data = [0x01u8, 0x02, 0x03];
+        let sh = arkade_script_hash(Script::from_bytes(&data));
+        let wh = arkade_witness_hash(&data);
+        assert_ne!(sh, wh);
+    }
+
+    #[test]
+    fn tweak_matches_ts_vector_generator_short_script() {
+        let tweaked =
+            compute_arkade_script_public_key(&xonly(GEN_X), &script(SCRIPT_00AC)).unwrap();
+        assert_eq!(hex::encode(tweaked.serialize()), EXPECTED_TWEAK_G_00AC);
+    }
+
+    #[test]
+    fn tweak_matches_ts_vector_generator_p2pkh() {
+        let tweaked =
+            compute_arkade_script_public_key(&xonly(GEN_X), &script(SCRIPT_P2PKH)).unwrap();
+        assert_eq!(hex::encode(tweaked.serialize()), EXPECTED_TWEAK_G_P2PKH);
+    }
+
+    #[test]
+    fn tweak_matches_ts_vector_non_generator() {
+        let tweaked =
+            compute_arkade_script_public_key(&xonly(ONES_32), &script(SCRIPT_00AC)).unwrap();
+        assert_eq!(hex::encode(tweaked.serialize()), EXPECTED_TWEAK_ONES_00AC);
+    }
+
+    #[test]
+    fn tweak_is_deterministic() {
+        let a = compute_arkade_script_public_key(&xonly(GEN_X), &script(SCRIPT_00AC)).unwrap();
+        let b = compute_arkade_script_public_key(&xonly(GEN_X), &script(SCRIPT_00AC)).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/ark-script/src/vtxo_script.rs
+++ b/ark-script/src/vtxo_script.rs
@@ -1,0 +1,237 @@
+//! Processing arkade-enhanced taproot leaves.
+//!
+//! [`ArkadeVtxoScript::new`] takes a mix of plain taproot leaves and
+//! [`ArkadeLeaf`]s; for every arkade leaf it derives a tweaked key per
+//! introspector (`P' = P + ArkScriptHash(script)·G`), appends those keys
+//! to the leaf's pubkey set, and re-encodes. The result is a flat script
+//! list ready for [`bitcoin::taproot::TaprootBuilder`] plus a map of which
+//! leaf carries which arkade script (needed later for PSBT signing).
+
+use crate::tapscript::ArkadeTapscript;
+use crate::tapscript::TapscriptError;
+use crate::tweak::compute_arkade_script_public_key;
+use crate::tweak::TweakError;
+use bitcoin::ScriptBuf;
+use bitcoin::XOnlyPublicKey;
+use std::collections::BTreeMap;
+
+/// Errors produced while processing arkade VTXO inputs.
+#[derive(Debug, thiserror::Error)]
+pub enum VtxoScriptError {
+    #[error(transparent)]
+    Tapscript(#[from] TapscriptError),
+    #[error(transparent)]
+    Tweak(#[from] TweakError),
+}
+
+/// An arkade-enhanced taproot leaf: a base [`ArkadeTapscript`] whose
+/// pubkey set will be extended with one tweaked key per introspector,
+/// each derived from `arkade_script`.
+#[derive(Debug, Clone)]
+pub struct ArkadeLeaf {
+    pub arkade_script: ScriptBuf,
+    pub tapscript: ArkadeTapscript,
+    pub introspectors: Vec<XOnlyPublicKey>,
+}
+
+/// Input to [`ArkadeVtxoScript::new`]: either a plain pre-built leaf
+/// script (passed through unchanged) or an [`ArkadeLeaf`].
+#[derive(Debug, Clone)]
+pub enum ArkadeVtxoInput {
+    Plain(ScriptBuf),
+    Arkade(ArkadeLeaf),
+}
+
+/// Output of arkade leaf processing.
+///
+/// - `scripts` — the final taproot leaf scripts, in input order.
+/// - `arkade_scripts` — for each leaf that came from an [`ArkadeLeaf`], the arkade script bytes
+///   keyed by leaf index. Plain leaves are absent from the map.
+#[derive(Debug, Clone)]
+pub struct ArkadeVtxoScript {
+    pub scripts: Vec<ScriptBuf>,
+    pub arkade_scripts: BTreeMap<usize, ScriptBuf>,
+}
+
+impl ArkadeVtxoScript {
+    pub fn new(inputs: Vec<ArkadeVtxoInput>) -> Result<Self, VtxoScriptError> {
+        let mut scripts = Vec::with_capacity(inputs.len());
+        let mut arkade_scripts = BTreeMap::new();
+
+        for input in inputs {
+            let leaf_index = scripts.len();
+            match input {
+                ArkadeVtxoInput::Plain(script) => scripts.push(script),
+                ArkadeVtxoInput::Arkade(leaf) => {
+                    let tweaked_keys = leaf
+                        .introspectors
+                        .iter()
+                        .map(|pk| compute_arkade_script_public_key(pk, &leaf.arkade_script))
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    let augmented = leaf.tapscript.with_additional_pubkeys(tweaked_keys);
+                    scripts.push(augmented.encode()?);
+                    arkade_scripts.insert(leaf_index, leaf.arkade_script);
+                }
+            }
+        }
+
+        Ok(Self {
+            scripts,
+            arkade_scripts,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::Sequence;
+
+    // TS-derived vectors. The introspector is the secp256k1 generator G as
+    // x-only. The arkade script is `OP_0 OP_INSPECTOUTPUTSCRIPTPUBKEY OP_1
+    // OP_EQUALVERIFY <32 bytes 0xaa> OP_EQUAL`.
+    const ARKADE_SCRIPT_HEX: &str =
+        "00d1518820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa87";
+    const INTRO_X_ONLY: &str = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const EXPECTED_TWEAKED: &str =
+        "a463e01f08ea4cb75a1b0756c3f06004985195db2c429bfd05e08b73be2aad85";
+
+    const EXPECTED_LEAF_0: &str = concat!(
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ad",
+        "20",
+        "a463e01f08ea4cb75a1b0756c3f06004985195db2c429bfd05e08b73be2aad85",
+        "ac",
+    );
+    const EXPECTED_LEAF_1: &str = concat!(
+        "020014",
+        "b2",
+        "75",
+        "20",
+        "0101010101010101010101010101010101010101010101010101010101010101",
+        "ad",
+        "20",
+        "0202020202020202020202020202020202020202020202020202020202020202",
+        "ac",
+    );
+
+    fn pk(byte: u8) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_slice(&[byte; 32]).unwrap()
+    }
+
+    fn xonly(hex_str: &str) -> XOnlyPublicKey {
+        XOnlyPublicKey::from_slice(&hex::decode(hex_str).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn mixed_arkade_and_plain_matches_ts() {
+        let arkade_script = ScriptBuf::from_bytes(hex::decode(ARKADE_SCRIPT_HEX).unwrap());
+        let plain_csv = ScriptBuf::from_bytes(hex::decode(EXPECTED_LEAF_1).unwrap());
+
+        let result = ArkadeVtxoScript::new(vec![
+            ArkadeVtxoInput::Arkade(ArkadeLeaf {
+                arkade_script: arkade_script.clone(),
+                tapscript: ArkadeTapscript::Multisig {
+                    pubkeys: vec![pk(0x01), pk(0x02)],
+                },
+                introspectors: vec![xonly(INTRO_X_ONLY)],
+            }),
+            ArkadeVtxoInput::Plain(plain_csv),
+        ])
+        .unwrap();
+
+        assert_eq!(result.scripts.len(), 2);
+        assert_eq!(hex::encode(result.scripts[0].as_bytes()), EXPECTED_LEAF_0);
+        assert_eq!(hex::encode(result.scripts[1].as_bytes()), EXPECTED_LEAF_1);
+
+        // Arkade script is recorded for leaf 0 only.
+        assert_eq!(result.arkade_scripts.len(), 1);
+        assert_eq!(result.arkade_scripts.get(&0), Some(&arkade_script));
+        assert!(!result.arkade_scripts.contains_key(&1));
+    }
+
+    #[test]
+    fn tweak_appears_in_encoded_leaf() {
+        // Sanity-check that the tweak we compute matches the TS vector, since
+        // the leaf-0 assertion depends on it.
+        let arkade_script = ScriptBuf::from_bytes(hex::decode(ARKADE_SCRIPT_HEX).unwrap());
+        let tweaked =
+            compute_arkade_script_public_key(&xonly(INTRO_X_ONLY), &arkade_script).unwrap();
+        assert_eq!(hex::encode(tweaked.serialize()), EXPECTED_TWEAKED);
+    }
+
+    #[test]
+    fn plain_only_input_passes_through() {
+        let plain = ScriptBuf::from_bytes(hex::decode(EXPECTED_LEAF_1).unwrap());
+        let result = ArkadeVtxoScript::new(vec![ArkadeVtxoInput::Plain(plain.clone())]).unwrap();
+        assert_eq!(result.scripts, vec![plain]);
+        assert!(result.arkade_scripts.is_empty());
+    }
+
+    #[test]
+    fn arkade_csv_leaf_appends_tweaked_key() {
+        // ArkadeLeaf whose base tapscript is a CSV multisig — the tweaked
+        // introspector key is appended alongside the existing signers.
+        let arkade_script = ScriptBuf::from_bytes(hex::decode(ARKADE_SCRIPT_HEX).unwrap());
+
+        let result = ArkadeVtxoScript::new(vec![ArkadeVtxoInput::Arkade(ArkadeLeaf {
+            arkade_script: arkade_script.clone(),
+            tapscript: ArkadeTapscript::CsvMultisig {
+                timelock: Sequence::from_height(100),
+                pubkeys: vec![pk(0x01)],
+            },
+            introspectors: vec![xonly(INTRO_X_ONLY)],
+        })])
+        .unwrap();
+
+        // Expect: <seq=100> CSV DROP <pk(0x01)> CHECKSIGVERIFY <tweaked> CHECKSIG.
+        // push_int(100) in bitcoin emits a 1-byte ScriptNum push (0x01 0x64).
+        let expected = concat!(
+            "01",
+            "64", // push 1 byte: 0x64 = 100
+            "b2",
+            "75", // CSV DROP
+            "20",
+            "0101010101010101010101010101010101010101010101010101010101010101",
+            "ad",
+            "20",
+            "a463e01f08ea4cb75a1b0756c3f06004985195db2c429bfd05e08b73be2aad85",
+            "ac",
+        );
+        assert_eq!(hex::encode(result.scripts[0].as_bytes()), expected);
+        assert_eq!(result.arkade_scripts.get(&0), Some(&arkade_script));
+    }
+
+    #[test]
+    fn multiple_arkade_leaves_all_recorded() {
+        let ark1 = ScriptBuf::from_bytes(hex::decode(ARKADE_SCRIPT_HEX).unwrap());
+        let ark2 = ScriptBuf::from_bytes(hex::decode("51").unwrap()); // trivial OP_1
+
+        let result = ArkadeVtxoScript::new(vec![
+            ArkadeVtxoInput::Arkade(ArkadeLeaf {
+                arkade_script: ark1.clone(),
+                tapscript: ArkadeTapscript::Multisig {
+                    pubkeys: vec![pk(0x01)],
+                },
+                introspectors: vec![xonly(INTRO_X_ONLY)],
+            }),
+            ArkadeVtxoInput::Arkade(ArkadeLeaf {
+                arkade_script: ark2.clone(),
+                tapscript: ArkadeTapscript::Multisig {
+                    pubkeys: vec![pk(0x02)],
+                },
+                introspectors: vec![xonly(INTRO_X_ONLY)],
+            }),
+        ])
+        .unwrap();
+
+        assert_eq!(result.arkade_scripts.len(), 2);
+        assert_eq!(result.arkade_scripts.get(&0), Some(&ark1));
+        assert_eq!(result.arkade_scripts.get(&1), Some(&ark2));
+    }
+}

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -14,7 +14,9 @@ ark-client = { path = "../ark-client", features = ["test-utils"] }
 ark-core = { path = "../ark-core" }
 ark-delegator = { path = "../ark-delegator" }
 ark-grpc = { path = "../ark-grpc", features = ["test-utils"] }
+ark-introspector-client = { path = "../ark-introspector-client" }
 ark-rest = { path = "../ark-rest" }
+ark-script = { path = "../ark-script" }
 async-stream = "0.3"
 bdk_esplora = "0.19.0"
 bdk_wallet = "1.0.0-beta.5"

--- a/e2e-tests/tests/e2e_arkade_script.rs
+++ b/e2e-tests/tests/e2e_arkade_script.rs
@@ -81,6 +81,7 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
     let custom_owner_pk = custom_owner_kp.public_key().x_only_public_key().0;
     let arkd_pk = server_info.signer_pk.x_only_public_key().0;
 
+    let (alice_offchain_address, _) = alice.get_offchain_address().unwrap();
     let (bob_address, _) = bob.get_offchain_address().unwrap();
     let receiver_amount = Amount::from_sat(100_000);
     let expected_receiver_script = bob_address.to_p2tr_script_pubkey();
@@ -144,50 +145,38 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
         custom_vtxo_outpoint.assets.clone(),
     );
 
-    let offchain = build_offchain_transactions(
-        &[SendReceiver::bitcoin(bob_address, receiver_amount)],
-        &custom_vtxo.to_ark_address(),
-        &[custom_input],
+    let (invalid_ark_tx, invalid_checkpoint_txs) = build_signed_submit_txs(
+        &secp,
+        &custom_owner_kp,
+        custom_owner_pk,
+        &custom_vtxo,
+        &custom_input,
         &server_info,
-    )
-    .unwrap();
+        alice_offchain_address,
+        receiver_amount,
+        &arkade_script,
+    );
 
-    let mut ark_tx = offchain.ark_tx;
-    let mut checkpoint_txs = offchain.checkpoint_txs;
+    let err = introspector
+        .submit_tx(&invalid_ark_tx, &invalid_checkpoint_txs)
+        .await
+        .unwrap_err();
+    tracing::info!(error = %err, "invalid arkade spend to alice was rejected as expected");
 
-    add_packet_to_psbt(
-        &mut ark_tx,
-        &Packet::new(vec![IntrospectorEntry {
-            vin: 0,
-            script: arkade_script,
-            witness: Witness::default(),
-        }])
-        .unwrap(),
-    )
-    .unwrap();
+    let bob_balance = bob.offchain_balance().await.unwrap();
+    assert_eq!(bob_balance.total(), Amount::ZERO);
 
-    sign_ark_transaction(
-        |_,
-         msg: secp256k1::Message|
-         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
-            let sig = secp.sign_schnorr_no_aux_rand(&msg, &custom_owner_kp);
-            Ok(vec![(sig, custom_owner_pk)])
-        },
-        &mut ark_tx,
-        0,
-    )
-    .unwrap();
-
-    sign_checkpoint_transaction(
-        |_,
-         msg: secp256k1::Message|
-         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
-            let sig = secp.sign_schnorr_no_aux_rand(&msg, &custom_owner_kp);
-            Ok(vec![(sig, custom_owner_pk)])
-        },
-        &mut checkpoint_txs[0],
-    )
-    .unwrap();
+    let (ark_tx, checkpoint_txs) = build_signed_submit_txs(
+        &secp,
+        &custom_owner_kp,
+        custom_owner_pk,
+        &custom_vtxo,
+        &custom_input,
+        &server_info,
+        bob_address,
+        receiver_amount,
+        &arkade_script,
+    );
 
     let response = introspector
         .submit_tx(&ark_tx, &checkpoint_txs)
@@ -206,6 +195,65 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     wait_until_balance!(&bob, confirmed: receiver_amount, pre_confirmed: Amount::ZERO);
+}
+
+fn build_signed_submit_txs(
+    secp: &Secp256k1<secp256k1::All>,
+    custom_owner_kp: &Keypair,
+    custom_owner_pk: bitcoin::XOnlyPublicKey,
+    custom_vtxo: &Vtxo,
+    custom_input: &VtxoInput,
+    server_info: &ark_core::server::Info,
+    recipient: ark_core::ArkAddress,
+    amount: Amount,
+    arkade_script: &ScriptBuf,
+) -> (bitcoin::Psbt, Vec<bitcoin::Psbt>) {
+    let offchain = build_offchain_transactions(
+        &[SendReceiver::bitcoin(recipient, amount)],
+        &custom_vtxo.to_ark_address(),
+        std::slice::from_ref(custom_input),
+        server_info,
+    )
+    .unwrap();
+
+    let mut ark_tx = offchain.ark_tx;
+    let mut checkpoint_txs = offchain.checkpoint_txs;
+
+    add_packet_to_psbt(
+        &mut ark_tx,
+        &Packet::new(vec![IntrospectorEntry {
+            vin: 0,
+            script: arkade_script.clone(),
+            witness: Witness::default(),
+        }])
+        .unwrap(),
+    )
+    .unwrap();
+
+    sign_ark_transaction(
+        |_,
+         msg: secp256k1::Message|
+         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
+            let sig = secp.sign_schnorr_no_aux_rand(&msg, custom_owner_kp);
+            Ok(vec![(sig, custom_owner_pk)])
+        },
+        &mut ark_tx,
+        0,
+    )
+    .unwrap();
+
+    sign_checkpoint_transaction(
+        |_,
+         msg: secp256k1::Message|
+         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
+            let sig = secp.sign_schnorr_no_aux_rand(&msg, custom_owner_kp);
+            Ok(vec![(sig, custom_owner_pk)])
+        },
+        &mut checkpoint_txs[0],
+    )
+    .unwrap();
+
+    (ark_tx, checkpoint_txs)
 }
 
 async fn wait_for_vtxo(

--- a/e2e-tests/tests/e2e_arkade_script.rs
+++ b/e2e-tests/tests/e2e_arkade_script.rs
@@ -1,0 +1,235 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use ark_core::introspector::packet::add_packet_to_psbt;
+use ark_core::introspector::packet::IntrospectorEntry;
+use ark_core::introspector::packet::Packet;
+use ark_core::script::csv_sig_script;
+use ark_core::send::build_offchain_transactions;
+use ark_core::send::sign_ark_transaction;
+use ark_core::send::sign_checkpoint_transaction;
+use ark_core::send::SendReceiver;
+use ark_core::send::VtxoInput;
+use ark_core::server::GetVtxosRequest;
+use ark_core::Vtxo;
+use ark_core::VtxoList;
+use ark_introspector_client::IntrospectorClient;
+use ark_script::opcodes::op;
+use ark_script::ArkadeLeaf;
+use ark_script::ArkadeTapscript;
+use ark_script::ArkadeVtxoInput;
+use ark_script::ArkadeVtxoScript;
+use bitcoin::key::Keypair;
+use bitcoin::key::Secp256k1;
+use bitcoin::opcodes::all::OP_EQUAL;
+use bitcoin::opcodes::all::OP_EQUALVERIFY;
+use bitcoin::opcodes::all::OP_PUSHNUM_1;
+use bitcoin::script::PushBytesBuf;
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::schnorr;
+use bitcoin::Amount;
+use bitcoin::ScriptBuf;
+use bitcoin::Witness;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use rand::thread_rng;
+use std::sync::Arc;
+use std::time::Duration;
+
+mod common;
+
+#[tokio::test]
+#[ignore]
+pub async fn e2e_arkade_script_submit_tx_to_bob() {
+    init_tracing();
+
+    let nigiri = Arc::new(Nigiri::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+    let (bob, _) = set_up_client("bob".to_string(), nigiri.clone(), secp.clone()).await;
+
+    let mut grpc_client = ark_grpc::Client::new("http://localhost:7070".to_string());
+    grpc_client.connect().await.unwrap();
+    let server_info = grpc_client.get_info().await.unwrap();
+
+    let introspector_url =
+        std::env::var("INTROSPECTOR_URL").unwrap_or_else(|_| "http://127.0.0.1:7073".to_string());
+    let introspector = IntrospectorClient::new(introspector_url.clone());
+    let introspector_info = introspector.get_info().await.unwrap();
+    let introspector_pk = introspector_info.signer_xonly();
+
+    tracing::info!(
+        introspector_url,
+        introspector_signer = %introspector_pk,
+        arkd_signer = %server_info.signer_pk,
+        "connected to arkd and introspector"
+    );
+
+    let fund_amount = Amount::ONE_BTC;
+    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    nigiri
+        .faucet_fund(&alice_boarding_address, fund_amount)
+        .await;
+
+    alice.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let custom_owner_kp = Keypair::new(&secp, &mut rng);
+    let custom_owner_pk = custom_owner_kp.public_key().x_only_public_key().0;
+    let arkd_pk = server_info.signer_pk.x_only_public_key().0;
+
+    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let receiver_amount = Amount::from_sat(100_000);
+    let expected_receiver_script = bob_address.to_p2tr_script_pubkey();
+    let expected_receiver_program = &expected_receiver_script.as_bytes()[2..];
+
+    let arkade_script = ScriptBuf::builder()
+        .push_int(0)
+        .push_opcode(op::INSPECTOUTPUTSCRIPTPUBKEY)
+        .push_opcode(OP_PUSHNUM_1)
+        .push_opcode(OP_EQUALVERIFY)
+        .push_slice(PushBytesBuf::try_from(expected_receiver_program.to_vec()).unwrap())
+        .push_opcode(OP_EQUAL)
+        .into_script();
+
+    let arkade_vtxo_script = ArkadeVtxoScript::new(vec![
+        ArkadeVtxoInput::Arkade(ArkadeLeaf {
+            arkade_script: arkade_script.clone(),
+            tapscript: ArkadeTapscript::Multisig {
+                pubkeys: vec![custom_owner_pk, arkd_pk],
+            },
+            introspectors: vec![introspector_pk],
+        }),
+        ArkadeVtxoInput::Plain(csv_sig_script(
+            server_info.unilateral_exit_delay,
+            custom_owner_pk,
+        )),
+    ])
+    .unwrap();
+
+    let spend_script = arkade_vtxo_script.scripts[0].clone();
+    let custom_vtxo = Vtxo::new_with_custom_scripts(
+        &secp,
+        arkd_pk,
+        custom_owner_pk,
+        arkade_vtxo_script.scripts,
+        server_info.unilateral_exit_delay,
+        server_info.network,
+    )
+    .unwrap();
+
+    let funding_txid = alice
+        .send(vec![SendReceiver::bitcoin(
+            custom_vtxo.to_ark_address(),
+            receiver_amount,
+        )])
+        .await
+        .unwrap();
+
+    tracing::info!(%funding_txid, "funded custom arkade vtxo");
+
+    let custom_vtxo_outpoint = wait_for_vtxo(&grpc_client, &custom_vtxo, server_info.dust).await;
+    let control_block = custom_vtxo.get_spend_info(spend_script.clone()).unwrap();
+    let custom_input = VtxoInput::new(
+        spend_script,
+        None,
+        control_block,
+        custom_vtxo.tapscripts(),
+        custom_vtxo.script_pubkey(),
+        custom_vtxo_outpoint.amount,
+        custom_vtxo_outpoint.outpoint,
+        custom_vtxo_outpoint.assets.clone(),
+    );
+
+    let offchain = build_offchain_transactions(
+        &[SendReceiver::bitcoin(bob_address, receiver_amount)],
+        &custom_vtxo.to_ark_address(),
+        &[custom_input],
+        &server_info,
+    )
+    .unwrap();
+
+    let mut ark_tx = offchain.ark_tx;
+    let mut checkpoint_txs = offchain.checkpoint_txs;
+
+    add_packet_to_psbt(
+        &mut ark_tx,
+        &Packet::new(vec![IntrospectorEntry {
+            vin: 0,
+            script: arkade_script,
+            witness: Witness::default(),
+        }])
+        .unwrap(),
+    )
+    .unwrap();
+
+    sign_ark_transaction(
+        |_,
+         msg: secp256k1::Message|
+         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
+            let sig = secp.sign_schnorr_no_aux_rand(&msg, &custom_owner_kp);
+            Ok(vec![(sig, custom_owner_pk)])
+        },
+        &mut ark_tx,
+        0,
+    )
+    .unwrap();
+
+    sign_checkpoint_transaction(
+        |_,
+         msg: secp256k1::Message|
+         -> Result<Vec<(schnorr::Signature, bitcoin::XOnlyPublicKey)>, ark_core::Error> {
+            let sig = secp.sign_schnorr_no_aux_rand(&msg, &custom_owner_kp);
+            Ok(vec![(sig, custom_owner_pk)])
+        },
+        &mut checkpoint_txs[0],
+    )
+    .unwrap();
+
+    let response = introspector
+        .submit_tx(&ark_tx, &checkpoint_txs)
+        .await
+        .unwrap();
+
+    tracing::info!(
+        ark_txid = %response.signed_ark_tx.unsigned_tx.compute_txid(),
+        checkpoints = response.signed_checkpoint_txs.len(),
+        "submitted arkade transaction to introspector"
+    );
+
+    wait_until_balance!(&bob, pre_confirmed: receiver_amount);
+
+    bob.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    wait_until_balance!(&bob, confirmed: receiver_amount, pre_confirmed: Amount::ZERO);
+}
+
+async fn wait_for_vtxo(
+    grpc_client: &ark_grpc::Client,
+    vtxo: &Vtxo,
+    dust: Amount,
+) -> ark_core::server::VirtualTxOutPoint {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let response = grpc_client
+                .list_vtxos(GetVtxosRequest::new_for_addresses(std::iter::once(
+                    vtxo.to_ark_address(),
+                )))
+                .await
+                .unwrap();
+
+            let list = VtxoList::new(dust, response.vtxos);
+            if let Some(vtxo_outpoint) = list.spendable_offchain().next().cloned() {
+                return vtxo_outpoint;
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .unwrap()
+}

--- a/justfile
+++ b/justfile
@@ -5,6 +5,10 @@ arkd_wallet_port := "6060"
 arkd_wallet_url := "http://localhost:" + arkd_wallet_port
 arkd_logs := "$PWD/arkd.log"
 arkd_wallet_logs := "$PWD/arkd-wallet.log"
+introspector_port := "7073"
+introspector_url := "http://127.0.0.1:" + introspector_port
+introspector_logs := "$PWD/introspector.log"
+introspector_container := "introspector"
 
 mod ark-rest
 mod nix
@@ -248,6 +252,92 @@ arkd-wallet-kill:
     fi
     [ ! -e "{{ arkd_wallet_logs }}" ] || mv -f {{ arkd_wallet_logs }} {{ arkd_wallet_logs }}.old
 
+# Checkout introspector (https://github.com/ArkLabsHQ/introspector) in a local directory.
+[positional-arguments]
+introspector-checkout tag:
+    #!/usr/bin/env bash
+
+    set -euxo pipefail
+
+    mkdir -p $INTROSPECTOR_GO_DIR
+    cd $INTROSPECTOR_GO_DIR
+
+    CHANGES_STASHED=false
+
+    if [ -d "introspector" ]; then
+        cd introspector
+
+        if ! git diff --quiet || ! git diff --staged --quiet; then
+            git stash push -m "Automated stash before update"
+            CHANGES_STASHED=true
+        fi
+
+        git fetch --all
+    else
+        git clone https://github.com/ArkLabsHQ/introspector.git
+        cd introspector
+    fi
+
+    if [ ! -z "$1" ]; then
+        git checkout $1
+    else
+        git checkout master
+    fi
+
+    if [ "$CHANGES_STASHED" = true ]; then
+        git stash pop
+    fi
+
+# Pull the introspector docker image.
+introspector-docker-pull:
+    #!/usr/bin/env bash
+
+    set -euxo pipefail
+
+    image="${INTROSPECTOR_IMAGE:-ghcr.io/arklabshq/introspector:latest}"
+    docker pull "$image"
+
+# Run introspector in docker against host arkd.
+introspector-docker-run:
+    #!/usr/bin/env bash
+
+    set -euxo pipefail
+
+    image="${INTROSPECTOR_IMAGE:-ghcr.io/arklabshq/introspector:latest}"
+
+    if ! docker image inspect "$image" > /dev/null 2>&1; then
+        echo "Docker image $image not found locally, pulling it first"
+        docker pull "$image"
+    fi
+
+    docker rm -f {{ introspector_container }} || true
+
+    docker run -d \
+        --name {{ introspector_container }} \
+        --network nigiri \
+        --add-host=host.docker.internal:host-gateway \
+        -p {{ introspector_port }}:7073 \
+        -e INTROSPECTOR_SECRET_KEY=5646b2e23bbb82491fb4ef262079ff17594d5e873fc6bcea5f1453edbe1029b1 \
+        -e INTROSPECTOR_NO_TLS=true \
+        -e INTROSPECTOR_ARKD_URL=host.docker.internal:7070 \
+        -e INTROSPECTOR_LOG_LEVEL=6 \
+        "$image"
+
+    just _wait-for-http {{ introspector_url }}/v1/info 60
+    docker logs {{ introspector_container }} &> {{ introspector_logs }} || true
+
+# Pull and run introspector in docker.
+introspector-docker-setup:
+    just introspector-docker-pull
+    just introspector-docker-run
+
+# Stop introspector docker container and save logs.
+introspector-docker-kill:
+    #!/usr/bin/env bash
+
+    docker logs {{ introspector_container }} &> {{ introspector_logs }} || true
+    docker rm -f {{ introspector_container }} && echo "Stopped introspector" || echo "introspector not running, skipped"
+
 # Wipe docker containers set up from the `arkd` repo.
 docker-wipe:
     @echo Stopping arkd-related docker containers
@@ -300,6 +390,31 @@ _wait-until-arkd-is-initialized:
 
     echo "arkd wallet was not initialized in time"
 
+    exit 1
+
+# Wait for an HTTP endpoint to become available.
+
+# Usage: just _wait-for-http url timeout_seconds
+[positional-arguments]
+_wait-for-http url timeout:
+    #!/usr/bin/env bash
+
+    set -euo pipefail
+
+    URL="${1}"
+    TIMEOUT="${2}"
+
+    echo "Waiting for HTTP endpoint '${URL}' (timeout: ${TIMEOUT}s)..."
+
+    for ((i=0; i<${TIMEOUT}; i+=1)); do
+      if curl -fsS "${URL}" > /dev/null; then
+        echo "HTTP endpoint '${URL}' is ready!"
+        exit 0
+      fi
+      sleep 1
+    done
+
+    echo "HTTP endpoint '${URL}' was not ready within ${TIMEOUT} seconds"
     exit 1
 
 # Wait for a specific log pattern in a docker container
@@ -385,7 +500,7 @@ e2e-tests:
 # Restart e2e test environment (arkd master) and run all e2e tests.
 e2e-full:
     @echo running integration tests
-    nigiri stop --delete && just arkd-kill arkd-wipe arkd-wallet-kill arkd-wallet-wipe docker-wipe
+    nigiri stop --delete && just arkd-kill arkd-wipe arkd-wallet-kill arkd-wallet-wipe introspector-docker-kill docker-wipe
     nigiri start
     sleep 1
     just arkd-build

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ arkd_wallet_logs := "$PWD/arkd-wallet.log"
 introspector_port := "7073"
 introspector_url := "http://127.0.0.1:" + introspector_port
 introspector_logs := "$PWD/introspector.log"
+introspector_image := "ark-rs-introspector:local"
 introspector_container := "introspector"
 
 mod ark-rest
@@ -288,6 +289,14 @@ introspector-checkout tag:
         git stash pop
     fi
 
+# Build the introspector docker image from source.
+introspector-docker-build:
+    #!/usr/bin/env bash
+
+    set -euxo pipefail
+
+    docker build -t {{ introspector_image }} "$INTROSPECTOR_DIR"
+
 # Pull the introspector docker image.
 introspector-docker-pull:
     #!/usr/bin/env bash
@@ -303,11 +312,12 @@ introspector-docker-run:
 
     set -euxo pipefail
 
-    image="${INTROSPECTOR_IMAGE:-ghcr.io/arklabshq/introspector:latest}"
+    image="${INTROSPECTOR_IMAGE:-{{ introspector_image }}}"
 
     if ! docker image inspect "$image" > /dev/null 2>&1; then
-        echo "Docker image $image not found locally, pulling it first"
-        docker pull "$image"
+        echo "Docker image $image not found locally"
+        echo "Build it with 'just introspector-docker-build' or set INTROSPECTOR_IMAGE to a pulled image"
+        exit 1
     fi
 
     docker rm -f {{ introspector_container }} || true
@@ -326,9 +336,11 @@ introspector-docker-run:
     just _wait-for-http {{ introspector_url }}/v1/info 60
     docker logs {{ introspector_container }} &> {{ introspector_logs }} || true
 
-# Pull and run introspector in docker.
-introspector-docker-setup:
-    just introspector-docker-pull
+# Build and run introspector in docker from source.
+[positional-arguments]
+introspector-docker-setup tag='master':
+    just introspector-checkout {{ tag }}
+    just introspector-docker-build
     just introspector-docker-run
 
 # Stop introspector docker container and save logs.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Arkade script support with custom opcodes, tapscript encoding, and BIP-340 public-key tweaking for script validation
  * Introspector service client library for transaction and intent submission
  * End-to-end tests for Arkade script spending workflows

* **Infrastructure**
  * Docker integration for introspector service in development environment
  * Updated CI/CD workflows to support introspector versioning
  * New environment variables for introspector configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->