### PR TITLE
Update `arkd-version` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arkd-version: [ 'v0.9.2' ]
+        arkd-version: [ 'v0.9.4' ]
     uses: ./.github/workflows/e2e-core.yml
     with:
       arkd-version: ${{ matrix.arkd-version }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         arkd-version: [
           'master',
-          'v0.9.2'
+          'v0.9.4'
           # Add more versions as needed
         ]
 

--- a/e2e-tests/tests/dlc_common/mod.rs
+++ b/e2e-tests/tests/dlc_common/mod.rs
@@ -114,11 +114,14 @@ pub async fn run_dlc_scenario(nigiri: &Nigiri, run_refund_scenario: bool) -> Res
     // the oracle attests to the outcome of a relevant event, but _before_ the batch ends. Thus,
     // choosing the timelock correctly is very important.
     //
-    // Use a locktime a couple of blocks behind the current tip so the refund path is already
-    // spendable on-chain. Not realistic for production, but proves the contract's refund path
-    // works end-to-end.
-    let current_height = nigiri.get_height();
-    let refund_locktime = bitcoin::absolute::LockTime::from_height(current_height - 2)?;
+    // Use a locktime some minutes behind the current time so the refund path is already spendable
+    // on-chain. Not realistic for production, but proves the contract's refund path works
+    // end-to-end.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("valid duration")
+        .as_secs() as u32;
+    let refund_locktime = bitcoin::absolute::LockTime::from_time(now - 3600)?;
     let dlc_refund_script = ScriptBuf::builder()
         .push_int(refund_locktime.to_consensus_u32() as i64)
         .push_opcode(OP_CLTV)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/E2E test workflows to use arkd v0.9.4 instead of v0.9.2.

* **Tests**
  * Modified DLC refund timelock computation methodology in end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->