### PR TITLE
feat(ark-client): narrow settle() to expired/recoverable VTXOs

### DIFF
--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -120,6 +120,12 @@ where
     /// periodically renewing their wallet: healthy VTXOs do not need to be touched, and including
     /// them would only inflate batch fees. Boarding outputs are always included because callers
     /// generally want freshly funded coins to enter the Ark.
+    ///
+    /// NOTE: sub-dust recoverable VTXOs can only be rescued when their combined value exceeds the
+    /// server's dust threshold; otherwise the batch protocol rejects the settlement with a
+    /// `cannot settle into sub-dust VTXO` error. When the wallet holds isolated sub-dust amounts,
+    /// fall back to [`Self::settle_all`], which can roll them in alongside healthy VTXOs that
+    /// act as carrier value.
     pub async fn settle<R>(&self, rng: &mut R) -> Result<Option<Txid>, Error>
     where
         R: Rng + CryptoRng + Clone,

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -59,7 +59,10 @@ where
 {
     /// Settle _all_ prior VTXOs and boarding outputs into the next batch, generating new confirmed
     /// VTXOs.
-    pub async fn settle<R>(&self, rng: &mut R) -> Result<Option<Txid>, Error>
+    ///
+    /// Most callers should prefer [`Self::settle`], which only renews VTXOs that have actually
+    /// expired. Settling unexpired VTXOs is rarely necessary.
+    pub async fn settle_all<R>(&self, rng: &mut R) -> Result<Option<Txid>, Error>
     where
         R: Rng + CryptoRng + Clone,
     {
@@ -108,6 +111,33 @@ where
         tracing::info!(%commitment_txid, "Settlement success");
 
         Ok(Some(commitment_txid))
+    }
+
+    /// Settle prior VTXOs that have expired or are recoverable into the next batch, generating new
+    /// confirmed VTXOs.
+    ///
+    /// Boarding outputs and healthy VTXOs are left untouched. This is the path callers typically
+    /// want when periodically renewing their wallet: healthy VTXOs do not need to be touched, and
+    /// including them would only inflate batch fees.
+    pub async fn settle<R>(&self, rng: &mut R) -> Result<Option<Txid>, Error>
+    where
+        R: Rng + CryptoRng + Clone,
+    {
+        let (vtxo_list, _) = self.list_vtxos().await?;
+
+        let outpoints: Vec<OutPoint> = vtxo_list.recoverable().map(|v| v.outpoint).collect();
+
+        if outpoints.is_empty() {
+            tracing::debug!("No expired or recoverable VTXOs to settle");
+            return Ok(None);
+        }
+
+        tracing::debug!(
+            num_to_settle = outpoints.len(),
+            "Attempting to settle expired and recoverable VTXOs"
+        );
+
+        self.settle_vtxos(rng, &outpoints, &[]).await
     }
 
     /// Settle _all_ prior VTXOs, boarding outputs, and the provided ArkNotes into the next batch.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -113,31 +113,37 @@ where
         Ok(Some(commitment_txid))
     }
 
-    /// Settle prior VTXOs that have expired or are recoverable into the next batch, generating new
-    /// confirmed VTXOs.
+    /// Settle prior VTXOs that have expired or are recoverable, together with all available
+    /// boarding outputs, into the next batch, generating new confirmed VTXOs.
     ///
