### PR TITLE
Support BOLT12 offers for submarine swaps

### DIFF
--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -23,7 +23,8 @@ bech32 = "0.11"
 bitcoin = { version = "0.32.7", features = ["rand", "serde"] }
 futures = "0.3.31"
 jiff = "0.2.1"
-lightning-invoice = { version = "0.33.2", features = ["serde"] }
+lightning = "0.2.2"
+lightning-invoice = { version = "0.34.0", features = ["serde"] }
 musig = { package = "secp256k1", version = "0.32.0-beta.2", features = ["serde"] }
 prost = "0.13.3"
 prost-types = "0.13.3"

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -3907,7 +3907,7 @@ pub struct SubmarineSwapData {
     pub id: String,
     /// Preimage for the swap (learned when Boltz claims the VHTLC).
     pub preimage: Option<[u8; 32]>,
-    /// The preimage hash of the BOLT11 invoice.
+    /// The preimage hash of the associated Lightning invoice (BOLT11 or BOLT12).
     pub preimage_hash: ripemd160::Hash,
     /// Public key of the receiving party.
     pub claim_public_key: PublicKey,

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -318,6 +318,22 @@ where
             .map_err(Error::ad_hoc)
             .context("failed to compute created_at")?;
 
+        let vhtlc = self
+            .build_vhtlc_script(
+                swap_response.claim_public_key,
+                refund_public_key.into(),
+                preimage_hash,
+                &swap_response.timeout_block_heights,
+            )
+            .context("failed to build Boltz VHTLC script")?;
+        let expected_vhtlc_address = vhtlc.address();
+        if expected_vhtlc_address != swap_response.address {
+            return Err(Error::ad_hoc(format!(
+                "Boltz VHTLC address ({}) does not match VHTLC parameters ({expected_vhtlc_address})",
+                swap_response.address
+            )));
+        }
+
         let data = SubmarineSwapData {
             id: swap_response.id.clone(),
             status: SwapStatus::Created,
@@ -413,6 +429,22 @@ where
             .duration_since(UNIX_EPOCH)
             .map_err(Error::ad_hoc)
             .context("failed to compute created_at")?;
+
+        let vhtlc = self
+            .build_vhtlc_script(
+                swap_response.claim_public_key,
+                refund_public_key.into(),
+                preimage_hash,
+                &swap_response.timeout_block_heights,
+            )
+            .context("failed to build Boltz VHTLC script")?;
+        let expected_vhtlc_address = vhtlc.address();
+        if expected_vhtlc_address != swap_response.address {
+            return Err(Error::ad_hoc(format!(
+                "Boltz VHTLC address ({}) does not match VHTLC parameters ({expected_vhtlc_address})",
+                swap_response.address
+            )));
+        }
 
         self.swap_storage()
             .insert_submarine(

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -178,6 +178,13 @@ pub struct SubmarineSwapResult {
     pub amount: Amount,
 }
 
+pub(crate) struct CreateSubmarineSwapParams {
+    pub(crate) invoice: LnInvoice,
+    pub(crate) refund_public_key: PublicKey,
+    pub(crate) key_derivation_index: Option<u32>,
+    pub(crate) preimage_hash: ripemd160::Hash,
+}
+
 #[derive(Clone, Debug)]
 pub struct ReverseSwapResult {
     pub swap_id: String,
@@ -247,38 +254,15 @@ where
 {
     // Submarine swap.
 
-    /// Prepare the payment of a BOLT11 invoice by setting up a submarine swap via Boltz.
-    ///
-    /// This function does not execute the payment itself. Once you are ready for payment you
-    /// will have to send the required `amount` to the `vhtlc_address`.
-    ///
-    /// If you are looking for a function which pays the invoice immediately, consider using
-    /// [`Client::pay_ln_invoice`] instead.
-    ///
-    /// # Arguments
-    ///
-    /// - `invoice`: a [`Bolt11Invoice`] to be paid.
-    ///
-    /// # Returns
-    ///
-    /// - A [`SubmarineSwapData`] object, including an identifier for the swap.
-    pub async fn prepare_ln_invoice_payment(
+    pub(crate) async fn create_submarine_swap(
         &self,
-        invoice: Bolt11Invoice,
+        params: CreateSubmarineSwapParams,
     ) -> Result<SubmarineSwapData, Error> {
-        let refund_keypair = self.next_keypair(crate::key_provider::KeypairIndex::New)?;
-        let refund_public_key = refund_keypair.public_key();
-        let key_derivation_index =
-            self.derivation_index_for_pk(&refund_keypair.x_only_public_key().0);
-
-        let preimage_hash = invoice.payment_hash();
-        let preimage_hash = ripemd160::Hash::hash(preimage_hash.as_byte_array());
-
         let request = CreateSubmarineSwapRequest {
             from: Asset::Ark,
             to: Asset::Btc,
-            invoice,
-            refund_public_key: refund_public_key.into(),
+            invoice: params.invoice.to_string(),
+            refund_public_key: params.refund_public_key,
             referral_id: self.inner.boltz_referral_id.clone(),
         };
         let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
@@ -321,8 +305,8 @@ where
         let vhtlc = self
             .build_vhtlc_script(
                 swap_response.claim_public_key,
-                refund_public_key.into(),
-                preimage_hash,
+                params.refund_public_key,
+                params.preimage_hash,
                 &swap_response.timeout_block_heights,
             )
             .context("failed to build Boltz VHTLC script")?;
@@ -338,23 +322,62 @@ where
             id: swap_response.id.clone(),
             status: SwapStatus::Created,
             preimage: None,
-            preimage_hash,
-            refund_public_key: refund_public_key.into(),
+            preimage_hash: params.preimage_hash,
+            refund_public_key: params.refund_public_key,
             claim_public_key: swap_response.claim_public_key,
             vhtlc_address: swap_response.address,
             timeout_block_heights: swap_response.timeout_block_heights,
             amount: swap_response.expected_amount,
-            invoice: LnInvoice::Bolt11(request.invoice.clone()),
+            invoice: params.invoice,
             created_at: created_at.as_secs(),
-            key_derivation_index,
+            key_derivation_index: params.key_derivation_index,
         };
 
         self.swap_storage()
             .insert_submarine(swap_response.id.clone(), data.clone())
             .await?;
 
+        Ok(data)
+    }
+
+    /// Prepare the payment of a BOLT11 invoice by setting up a submarine swap via Boltz.
+    ///
+    /// This function does not execute the payment itself. Once you are ready for payment you
+    /// will have to send the required `amount` to the `vhtlc_address`.
+    ///
+    /// If you are looking for a function which pays the invoice immediately, consider using
+    /// [`Client::pay_ln_invoice`] instead.
+    ///
+    /// # Arguments
+    ///
+    /// - `invoice`: a [`Bolt11Invoice`] to be paid.
+    ///
+    /// # Returns
+    ///
+    /// - A [`SubmarineSwapData`] object, including an identifier for the swap.
+    pub async fn prepare_ln_invoice_payment(
+        &self,
+        invoice: Bolt11Invoice,
+    ) -> Result<SubmarineSwapData, Error> {
+        let refund_keypair = self.next_keypair(crate::key_provider::KeypairIndex::New)?;
+        let refund_public_key = refund_keypair.public_key();
+        let key_derivation_index =
+            self.derivation_index_for_pk(&refund_keypair.x_only_public_key().0);
+
+        let preimage_hash = invoice.payment_hash();
+        let preimage_hash = ripemd160::Hash::hash(preimage_hash.as_byte_array());
+
+        let data = self
+            .create_submarine_swap(CreateSubmarineSwapParams {
+                invoice: LnInvoice::Bolt11(invoice),
+                refund_public_key: refund_public_key.into(),
+                key_derivation_index,
+                preimage_hash,
+            })
+            .await?;
+
         tracing::info!(
-            swap_id = swap_response.id,
+            swap_id = data.id,
             vhtlc_address = %data.vhtlc_address,
             expected_amount = %data.amount,
             "Prepared Lightning invoice payment"
@@ -386,97 +409,26 @@ where
         let preimage_hash = invoice.payment_hash();
         let preimage_hash = ripemd160::Hash::hash(preimage_hash.as_byte_array());
 
-        let request = CreateSubmarineSwapRequest {
-            from: Asset::Ark,
-            to: Asset::Btc,
-            invoice,
-            refund_public_key: refund_public_key.into(),
-            referral_id: self.inner.boltz_referral_id.clone(),
-        };
-        let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
-
-        let client = reqwest::Client::builder()
-            .timeout(self.inner.timeout)
-            .build()
-            .map_err(|e| Error::ad_hoc(e.to_string()))?;
-        let response = client
-            .post(&url)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| Error::ad_hoc(e.to_string()))
-            .context("failed to send submarine swap request")?;
-
-        if !response.status().is_success() {
-            let error_text = response
-                .text()
-                .await
-                .map_err(|e| Error::ad_hoc(e.to_string()))
-                .context("failed to read error text")?;
-
-            return Err(Error::ad_hoc(format!(
-                "failed to create submarine swap: {error_text}"
-            )));
-        }
-
-        let swap_response: CreateSubmarineSwapResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::ad_hoc(e.to_string()))
-            .context("failed to deserialize submarine swap response")?;
-
-        let created_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(Error::ad_hoc)
-            .context("failed to compute created_at")?;
-
-        let vhtlc = self
-            .build_vhtlc_script(
-                swap_response.claim_public_key,
-                refund_public_key.into(),
+        let data = self
+            .create_submarine_swap(CreateSubmarineSwapParams {
+                invoice: LnInvoice::Bolt11(invoice),
+                refund_public_key: refund_public_key.into(),
+                key_derivation_index,
                 preimage_hash,
-                &swap_response.timeout_block_heights,
-            )
-            .context("failed to build Boltz VHTLC script")?;
-        let expected_vhtlc_address = vhtlc.address();
-        if expected_vhtlc_address != swap_response.address {
-            return Err(Error::ad_hoc(format!(
-                "Boltz VHTLC address ({}) does not match VHTLC parameters ({expected_vhtlc_address})",
-                swap_response.address
-            )));
-        }
-
-        self.swap_storage()
-            .insert_submarine(
-                swap_response.id.clone(),
-                SubmarineSwapData {
-                    id: swap_response.id.clone(),
-                    status: SwapStatus::Created,
-                    preimage: None,
-                    preimage_hash,
-                    refund_public_key: refund_public_key.into(),
-                    claim_public_key: swap_response.claim_public_key,
-                    vhtlc_address: swap_response.address,
-                    timeout_block_heights: swap_response.timeout_block_heights,
-                    amount: swap_response.expected_amount,
-                    invoice: LnInvoice::Bolt11(request.invoice.clone()),
-                    created_at: created_at.as_secs(),
-                    key_derivation_index,
-                },
-            )
+            })
             .await?;
 
-        let vhtlc_address = swap_response.address;
-        let amount = swap_response.expected_amount;
-
+        let vhtlc_address = data.vhtlc_address;
+        let amount = data.amount;
+        let swap_id = data.id;
         let txid = self
             .send(vec![SendReceiver::bitcoin(vhtlc_address, amount)])
             .await?;
 
-        tracing::info!(swap_id = swap_response.id, %amount, "Funded VHTLC");
+        tracing::info!(%swap_id, %amount, "Funded VHTLC");
 
         Ok(SubmarineSwapResult {
-            swap_id: swap_response.id,
+            swap_id,
             txid,
             amount,
         })
@@ -4148,7 +4100,7 @@ struct CreateReverseSwapResponse {
 struct CreateSubmarineSwapRequest {
     from: Asset,
     to: Asset,
-    invoice: Bolt11Invoice,
+    invoice: String,
     #[serde(rename = "refundPublicKey")]
     refund_public_key: PublicKey,
     #[serde(rename = "referralId", skip_serializing_if = "Option::is_none")]
@@ -4562,10 +4514,8 @@ mod tests {
         let request = CreateSubmarineSwapRequest {
             from: Asset::Ark,
             to: Asset::Btc,
-            invoice: Bolt11Invoice::from_str(
-                "lntbs10u1p5wmeeepp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp5ckaskagag554na8d56tlrfdxasstqrmmpkvswqqqx6y386jcfq9s9qxpqysgqt7z0vkdwkqamydae7ctgkh7l8q75w7q9394ce3lda2mkfxrpfdtj5gmltuctav7jdgatkflhztrjjzutdla5e4xp0uhxxy7sluzll4qpkkh6wv",
-            )
-            .unwrap(),
+            invoice: "lntbs10u1p5wmeeepp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp5ckaskagag554na8d56tlrfdxasstqrmmpkvswqqqx6y386jcfq9s9qxpqysgqt7z0vkdwkqamydae7ctgkh7l8q75w7q9394ce3lda2mkfxrpfdtj5gmltuctav7jdgatkflhztrjjzutdla5e4xp0uhxxy7sluzll4qpkkh6wv"
+                .to_string(),
             refund_public_key: PublicKey::from_str(
                 "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
             )
@@ -4582,10 +4532,8 @@ mod tests {
         let request = CreateSubmarineSwapRequest {
             from: Asset::Ark,
             to: Asset::Btc,
-            invoice: Bolt11Invoice::from_str(
-                "lntbs10u1p5wmeeepp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp5ckaskagag554na8d56tlrfdxasstqrmmpkvswqqqx6y386jcfq9s9qxpqysgqt7z0vkdwkqamydae7ctgkh7l8q75w7q9394ce3lda2mkfxrpfdtj5gmltuctav7jdgatkflhztrjjzutdla5e4xp0uhxxy7sluzll4qpkkh6wv",
-            )
-            .unwrap(),
+            invoice: "lntbs10u1p5wmeeepp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp5ckaskagag554na8d56tlrfdxasstqrmmpkvswqqqx6y386jcfq9s9qxpqysgqt7z0vkdwkqamydae7ctgkh7l8q75w7q9394ce3lda2mkfxrpfdtj5gmltuctav7jdgatkflhztrjjzutdla5e4xp0uhxxy7sluzll4qpkkh6wv"
+                .to_string(),
             refund_public_key: PublicKey::from_str(
                 "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
             )

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -134,10 +134,10 @@ impl<'de> Deserialize<'de> for LnInvoice {
 
 impl LnInvoice {
     /// Extract the SHA256 payment hash from the invoice.
-    pub fn payment_hash(&self) -> Result<sha256::Hash, Error> {
+    pub fn payment_hash(&self) -> sha256::Hash {
         match self {
-            LnInvoice::Bolt11(invoice) => Ok(*invoice.payment_hash()),
-            LnInvoice::Bolt12(invoice) => Ok(invoice.payment_hash()),
+            LnInvoice::Bolt11(invoice) => *invoice.payment_hash(),
+            LnInvoice::Bolt12(invoice) => invoice.payment_hash(),
         }
     }
 }

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -48,9 +48,15 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
+use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+
+mod bolt12;
+
+pub use bolt12::Bolt12SubmarineSwapResult;
+pub use bolt12::ParsedBolt12Invoice;
 
 /// Maximum byte length of a BOLT11 invoice description (`d` field).
 ///
@@ -81,14 +87,79 @@ pub enum SwapType {
     Unknown,
 }
 
-impl std::fmt::Display for SwapType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for SwapType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Submarine => write!(f, "submarine"),
             Self::Reverse => write!(f, "reverse"),
             Self::Chain => write!(f, "chain"),
             Self::Unknown => write!(f, "unknown"),
         }
+    }
+}
+
+/// A Lightning invoice, either BOLT11 or BOLT12.
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum LnInvoice {
+    /// A BOLT11 Lightning invoice.
+    Bolt11(Bolt11Invoice),
+    /// A BOLT12 Lightning invoice.
+    Bolt12(ParsedBolt12Invoice),
+}
+
+impl<'de> Deserialize<'de> for LnInvoice {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        let bolt11_err = match s.parse::<Bolt11Invoice>() {
+            Ok(invoice) => return Ok(LnInvoice::Bolt11(invoice)),
+            Err(e) => e,
+        };
+
+        let invoice = ParsedBolt12Invoice::parse(s).map_err(|bolt12_err| {
+            serde::de::Error::custom(format!(
+                "string could not be parsed as BOLT11 or BOLT12 invoice. \
+                 BOLT11 parse error: {bolt11_err}. \
+                 BOLT12 parse error: {bolt12_err}"
+            ))
+        })?;
+
+        Ok(LnInvoice::Bolt12(invoice))
+    }
+}
+
+impl LnInvoice {
+    /// Extract the SHA256 payment hash from the invoice.
+    pub fn payment_hash(&self) -> Result<sha256::Hash, Error> {
+        match self {
+            LnInvoice::Bolt11(invoice) => Ok(*invoice.payment_hash()),
+            LnInvoice::Bolt12(invoice) => Ok(invoice.payment_hash()),
+        }
+    }
+}
+
+impl fmt::Display for LnInvoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LnInvoice::Bolt11(invoice) => write!(f, "{invoice}"),
+            LnInvoice::Bolt12(invoice) => write!(f, "{invoice}"),
+        }
+    }
+}
+
+impl From<Bolt11Invoice> for LnInvoice {
+    fn from(invoice: Bolt11Invoice) -> Self {
+        LnInvoice::Bolt11(invoice)
+    }
+}
+
+impl From<ParsedBolt12Invoice> for LnInvoice {
+    fn from(invoice: ParsedBolt12Invoice) -> Self {
+        LnInvoice::Bolt12(invoice)
     }
 }
 
@@ -212,7 +283,10 @@ where
         };
         let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(self.inner.timeout)
+            .build()
+            .map_err(|e| Error::ad_hoc(e.to_string()))?;
         let response = client
             .post(&url)
             .json(&request)
@@ -254,7 +328,7 @@ where
             vhtlc_address: swap_response.address,
             timeout_block_heights: swap_response.timeout_block_heights,
             amount: swap_response.expected_amount,
-            invoice: request.invoice.clone(),
+            invoice: LnInvoice::Bolt11(request.invoice.clone()),
             created_at: created_at.as_secs(),
             key_derivation_index,
         };
@@ -305,7 +379,10 @@ where
         };
         let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(self.inner.timeout)
+            .build()
+            .map_err(|e| Error::ad_hoc(e.to_string()))?;
         let response = client
             .post(&url)
             .json(&request)
@@ -350,7 +427,7 @@ where
                     vhtlc_address: swap_response.address,
                     timeout_block_heights: swap_response.timeout_block_heights,
                     amount: swap_response.expected_amount,
-                    invoice: request.invoice.clone(),
+                    invoice: LnInvoice::Bolt11(request.invoice.clone()),
                     created_at: created_at.as_secs(),
                     key_derivation_index,
                 },
@@ -1820,7 +1897,7 @@ where
     ///
     /// Returns a [`ChainSwapResult`] containing the swap ID and the address the user must
     /// fund to initiate the swap. For [`ChainSwapDirection::ArkToBtc`], the user should send
-    /// Ark VTXOs to the `user_lockup_address` using [`Client::send_vtxo`]. For
+    /// Ark VTXOs to the `user_lockup_address` using [`Client::send`]. For
     /// [`ChainSwapDirection::BtcToArk`], the user should send BTC to the `user_lockup_address`.
     ///
     /// After funding, use [`Self::wait_for_chain_swap_server_lockup`] to wait for Boltz to
@@ -3859,8 +3936,8 @@ pub struct SubmarineSwapData {
     /// Address where funds are locked.
     #[serde_as(as = "DisplayFromStr")]
     pub vhtlc_address: ArkAddress,
-    /// BOLT11 invoice associated with the swap.
-    pub invoice: Bolt11Invoice,
+    /// Lightning invoice associated with the swap (BOLT11 or BOLT12).
+    pub invoice: LnInvoice,
     /// Current swap status.
     pub status: SwapStatus,
     /// UNIX timestamp when swap was created.
@@ -4344,6 +4421,29 @@ struct ChainSwapSideDetails {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_ln_invoice_serde_roundtrip_bolt11() {
+        let bolt11_str = "lntbs10u1p5wmeeepp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp5ckaskagag554na8d56tlrfdxasstqrmmpkvswqqqx6y386jcfq9s9qxpqysgqt7z0vkdwkqamydae7ctgkh7l8q75w7q9394ce3lda2mkfxrpfdtj5gmltuctav7jdgatkflhztrjjzutdla5e4xp0uhxxy7sluzll4qpkkh6wv";
+        let bolt11: Bolt11Invoice = bolt11_str.parse().unwrap();
+        let invoice = LnInvoice::Bolt11(bolt11);
+
+        let json = serde_json::to_string(&invoice).unwrap();
+        let deserialized: LnInvoice = serde_json::from_str(&json).unwrap();
+
+        match deserialized {
+            LnInvoice::Bolt11(inv) => assert_eq!(inv.to_string(), bolt11_str),
+            LnInvoice::Bolt12(_) => panic!("expected Bolt11 variant"),
+        }
+    }
+
+    #[test]
+    fn test_ln_invoice_deser_rejects_garbage() {
+        // Invalid strings that are neither valid BOLT11 nor BOLT12 should fail deserialization.
+        let garbage = r#""not-a-real-invoice""#;
+        let result: Result<LnInvoice, _> = serde_json::from_str(garbage);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_deserialize_create_reverse_swap_response() {

--- a/ark-client/src/boltz/bolt12.rs
+++ b/ark-client/src/boltz/bolt12.rs
@@ -120,9 +120,9 @@ where
     /// # Trust Model
     ///
     /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
-    /// is not locally verified against the offer's signing key. This is the same trust model as
-    /// BOLT11 submarine swaps, where the VHTLC address and claim keys are provided by Boltz. The
-    /// invoice is parsed locally, but its signature is not verified against the original offer.
+    /// is not locally verified against the offer's signing key. The invoice is parsed locally,
+    /// but its signature is not verified against the original offer. The returned VHTLC address
+    /// is verified against the VHTLC parameters before it is persisted or funded.
     ///
     /// # Arguments
     ///
@@ -155,9 +155,9 @@ where
     /// # Trust Model
     ///
     /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
-    /// is not locally verified against the offer's signing key. This is the same trust model as
-    /// BOLT11 submarine swaps, where the VHTLC address and claim keys are provided by Boltz. The
-    /// invoice is parsed locally, but its signature is not verified against the original offer.
+    /// is not locally verified against the offer's signing key. The invoice is parsed locally,
+    /// but its signature is not verified against the original offer. The returned VHTLC address
+    /// is verified against the VHTLC parameters before it is persisted or funded.
     ///
     /// # Arguments
     ///
@@ -251,6 +251,22 @@ where
             .duration_since(UNIX_EPOCH)
             .map_err(Error::ad_hoc)
             .context("failed to compute created_at")?;
+
+        let vhtlc = self
+            .build_vhtlc_script(
+                swap_response.claim_public_key,
+                refund_public_key.into(),
+                preimage_hash,
+                &swap_response.timeout_block_heights,
+            )
+            .context("failed to build Boltz VHTLC script")?;
+        let expected_vhtlc_address = vhtlc.address();
+        if expected_vhtlc_address != swap_response.address {
+            return Err(Error::ad_hoc(format!(
+                "Boltz VHTLC address ({}) does not match VHTLC parameters ({expected_vhtlc_address})",
+                swap_response.address
+            )));
+        }
 
         let data = SubmarineSwapData {
             id: swap_response.id.clone(),

--- a/ark-client/src/boltz/bolt12.rs
+++ b/ark-client/src/boltz/bolt12.rs
@@ -18,9 +18,11 @@ use bitcoin::Amount;
 use bitcoin::PublicKey;
 use bitcoin::Txid;
 use lightning::offers::invoice::Bolt12Invoice;
+use lightning::offers::offer::Offer;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
+use std::str::FromStr;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -120,9 +122,10 @@ where
     /// # Trust Model
     ///
     /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
-    /// is not locally verified against the offer's signing key. The invoice is parsed locally,
-    /// but its signature is not verified against the original offer. The returned VHTLC address
-    /// is verified against the VHTLC parameters before it is persisted or funded.
+    /// is locally verified against the offer: its signing public key must match the offer's
+    /// `issuer_signing_pubkey` (if set) or the final hop of one of the offer's blinded message
+    /// paths, and its `offer_id` (if present) must match the offer's identifier. The returned
+    /// VHTLC address is verified against the VHTLC parameters before it is persisted or funded.
     ///
     /// # Arguments
     ///
@@ -155,9 +158,10 @@ where
     /// # Trust Model
     ///
     /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
-    /// is not locally verified against the offer's signing key. The invoice is parsed locally,
-    /// but its signature is not verified against the original offer. The returned VHTLC address
-    /// is verified against the VHTLC parameters before it is persisted or funded.
+    /// is locally verified against the offer: its signing public key must match the offer's
+    /// `issuer_signing_pubkey` (if set) or the final hop of one of the offer's blinded message
+    /// paths, and its `offer_id` (if present) must match the offer's identifier. The returned
+    /// VHTLC address is verified against the VHTLC parameters before it is persisted or funded.
     ///
     /// # Arguments
     ///
@@ -295,11 +299,10 @@ where
     /// This calls `POST /v2/lightning/BTC/bolt12/fetch` to resolve a BOLT12 offer into an invoice
     /// that can be used to create a submarine swap.
     ///
-    /// # Security Note
-    ///
-    /// Callers that use the returned invoice outside of this SDK's submarine swap methods should
-    /// verify the invoice's signing key against the offer's signing key (or the public key of
-    /// the final hop in one of the offer's message paths).
+    /// The returned invoice is locally verified against the offer: the invoice's signing public key
+    /// must match the offer's `issuer_signing_pubkey` (if set) or the final hop of one of the
+    /// offer's blinded message paths, and the invoice's `offer_id` (if present) must match the
+    /// offer's identifier.
     ///
     /// # Arguments
     ///
@@ -355,10 +358,75 @@ where
         let invoice = ParsedBolt12Invoice::parse(response.invoice)
             .context("bolt12_fetch returned invalid BOLT12 invoice")?;
 
-        tracing::info!("Fetched BOLT12 invoice from offer");
+        // Verify the invoice matches the offer before using it.
+        verify_bolt12_invoice_against_offer(offer, &invoice)?;
+
+        tracing::info!("Fetched and verified BOLT12 invoice from offer");
 
         Ok(invoice)
     }
+}
+
+/// Verify that a BOLT12 invoice corresponds to the offer it claims to be for.
+///
+/// Checks:
+///
+/// 1. If the offer specifies an explicit `issuer_signing_pubkey`, the invoice's `signing_pubkey`
+///    must match it.
+/// 2. Otherwise, if the offer has blinded message paths, the invoice's `signing_pubkey` must match
+///    the `blinded_node_id` of the final hop in one of those paths.
+/// 3. If the invoice carries an `offer_id`, it must match the offer's own identifier.
+///
+/// This prevents a Boltz endpoint from returning an invoice for a different node than the
+/// one the user intended to pay — the central trust gap in the Boltz-resolves-offer flow.
+pub fn verify_bolt12_invoice_against_offer(
+    offer_str: &str,
+    invoice: &ParsedBolt12Invoice,
+) -> Result<(), Error> {
+    let offer = Offer::from_str(offer_str)
+        .map_err(|e| Error::ad_hoc(format!("invalid bolt12 offer: {e:?}")))?;
+    let invoice_signing_pk = invoice.invoice().signing_pubkey();
+
+    // Check 1: explicit issuer_signing_pubkey.
+    if let Some(issuer_pk) = offer.issuer_signing_pubkey() {
+        if invoice_signing_pk != issuer_pk {
+            return Err(Error::ad_hoc(format!(
+                "BOLT12 invoice signing pubkey ({invoice_signing_pk}) does not match \
+                 offer issuer_signing_pubkey ({issuer_pk})",
+            )));
+        }
+    } else {
+        // Check 2: offer has blinded paths — verify invoice signing key is the
+        // final hop in one of them.
+        let paths = offer.paths();
+        if !paths.is_empty() {
+            let matches = paths
+                .iter()
+                .filter_map(|path| path.blinded_hops().last())
+                .any(|last_hop| invoice_signing_pk == last_hop.blinded_node_id);
+            if !matches {
+                return Err(Error::ad_hoc(format!(
+                    "BOLT12 invoice signing pubkey ({invoice_signing_pk}) does not match \
+                     the final hop of any blinded message path in the offer",
+                )));
+            }
+        }
+        // If neither issuer_signing_pubkey nor paths are set, we cannot verify the
+        // invoice's signing key — the offer is unusually permissive. Accept it.
+    }
+
+    // Check 3: offer_id cross-check (if the invoice carries one).
+    if let Some(invoice_offer_id) = invoice.invoice().offer_id() {
+        if invoice_offer_id != offer.id() {
+            return Err(Error::ad_hoc(format!(
+                "BOLT12 invoice offer_id ({invoice_offer_id:?}) does not match \
+                 offer id ({:?})",
+                offer.id()
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 /// Request to the Boltz API to create a submarine swap with a string invoice (BOLT11 or BOLT12).

--- a/ark-client/src/boltz/bolt12.rs
+++ b/ark-client/src/boltz/bolt12.rs
@@ -1,0 +1,404 @@
+use crate::boltz::Asset;
+use crate::boltz::CreateSubmarineSwapResponse;
+use crate::error::ErrorContext;
+use crate::wallet::BoardingWallet;
+use crate::wallet::OnchainWallet;
+use crate::Blockchain;
+use crate::Client;
+use crate::Error;
+use crate::LnInvoice;
+use crate::SubmarineSwapData;
+use crate::SwapStatus;
+use crate::SwapStorage;
+use ark_core::send::SendReceiver;
+use bitcoin::hashes::ripemd160;
+use bitcoin::hashes::sha256;
+use bitcoin::hashes::Hash;
+use bitcoin::Amount;
+use bitcoin::PublicKey;
+use bitcoin::Txid;
+use lightning::offers::invoice::Bolt12Invoice;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+/// A BOLT12 invoice paired with its original encoded string.
+#[derive(Debug, Clone)]
+pub struct ParsedBolt12Invoice {
+    encoded: String,
+    invoice: Bolt12Invoice,
+}
+
+impl ParsedBolt12Invoice {
+    pub fn parse(encoded: impl Into<String>) -> Result<Self, Error> {
+        let encoded = encoded.into().trim().to_string();
+
+        let parsed =
+            bech32::primitives::decode::CheckedHrpstring::new::<bech32::NoChecksum>(&encoded)
+                .map_err(|e| Error::ad_hoc(format!("invalid bolt12 invoice encoding: {e}")))?;
+
+        if parsed.hrp().lowercase_char_iter().ne("lni".chars()) {
+            return Err(Error::ad_hoc(format!(
+                "expected bolt12 invoice with 'lni' prefix, got '{}'",
+                parsed.hrp()
+            )));
+        }
+
+        let data = parsed.byte_iter().collect::<Vec<_>>();
+        let invoice = Bolt12Invoice::try_from(data)
+            .map_err(|e| Error::ad_hoc(format!("invalid bolt12 invoice: {e:?}")))?;
+
+        Ok(Self { encoded, invoice })
+    }
+
+    pub fn encoded(&self) -> &str {
+        &self.encoded
+    }
+
+    pub fn invoice(&self) -> &Bolt12Invoice {
+        &self.invoice
+    }
+
+    pub fn payment_hash(&self) -> sha256::Hash {
+        sha256::Hash::from_byte_array(self.invoice.payment_hash().0)
+    }
+}
+
+impl Serialize for ParsedBolt12Invoice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.encoded)
+    }
+}
+
+impl<'de> Deserialize<'de> for ParsedBolt12Invoice {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        Self::parse(encoded).map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for ParsedBolt12Invoice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.encoded)
+    }
+}
+
+/// Result of a Bolt12 offer payment preparation.
+#[derive(Clone, Debug)]
+pub struct Bolt12SubmarineSwapResult {
+    pub swap_id: String,
+    pub txid: Txid,
+    pub amount: Amount,
+    /// The BOLT12 invoice fetched from the offer and used for this swap.
+    pub invoice: String,
+}
+
+impl<B, W, S, K> Client<B, W, S, K>
+where
+    B: Blockchain,
+    W: BoardingWallet + OnchainWallet,
+    S: SwapStorage + 'static,
+    K: crate::KeyProvider,
+{
+    /// Prepare the payment of a BOLT12 offer by fetching an invoice and setting up a submarine
+    /// swap via Boltz.
+    ///
+    /// This function does not execute the payment itself. Once you are ready for payment you
+    /// will have to send the required `amount` to the `vhtlc_address` in the returned swap data.
+    ///
+    /// If you are looking for a function which pays the offer immediately, consider using
+    /// [`Client::pay_bolt12_offer`] instead.
+    ///
+    /// # Trust Model
+    ///
+    /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
+    /// is not locally verified against the offer's signing key. This is the same trust model as
+    /// BOLT11 submarine swaps, where the VHTLC address and claim keys are provided by Boltz. The
+    /// invoice is parsed locally, but its signature is not verified against the original offer.
+    ///
+    /// # Arguments
+    ///
+    /// - `offer`: a BOLT12 offer string.
+    /// - `amount`: optional amount. Required if the offer does not specify an amount.
+    ///
+    /// # Returns
+    ///
+    /// - A [`SubmarineSwapData`] object, including an identifier for the swap.
+    pub async fn prepare_bolt12_offer_payment(
+        &self,
+        offer: &str,
+        amount: Option<Amount>,
+    ) -> Result<SubmarineSwapData, Error> {
+        let (data, _invoice_str) = self.create_bolt12_submarine_swap(offer, amount).await?;
+
+        tracing::info!(
+            swap_id = data.id,
+            vhtlc_address = %data.vhtlc_address,
+            expected_amount = %data.amount,
+            "Prepared BOLT12 offer payment"
+        );
+
+        Ok(data)
+    }
+
+    /// Pay a BOLT12 offer by performing a submarine swap via Boltz. This fetches the BOLT12
+    /// invoice from the offer, creates a submarine swap, and funds the VHTLC.
+    ///
+    /// # Trust Model
+    ///
+    /// This method fetches the BOLT12 invoice via the Boltz API (`bolt12_fetch`). The invoice
+    /// is not locally verified against the offer's signing key. This is the same trust model as
+    /// BOLT11 submarine swaps, where the VHTLC address and claim keys are provided by Boltz. The
+    /// invoice is parsed locally, but its signature is not verified against the original offer.
+    ///
+    /// # Arguments
+    ///
+    /// - `offer`: a BOLT12 offer string.
+    /// - `amount`: optional amount. Required if the offer does not specify an amount.
+    ///
+    /// # Returns
+    ///
+    /// - A [`Bolt12SubmarineSwapResult`], including an identifier for the swap and the TXID of the
+    ///   Ark transaction that funds the VHTLC.
+    pub async fn pay_bolt12_offer(
+        &self,
+        offer: &str,
+        amount: Option<Amount>,
+    ) -> Result<Bolt12SubmarineSwapResult, Error> {
+        let (data, invoice) = self.create_bolt12_submarine_swap(offer, amount).await?;
+
+        let vhtlc_address = data.vhtlc_address;
+        let amount = data.amount;
+        let swap_id = data.id;
+        let txid = self
+            .send(vec![SendReceiver::bitcoin(vhtlc_address, amount)])
+            .await?;
+
+        tracing::info!(%swap_id, %amount, "Funded VHTLC for BOLT12 offer");
+
+        Ok(Bolt12SubmarineSwapResult {
+            swap_id,
+            txid,
+            amount,
+            invoice: invoice.encoded().to_string(),
+        })
+    }
+
+    /// Shared setup for BOLT12 submarine swaps: fetch invoice, create swap, persist data.
+    async fn create_bolt12_submarine_swap(
+        &self,
+        offer: &str,
+        amount: Option<Amount>,
+    ) -> Result<(SubmarineSwapData, ParsedBolt12Invoice), Error> {
+        let invoice = self.fetch_bolt12_invoice(offer, amount).await?;
+
+        let payment_hash = invoice.payment_hash();
+        let preimage_hash = ripemd160::Hash::hash(payment_hash.as_byte_array());
+
+        let refund_keypair = self.next_keypair(crate::key_provider::KeypairIndex::New)?;
+        let refund_public_key = refund_keypair.public_key();
+        let key_derivation_index =
+            self.derivation_index_for_pk(&refund_keypair.x_only_public_key().0);
+
+        let request = CreateStringInvoiceSubmarineSwapRequest {
+            from: Asset::Ark,
+            to: Asset::Btc,
+            invoice: invoice.encoded().to_string(),
+            refund_public_key: refund_public_key.into(),
+            referral_id: self.inner.boltz_referral_id.clone(),
+        };
+        let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
+
+        let client = reqwest::Client::builder()
+            .timeout(self.inner.timeout)
+            .build()
+            .map_err(|e| Error::ad_hoc(e.to_string()))?;
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to send submarine swap request")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .map_err(|e| Error::ad_hoc(e.to_string()))
+                .context("failed to read error text")?;
+
+            return Err(Error::ad_hoc(format!(
+                "failed to create submarine swap: {error_text}"
+            )));
+        }
+
+        let swap_response: CreateSubmarineSwapResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to deserialize submarine swap response")?;
+
+        let created_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(Error::ad_hoc)
+            .context("failed to compute created_at")?;
+
+        let data = SubmarineSwapData {
+            id: swap_response.id.clone(),
+            status: SwapStatus::Created,
+            preimage: None,
+            preimage_hash,
+            refund_public_key: refund_public_key.into(),
+            claim_public_key: swap_response.claim_public_key,
+            vhtlc_address: swap_response.address,
+            timeout_block_heights: swap_response.timeout_block_heights,
+            amount: swap_response.expected_amount,
+            invoice: LnInvoice::Bolt12(invoice.clone()),
+            created_at: created_at.as_secs(),
+            key_derivation_index,
+        };
+
+        self.swap_storage()
+            .insert_submarine(swap_response.id.clone(), data.clone())
+            .await?;
+
+        Ok((data, invoice))
+    }
+
+    /// Fetch a BOLT12 invoice from an offer using the Boltz API.
+    ///
+    /// This calls `POST /v2/lightning/BTC/bolt12/fetch` to resolve a BOLT12 offer into an invoice
+    /// that can be used to create a submarine swap.
+    ///
+    /// # Security Note
+    ///
+    /// Callers that use the returned invoice outside of this SDK's submarine swap methods should
+    /// verify the invoice's signing key against the offer's signing key (or the public key of
+    /// the final hop in one of the offer's message paths).
+    ///
+    /// # Arguments
+    ///
+    /// - `offer`: a BOLT12 offer string (typically starts with `lno`).
+    /// - `amount`: optional amount. Required if the offer does not specify an amount.
+    ///
+    /// # Returns
+    ///
+    /// The BOLT12 invoice string (typically starts with `lni`).
+    async fn fetch_bolt12_invoice(
+        &self,
+        offer: &str,
+        amount: Option<Amount>,
+    ) -> Result<ParsedBolt12Invoice, Error> {
+        let request = Bolt12FetchInvoiceRequest {
+            offer: offer.to_string(),
+            amount: amount.map(|amount| amount.to_sat()),
+        };
+
+        let url = format!(
+            "{}/v2/lightning/BTC/bolt12/fetch",
+            self.inner.boltz_bolt12_url().trim_end_matches('/')
+        );
+        let client = reqwest::Client::builder()
+            .timeout(self.inner.timeout)
+            .build()
+            .map_err(|e| Error::ad_hoc(e.to_string()))?;
+        let response = client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to fetch bolt12 invoice from offer")?;
+
+        if !response.status().is_success() {
+            let error_text = response
+                .text()
+                .await
+                .map_err(|e| Error::ad_hoc(e.to_string()))
+                .context("failed to read bolt12_fetch error text")?;
+
+            return Err(Error::ad_hoc(format!(
+                "failed to fetch bolt12 invoice from offer: {error_text}"
+            )));
+        }
+
+        let response: Bolt12FetchInvoiceResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::ad_hoc(e.to_string()))
+            .context("failed to deserialize bolt12_fetch response")?;
+        let invoice = ParsedBolt12Invoice::parse(response.invoice)
+            .context("bolt12_fetch returned invalid BOLT12 invoice")?;
+
+        tracing::info!("Fetched BOLT12 invoice from offer");
+
+        Ok(invoice)
+    }
+}
+
+/// Request to the Boltz API to create a submarine swap with a string invoice (BOLT11 or BOLT12).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CreateStringInvoiceSubmarineSwapRequest {
+    from: Asset,
+    to: Asset,
+    invoice: String,
+    #[serde(rename = "refundPublicKey")]
+    refund_public_key: PublicKey,
+    #[serde(rename = "referralId", skip_serializing_if = "Option::is_none")]
+    referral_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Bolt12FetchInvoiceRequest {
+    offer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    amount: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Bolt12FetchInvoiceResponse {
+    invoice: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_BOLT12_INVOICE: &str = "lni1qqgyfz22nen8c8lf89xjzwcd4dd55q3qqc3xu3s3rg94nj40zfsy866mhu5vxne6tcej5878k2mneuvgjy8s5ytpwf4j6unnyppy7nz5xyezqefjv5gwuqmturepmkwfg3x5wqavcls4n563gjrfqh9rjkq336k7ctymg7saa5p547vcr3kax2ylxq0svfy5xym9fkw8tpr0ye9tlky0tddvc7f8jhqzqvh7r68ewg5gsnu9p0nja65vl7k0y9ymgg8lv5hkswq745rhs0s7cqpnxvlsgq65m7zhxpwj24nvq4wptz572erpcncv3csjv2ljrxl75cdrv3vlu256y45a3ntr4yxt8qak8n4v6gpev8qv5c7hszqxaece3hqpnsaej89fcqcf3hvn23jtyjffs88sxnsqxg0vzx6v54mq9xz3tufvyfj5nu4w9ut3nc83ulvxlltuypwt2qvujpmpqyasyrslctv267z2hdpd7kxumutzzq4w0hd2daakzvmkaxf29kkddcrx5nuxw6ccdwh2jpzvugesqc2l09gzqp3zderpzxstt8927ynqg044h0egcd8n5h3n9g0u0v4h8ncc3yg02gp3apyq2sq9sggrkavptf4xkaxr0y64s5v6rln7afe4lqzlgtqunfzj2qmedhka97c6pxqz4e7a4fhhkcfnwm5e9gk6e4hqv6j0semtrp46a2gyfn3rxqrptaus8w9rgyaa0kuutdn9nc2hhlnta5zkkkhmdn46ahrh9rwjkhquryyjqyptpkyl5fs5v6qka8v747nqhmuxadur3r5lgdsruhq6z4w64pq0hwsqxg68q4r8hnhzp3248m2py0h0a58ypqjkshj3mp0txuvahcyjrqm2cy4czqtk34y96hvhsv3lamy5s5za4k3pcqqqqqqqqqqqqqqq5qqqqqqqqqqqqqwjfvkl43fqqqqqqzjqg6s945d6sg9crdtxau5wsdcl9uze6wfg5ltdzaxnljwf45qwrr59m6qgxg0y0z4qx85yszhqxqsqqzczzq4w0hd2daakzvmkaxf29kkddcrx5nuxw6ccdwh2jpzvugesqc2l08cypufuzjvgwtk8zzns3cnap3hsy0dpdku8vfac7rjhh5tsuaff5476hwxu0unzn5q5u3pppfhwtr7fyyfjrmg7xyts6wgk4yne2leul4us";
+
+    #[test]
+    fn test_parse_bolt12_invoice_with_ldk() {
+        let invoice = ParsedBolt12Invoice::parse(VALID_BOLT12_INVOICE).unwrap();
+        assert_eq!(invoice.encoded(), VALID_BOLT12_INVOICE);
+        assert_ne!(invoice.payment_hash().as_byte_array(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn test_parse_bolt12_invoice_wrong_hrp() {
+        let invalid_invoice = VALID_BOLT12_INVOICE.replacen("lni", "lno", 1);
+        let err = ParsedBolt12Invoice::parse(invalid_invoice).unwrap_err();
+        assert!(err.to_string().contains("lni"));
+    }
+
+    #[test]
+    fn test_ln_invoice_serde_roundtrip_bolt12() {
+        let invoice = LnInvoice::Bolt12(ParsedBolt12Invoice::parse(VALID_BOLT12_INVOICE).unwrap());
+
+        let json = serde_json::to_string(&invoice).unwrap();
+        let deserialized: LnInvoice = serde_json::from_str(&json).unwrap();
+
+        match deserialized {
+            LnInvoice::Bolt12(invoice) => assert_eq!(invoice.encoded(), VALID_BOLT12_INVOICE),
+            LnInvoice::Bolt11(_) => panic!("expected Bolt12 variant"),
+        }
+    }
+}

--- a/ark-client/src/boltz/bolt12.rs
+++ b/ark-client/src/boltz/bolt12.rs
@@ -1,5 +1,4 @@
-use crate::boltz::Asset;
-use crate::boltz::CreateSubmarineSwapResponse;
+use crate::boltz::CreateSubmarineSwapParams;
 use crate::error::ErrorContext;
 use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
@@ -8,14 +7,12 @@ use crate::Client;
 use crate::Error;
 use crate::LnInvoice;
 use crate::SubmarineSwapData;
-use crate::SwapStatus;
 use crate::SwapStorage;
 use ark_core::send::SendReceiver;
 use bitcoin::hashes::ripemd160;
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::Amount;
-use bitcoin::PublicKey;
 use bitcoin::Txid;
 use lightning::offers::invoice::Bolt12Invoice;
 use lightning::offers::offer::Offer;
@@ -23,8 +20,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 /// A BOLT12 invoice paired with its original encoded string.
 #[derive(Debug, Clone)]
@@ -212,83 +207,13 @@ where
         let key_derivation_index =
             self.derivation_index_for_pk(&refund_keypair.x_only_public_key().0);
 
-        let request = CreateStringInvoiceSubmarineSwapRequest {
-            from: Asset::Ark,
-            to: Asset::Btc,
-            invoice: invoice.encoded().to_string(),
-            refund_public_key: refund_public_key.into(),
-            referral_id: self.inner.boltz_referral_id.clone(),
-        };
-        let url = format!("{}/v2/swap/submarine", self.inner.boltz_url);
-
-        let client = reqwest::Client::builder()
-            .timeout(self.inner.timeout)
-            .build()
-            .map_err(|e| Error::ad_hoc(e.to_string()))?;
-        let response = client
-            .post(&url)
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| Error::ad_hoc(e.to_string()))
-            .context("failed to send submarine swap request")?;
-
-        if !response.status().is_success() {
-            let error_text = response
-                .text()
-                .await
-                .map_err(|e| Error::ad_hoc(e.to_string()))
-                .context("failed to read error text")?;
-
-            return Err(Error::ad_hoc(format!(
-                "failed to create submarine swap: {error_text}"
-            )));
-        }
-
-        let swap_response: CreateSubmarineSwapResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::ad_hoc(e.to_string()))
-            .context("failed to deserialize submarine swap response")?;
-
-        let created_at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(Error::ad_hoc)
-            .context("failed to compute created_at")?;
-
-        let vhtlc = self
-            .build_vhtlc_script(
-                swap_response.claim_public_key,
-                refund_public_key.into(),
+        let data = self
+            .create_submarine_swap(CreateSubmarineSwapParams {
+                invoice: LnInvoice::Bolt12(invoice.clone()),
+                refund_public_key: refund_public_key.into(),
+                key_derivation_index,
                 preimage_hash,
-                &swap_response.timeout_block_heights,
-            )
-            .context("failed to build Boltz VHTLC script")?;
-        let expected_vhtlc_address = vhtlc.address();
-        if expected_vhtlc_address != swap_response.address {
-            return Err(Error::ad_hoc(format!(
-                "Boltz VHTLC address ({}) does not match VHTLC parameters ({expected_vhtlc_address})",
-                swap_response.address
-            )));
-        }
-
-        let data = SubmarineSwapData {
-            id: swap_response.id.clone(),
-            status: SwapStatus::Created,
-            preimage: None,
-            preimage_hash,
-            refund_public_key: refund_public_key.into(),
-            claim_public_key: swap_response.claim_public_key,
-            vhtlc_address: swap_response.address,
-            timeout_block_heights: swap_response.timeout_block_heights,
-            amount: swap_response.expected_amount,
-            invoice: LnInvoice::Bolt12(invoice.clone()),
-            created_at: created_at.as_secs(),
-            key_derivation_index,
-        };
-
-        self.swap_storage()
-            .insert_submarine(swap_response.id.clone(), data.clone())
+            })
             .await?;
 
         Ok((data, invoice))
@@ -427,18 +352,6 @@ pub fn verify_bolt12_invoice_against_offer(
     }
 
     Ok(())
-}
-
-/// Request to the Boltz API to create a submarine swap with a string invoice (BOLT11 or BOLT12).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CreateStringInvoiceSubmarineSwapRequest {
-    from: Asset,
-    to: Asset,
-    invoice: String,
-    #[serde(rename = "refundPublicKey")]
-    refund_public_key: PublicKey,
-    #[serde(rename = "referralId", skip_serializing_if = "Option::is_none")]
-    referral_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -58,10 +58,13 @@ mod unilateral_exit;
 mod utils;
 
 pub use asset::IssueAssetResult;
+pub use boltz::Bolt12SubmarineSwapResult;
 pub use boltz::ChainSwapAmount;
 pub use boltz::ChainSwapData;
 pub use boltz::ChainSwapDirection;
 pub use boltz::ChainSwapResult;
+pub use boltz::LnInvoice;
+pub use boltz::ParsedBolt12Invoice;
 pub use boltz::PendingVhtlcSpendTx;
 pub use boltz::PendingVhtlcSpendType;
 pub use boltz::ReverseSwapData;
@@ -301,6 +304,7 @@ pub struct OfflineClient<B, W, S, K> {
     wallet: Arc<W>,
     swap_storage: Arc<S>,
     boltz_url: String,
+    boltz_bolt12_url: Option<String>,
     boltz_referral_id: Option<String>,
     timeout: Duration,
     delegator_pk: Option<XOnlyPublicKey>,
@@ -459,6 +463,7 @@ where
             wallet,
             swap_storage,
             boltz_url,
+            boltz_bolt12_url: None,
             boltz_referral_id,
             timeout,
             delegator_pk,
@@ -472,6 +477,14 @@ where
     /// swap creation requests (this opts out of the SDK default).
     pub fn with_boltz_referral_id(mut self, boltz_referral_id: Option<String>) -> Self {
         self.boltz_referral_id = boltz_referral_id;
+        self
+    }
+
+    /// Override the Boltz BOLT12 API URL after construction.
+    ///
+    /// When unset, BOLT12-specific endpoints use the regular Boltz URL.
+    pub fn with_boltz_bolt12_url(mut self, boltz_bolt12_url: Option<String>) -> Self {
+        self.boltz_bolt12_url = boltz_bolt12_url;
         self
     }
 
@@ -575,6 +588,11 @@ where
     /// Returns the Boltz referral ID sent with all swap creation requests, if any.
     pub fn boltz_referral_id(&self) -> Option<&str> {
         self.boltz_referral_id.as_deref()
+    }
+
+    /// Returns the Boltz BOLT12 API URL, falling back to the regular Boltz URL.
+    pub fn boltz_bolt12_url(&self) -> &str {
+        self.boltz_bolt12_url.as_deref().unwrap_or(&self.boltz_url)
     }
 
     /// Connects to the Ark server and retrieves server information.

--- a/ark-client/src/swap_storage/sqlite.rs
+++ b/ark-client/src/swap_storage/sqlite.rs
@@ -477,6 +477,7 @@ impl SwapStorage for SqliteSwapStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::LnInvoice;
     use ark_core::ArkAddress;
     use bitcoin::hashes::ripemd160;
     use bitcoin::hashes::Hash;
@@ -508,7 +509,7 @@ mod tests {
                 unilateral_refund_without_receiver: 288,
             },
             amount: Amount::from_sat(100_000),
-            invoice: Bolt11Invoice::from_str("lnbcrt10u1p5d55pjpp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp57x0nwf7nzsndjdrvsre570ehg0szw34l284hswdz6zpqvktq9mrs9qxpqysgqllgxhxeny0tvtnxuqgn4s0t2qamc6yqc4t3pe6p2x5lgs8v8r3vxzxp3a3ax9j7d2ta5cduddln8n9se7q0jgg7s0h8t2vhljlu3wkcps9k8xs").unwrap(),
+            invoice: LnInvoice::Bolt11(Bolt11Invoice::from_str("lnbcrt10u1p5d55pjpp56ms94rkev7tdrwqyus5a63lny2mqzq9vh2rq3u4ym3v4lxv6xl4qdql2djkuepqw3hjqs2jfvsxzerywfjhxuccqz95xqztfsp57x0nwf7nzsndjdrvsre570ehg0szw34l284hswdz6zpqvktq9mrs9qxpqysgqllgxhxeny0tvtnxuqgn4s0t2qamc6yqc4t3pe6p2x5lgs8v8r3vxzxp3a3ax9j7d2ta5cduddln8n9se7q0jgg7s0h8t2vhljlu3wkcps9k8xs").unwrap()),
             created_at: 1234567890,
             key_derivation_index: None,
         }

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -117,7 +117,7 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
-        let channel = tonic::transport::Endpoint::from_shared(self.url.clone())
+        let channel = tonic::transport::Endpoint::new(self.url.clone())
             .map_err(Error::connect)?
             .connect()
             .await

--- a/ark-grpc/src/error.rs
+++ b/ark-grpc/src/error.rs
@@ -100,7 +100,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.description())?;
         if let Some(source) = self.source() {
-            f.write_str(&source.to_string())?;
+            write!(f, ": {}", source)?;
         }
 
         Ok(())

--- a/e2e-tests/tests/boltz_bolt12_submarine.rs
+++ b/e2e-tests/tests/boltz_bolt12_submarine.rs
@@ -1,0 +1,66 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use rand::thread_rng;
+use std::env;
+use std::sync::Arc;
+
+mod common;
+
+// This test exercises the fully implemented BOLT12 submarine flow:
+// BOLT12 offer -> Boltz bolt12_fetch invoice -> submarine swap -> Ark VHTLC funding.
+//
+// Generate a local CLN offer with:
+// docker exec cln lightning-cli --network=regtest offer any "ark-rs BOLT12 e2e"
+//
+// Then pass the returned `bolt12` value via `BOLT12_OFFER` when running this test.
+const BOLT12_OFFER_ENV: &str = "BOLT12_OFFER";
+
+// Must be above Boltz's minimum. Used when the offer does not specify a fixed amount.
+const AMOUNT: Amount = Amount::from_sat(2_000);
+
+#[tokio::test]
+#[ignore]
+pub async fn bolt12_submarine_swap() {
+    // This test requires the Boltz/Fulmine regtest environment in addition to the regular e2e
+    // setup. See `.pi/skills/boltz-regtest/SKILL.md` for local setup instructions.
+    //
+    // The offer must be reachable by Boltz's BOLT12 node. In the local setup, generate it from
+    // the Nigiri CLN node and pass the returned `bolt12` value via BOLT12_OFFER.
+
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let offer = env::var(BOLT12_OFFER_ENV)
+        .unwrap_or_else(|_| panic!("set {BOLT12_OFFER_ENV} before running this test"));
+
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    let alice_fund_amount = Amount::ONE_BTC;
+
+    nigiri
+        .faucet_fund(&alice.get_boarding_address().unwrap(), alice_fund_amount)
+        .await;
+
+    alice.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    wait_until_balance!(&alice, confirmed: alice_fund_amount, pre_confirmed: Amount::ZERO);
+
+    let res = alice.pay_bolt12_offer(&offer, Some(AMOUNT)).await.unwrap();
+
+    assert!(
+        res.invoice.starts_with("lni"),
+        "Boltz should resolve the offer into a BOLT12 invoice"
+    );
+
+    wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: alice_fund_amount - res.amount);
+}

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -449,6 +449,7 @@ pub async fn set_up_client(
         None,
         vec![],
     )
+    .with_boltz_bolt12_url(Some("http://localhost:9005".to_string()))
     .connect_with_retries(5)
     .await
     .unwrap();


### PR DESCRIPTION
Based on #197.

Now provides an e2e test. I left out the proposed BOLT12 helper for reverse submarine swaps because they were unused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BOLT12 Lightning invoice support for submarine swaps and unified handling of BOLT11/BOLT12 invoices.
  * Configurable Boltz BOLT12 API endpoint for clients and new public result types for BOLT12 payments.

* **Bug Fixes**
  * Validates Boltz-provided VHTLC/address before persisting or funding swaps.

* **Tests**
  * Added unit tests for invoice parsing/serde and an ignored end-to-end BOLT12 submarine swap test.

* **Chores**
  * Bumped Lightning invoice dependency to 0.34.0 and declared updated Lightning dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/rust-sdk/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->