### PR TITLE
feat!: expose invoice metadata on ReverseSwapData

### DIFF
--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -1119,6 +1119,8 @@ where
             timeout_block_heights: response.timeout_block_heights,
             created_at: created_at.as_secs(),
             key_derivation_index,
+            bolt11: response.invoice.to_string(),
+            invoice_expiry: response.invoice.expiry_time().as_secs(),
         };
 
         self.swap_storage()
@@ -1230,6 +1232,8 @@ where
             timeout_block_heights: response.timeout_block_heights,
             created_at: created_at.as_secs(),
             key_derivation_index,
+            bolt11: response.invoice.to_string(),
+            invoice_expiry: response.invoice.expiry_time().as_secs(),
         };
 
         self.swap_storage()
@@ -3858,6 +3862,10 @@ pub struct ReverseSwapData {
     /// `None` for legacy swap data created before this field was added.
     #[serde(default)]
     pub key_derivation_index: Option<u32>,
+    /// BOLT11 invoice string for this swap.
+    pub bolt11: String,
+    /// Invoice expiry in seconds, derived from the BOLT11 invoice itself.
+    pub invoice_expiry: u64,
 }
 
 /// All possible states of a Boltz swap.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -67,6 +67,7 @@ pub use boltz::PendingVhtlcSpendType;
 pub use boltz::ReverseSwapData;
 pub use boltz::SubmarineSwapData;
 pub use boltz::SwapAmount;
+pub use boltz::SwapStatus;
 pub use boltz::SwapStatusInfo;
 pub use boltz::SwapType;
 pub use boltz::TimeoutBlockHeights;

--- a/ark-client/src/swap_storage/sqlite.rs
+++ b/ark-client/src/swap_storage/sqlite.rs
@@ -538,6 +538,8 @@ mod tests {
             },
             created_at: 1234567890,
             key_derivation_index: None,
+            bolt11: "lnbc100u1ptest".to_string(),
+            invoice_expiry: 3600,
         }
     }
 


### PR DESCRIPTION
Persist the BOLT11 invoice string and requested invoice expiry on ReverseSwapData so consumers can list, display, and monitor pending reverse swaps across app restarts without maintaining a parallel metadata store.

Also re-export SwapStatus at the crate root so callers can inspect the persisted status without reaching into the private boltz module.

BREAKING CHANGE: ReverseSwapData gained a required `bolt11: String` field and an `invoice_expiry: Option<u64>` field. Callers constructing the struct directly must populate both.

Imho it's better to have a breaking change now than having option<string> for the reset of our lives :D 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated reverse-swap invoice persistence so invoices are stored in a consistent serialized form and invoice expiry is always recorded.

* **Exports**
  * Re-exported swap status type for downstream use.

* **Tests**
  * Updated test helpers to reflect the new invoice and expiry storage fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->