-    /// Boarding outputs and healthy VTXOs are left untouched. This is the path callers typically
-    /// want when periodically renewing their wallet: healthy VTXOs do not need to be touched, and
-    /// including them would only inflate batch fees.
+    /// Healthy (unexpired) VTXOs are left untouched. This is the path callers typically want when
+    /// periodically renewing their wallet: healthy VTXOs do not need to be touched, and including
+    /// them would only inflate batch fees. Boarding outputs are always included because callers
+    /// generally want freshly funded coins to enter the Ark.
     pub async fn settle<R>(&self, rng: &mut R) -> Result<Option<Txid>, Error>
     where
         R: Rng + CryptoRng + Clone,
     {
         let (vtxo_list, _) = self.list_vtxos().await?;
+        let vtxo_outpoints: Vec<OutPoint> = vtxo_list.recoverable().map(|v| v.outpoint).collect();
 
-        let outpoints: Vec<OutPoint> = vtxo_list.recoverable().map(|v| v.outpoint).collect();
+        let (boarding_inputs, _, _) = self.fetch_commitment_transaction_inputs().await?;
+        let boarding_outpoints: Vec<OutPoint> =
+            boarding_inputs.iter().map(|i| i.outpoint()).collect();
 
-        if outpoints.is_empty() {
-            tracing::debug!("No expired or recoverable VTXOs to settle");
+        if vtxo_outpoints.is_empty() && boarding_outpoints.is_empty() {
+            tracing::debug!("No expired/recoverable VTXOs or boarding outputs to settle");
             return Ok(None);
         }
 
         tracing::debug!(
-            num_to_settle = outpoints.len(),
-            "Attempting to settle expired and recoverable VTXOs"
+            num_vtxos = vtxo_outpoints.len(),
+            num_boarding = boarding_outpoints.len(),
+            "Attempting to settle expired/recoverable VTXOs and boarding outputs"
         );
 
-        self.settle_vtxos(rng, &outpoints, &[]).await
+        self.settle_vtxos(rng, &vtxo_outpoints, &boarding_outpoints)
+            .await
     }
 
     /// Settle _all_ prior VTXOs, boarding outputs, and the provided ArkNotes into the next batch.

--- a/e2e-tests/tests/e2e_arkade_script.rs
+++ b/e2e-tests/tests/e2e_arkade_script.rs
@@ -74,7 +74,7 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
         .faucet_fund(&alice_boarding_address, fund_amount)
         .await;
 
-    alice.settle(&mut rng).await.unwrap();
+    alice.settle_all(&mut rng).await.unwrap();
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let custom_owner_kp = Keypair::new(&secp, &mut rng);
@@ -191,7 +191,7 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
 
     wait_until_balance!(&bob, pre_confirmed: receiver_amount);
 
-    bob.settle(&mut rng).await.unwrap();
+    bob.settle_all(&mut rng).await.unwrap();
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     wait_until_balance!(&bob, confirmed: receiver_amount, pre_confirmed: Amount::ZERO);

--- a/e2e-tests/tests/e2e_assets.rs
+++ b/e2e-tests/tests/e2e_assets.rs
@@ -108,7 +108,7 @@ pub async fn e2e_assets() {
 
     tracing::info!("=== Step 3: Settle asset ===");
 
-    alice.settle(&mut rng).await.unwrap();
+    alice.settle_all(&mut rng).await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     let balance = alice.offchain_balance().await.unwrap();

--- a/e2e-tests/tests/e2e_concurrent_settlement.rs
+++ b/e2e-tests/tests/e2e_concurrent_settlement.rs
@@ -138,20 +138,20 @@ pub async fn concurrent_boarding() {
     let alice_task = tokio::spawn({
         async move {
             let mut rng = StdRng::from_entropy();
-            alice.settle(&mut rng).await.unwrap();
+            alice.settle_all(&mut rng).await.unwrap();
             alice
         }
     });
 
     let bob_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        bob.settle(&mut rng).await.unwrap();
+        bob.settle_all(&mut rng).await.unwrap();
         bob
     });
 
     let claire_task = tokio::spawn(async move {
         let mut rng = StdRng::from_entropy();
-        claire.settle(&mut rng).await.unwrap();
+        claire.settle_all(&mut rng).await.unwrap();
         claire
     });
 

--- a/e2e-tests/tests/e2e_sub_dust.rs
+++ b/e2e-tests/tests/e2e_sub_dust.rs
@@ -83,7 +83,7 @@ pub async fn send_subdust_amount() {
     );
     wait_until_balance!(&bob, confirmed: Amount::ZERO, pre_confirmed: regular_amount, recoverable: sub_dust_amount);
 
-    bob.settle(&mut rng).await.unwrap();
+    bob.settle_all(&mut rng).await.unwrap();
 
     wait_until_balance!(&bob, confirmed: regular_amount + sub_dust_amount, pre_confirmed: Amount::ZERO, recoverable: Amount::ZERO);
 }

--- a/e2e-tests/tests/e2e_two_party.rs
+++ b/e2e-tests/tests/e2e_two_party.rs
@@ -110,7 +110,7 @@ pub async fn e2e() {
     );
     wait_until_balance!(&bob, confirmed: Amount::ZERO, pre_confirmed: send_to_bob_vtxo_amount);
 
-    bob.settle(&mut rng).await.unwrap();
+    bob.settle_all(&mut rng).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let alice_offchain_balance = alice.offchain_balance().await.unwrap();
@@ -130,7 +130,7 @@ pub async fn e2e() {
     assert_eq!(bob_offchain_balance.confirmed(), send_to_bob_vtxo_amount);
     assert_eq!(bob_offchain_balance.pre_confirmed(), Amount::ZERO);
 
-    alice.settle(&mut rng).await.unwrap();
+    alice.settle_all(&mut rng).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     let alice_offchain_balance = alice.offchain_balance().await.unwrap();


### PR DESCRIPTION
Rename the existing full-renewal settle to settle_all, and introduce a new settle that only renews VTXOs in the server's recoverable bucket plus any confirmed/pre-confirmed VTXOs the client sees as expired. This keeps periodic renewals cheap by leaving healthy VTXOs and boarding outputs untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-batch settlement option to process all pending items in one operation (`settle_all`).
* **Refactoring**
  * Updated selective settlement to target only recoverable VTXOs (leaving healthy/unexpired ones untouched) while still settling available boarding outputs.
  * Selective settlement now returns “no action” when nothing eligible is found; documentation notes a sub-dust recoverable case may require falling back to full-batch settlement.
* **Tests**
  * Updated end-to-end tests to use full-batch settlement where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->