### PR TITLE
Support unilateral exit with VHTLC ancestor

### DIFF
--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -632,8 +632,8 @@ where
 
         let mut unsigned_commitment_tx = None;
 
-        let mut vtxo_graph_chunks = Some(Vec::new());
-        let mut vtxo_graph: Option<TxGraph> = None;
+        let mut vtxo_batch_tree_graph_chunks = Some(Vec::new());
+        let mut vtxo_batch_tree_graph: Option<TxGraph> = None;
 
         let mut connectors_graph_chunks = Some(Vec::new());
         let mut batch_expiry = None;
@@ -684,15 +684,15 @@ where
 
                         match e.batch_tree_event_type {
                             BatchTreeEventType::Vtxo => {
-                                match &mut vtxo_graph_chunks {
-                                    Some(vtxo_graph_chunks) => {
-                                        tracing::debug!("Got new VTXO graph chunk");
+                                match &mut vtxo_batch_tree_graph_chunks {
+                                    Some(vtxo_batch_tree_graph_chunks) => {
+                                        tracing::debug!("Got new VTXO batch-tree graph chunk");
 
-                                        vtxo_graph_chunks.push(e.tx_graph_chunk)
+                                        vtxo_batch_tree_graph_chunks.push(e.tx_graph_chunk)
                                     }
                                     None => {
                                         return Err(Error::ark_server(
-                                            "received unexpected VTXO graph chunk",
+                                            "received unexpected VTXO batch-tree graph chunk",
                                         ));
                                     }
                                 };
@@ -720,9 +720,9 @@ where
 
                         match e.batch_tree_event_type {
                             BatchTreeEventType::Vtxo => {
-                                match vtxo_graph {
-                                    Some(ref mut vtxo_graph) => {
-                                        vtxo_graph.apply(|graph| {
+                                match vtxo_batch_tree_graph {
+                                    Some(ref mut vtxo_batch_tree_graph) => {
+                                        vtxo_batch_tree_graph.apply(|graph| {
                                             if graph.root().unsigned_tx.compute_txid() != e.txid {
                                                 Ok(true)
                                             } else {
@@ -734,14 +734,14 @@ where
                                     }
                                     None => {
                                         return Err(Error::ark_server(
-                                            "received batch tree signature without TX graph",
+                                            "received batch-tree signature without transaction graph",
                                         ));
                                     }
                                 };
                             }
                             BatchTreeEventType::Connector => {
                                 return Err(Error::ark_server(
-                                    "received batch tree signature for connectors tree",
+                                    "received batch-tree signature for connector tree",
                                 ));
                             }
                         }
@@ -751,14 +751,13 @@ where
                             continue;
                         }
 
-                        let chunks = vtxo_graph_chunks.take().ok_or(Error::ark_server(
-                            "received tree signing started event without VTXO graph chunks",
+                        let chunks = vtxo_batch_tree_graph_chunks.take().ok_or(Error::ark_server(
+                            "received batch-tree signing started event without VTXO batch-tree graph chunks",
                         ))?;
-                        vtxo_graph = Some(
-                            TxGraph::new(chunks)
-                                .map_err(Error::from)
-                                .context("failed to build VTXO graph before generating nonces")?,
-                        );
+                        vtxo_batch_tree_graph =
+                            Some(TxGraph::new(chunks).map_err(Error::from).context(
+                                "failed to build VTXO batch-tree graph before generating nonces",
+                            )?);
 
                         tracing::info!(batch_id = e.id, "Batch signing started");
 
@@ -775,7 +774,9 @@ where
                             let own_cosigner_pk = own_cosigner_kp.public_key();
                             let nonce_tree = generate_nonce_tree(
                                 rng,
-                                vtxo_graph.as_ref().expect("VTXO graph"),
+                                vtxo_batch_tree_graph
+                                    .as_ref()
+                                    .expect("VTXO batch-tree graph"),
                                 own_cosigner_pk,
                                 &e.unsigned_commitment_tx,
                             )
@@ -840,19 +841,20 @@ where
 
                         agg_nonce_pks.insert(e.txid, agg_nonce_pk);
 
-                        if vtxo_graph.is_none() {
-                            let chunks = vtxo_graph_chunks.take().ok_or(Error::ark_server(
-                                "received tree nonces event without VTXO graph chunks",
+                        if vtxo_batch_tree_graph.is_none() {
+                            let chunks = vtxo_batch_tree_graph_chunks.take().ok_or(Error::ark_server(
+                                "received batch-tree nonces event without VTXO batch-tree graph chunks",
                             ))?;
-                            vtxo_graph = Some(
+                            vtxo_batch_tree_graph = Some(
                                 TxGraph::new(chunks)
                                     .map_err(Error::from)
-                                    .context("failed to build VTXO graph before tree signing")?,
+                                    .context("failed to build VTXO batch-tree graph before batch-tree signing")?,
                             );
                         }
-                        let vtxo_graph_ref = vtxo_graph.as_ref().expect("just populated");
+                        let vtxo_batch_tree_graph_ref =
+                            vtxo_batch_tree_graph.as_ref().expect("just populated");
 
-                        if agg_nonce_pks.len() == vtxo_graph_ref.nb_of_nodes() {
+                        if agg_nonce_pks.len() == vtxo_batch_tree_graph_ref.nb_of_nodes() {
                             let cosigner_kp = own_cosigner_kps
                                 .iter()
                                 .find(|kp| kp.public_key().x_only_public_key().0 == cosigner_pk)
@@ -879,7 +881,7 @@ where
                                 .ok_or_else(|| Error::ad_hoc("missing batch expiry"))?;
 
                             let mut partial_sig_tree = PartialSigTree::default();
-                            for (txid, _) in vtxo_graph_ref.as_map() {
+                            for (txid, _) in vtxo_batch_tree_graph_ref.as_map() {
                                 let agg_nonce_pk = agg_nonce_pks.get(&txid).ok_or_else(|| {
                                     Error::ad_hoc(format!(
                                         "missing aggregated nonce PK for TX {txid}"
@@ -892,12 +894,12 @@ where
                                     ark_forfeit_pk,
                                     cosigner_kp,
                                     *agg_nonce_pk,
-                                    vtxo_graph_ref,
+                                    vtxo_batch_tree_graph_ref,
                                     unsigned_commitment_tx,
                                     our_nonce_tree,
                                 )
                                 .map_err(Error::from)
-                                .context("failed to sign VTXO tree")?;
+                                .context("failed to sign VTXO batch-tree transactions")?;
 
                                 partial_sig_tree.0.extend(sigs.0);
                             }
@@ -910,7 +912,7 @@ where
                                 )
                                 .await
                                 .map_err(Error::ark_server)
-                                .context("failed to submit VTXO tree signatures")?;
+                                .context("failed to submit VTXO batch-tree signatures")?;
                         }
                     }
                     StreamEvent::TreeNoncesAggregated(e) => {
@@ -1374,8 +1376,8 @@ where
 
         let mut unsigned_commitment_tx = None;
 
-        let mut vtxo_graph_chunks = Some(Vec::new());
-        let mut vtxo_graph: Option<TxGraph> = None;
+        let mut vtxo_batch_tree_graph_chunks = Some(Vec::new());
+        let mut vtxo_batch_tree_graph: Option<TxGraph> = None;
 
         let mut connectors_graph_chunks = Some(Vec::new());
         let mut batch_expiry = None;
@@ -1433,15 +1435,15 @@ where
 
                         match e.batch_tree_event_type {
                             BatchTreeEventType::Vtxo => {
-                                match &mut vtxo_graph_chunks {
-                                    Some(vtxo_graph_chunks) => {
-                                        tracing::debug!("Got new VTXO graph chunk");
+                                match &mut vtxo_batch_tree_graph_chunks {
+                                    Some(vtxo_batch_tree_graph_chunks) => {
+                                        tracing::debug!("Got new VTXO batch-tree graph chunk");
 
-                                        vtxo_graph_chunks.push(e.tx_graph_chunk)
+                                        vtxo_batch_tree_graph_chunks.push(e.tx_graph_chunk)
                                     }
                                     None => {
                                         return Err(Error::ark_server(
-                                            "received unexpected VTXO graph chunk",
+                                            "received unexpected VTXO batch-tree graph chunk",
                                         ));
                                     }
                                 };
@@ -1469,9 +1471,9 @@ where
 
                         match e.batch_tree_event_type {
                             BatchTreeEventType::Vtxo => {
-                                match vtxo_graph {
-                                    Some(ref mut vtxo_graph) => {
-                                        vtxo_graph.apply(|graph| {
+                                match vtxo_batch_tree_graph {
+                                    Some(ref mut vtxo_batch_tree_graph) => {
+                                        vtxo_batch_tree_graph.apply(|graph| {
                                             if graph.root().unsigned_tx.compute_txid() != e.txid {
                                                 Ok(true)
                                             } else {
@@ -1483,14 +1485,14 @@ where
                                     }
                                     None => {
                                         return Err(Error::ark_server(
-                                            "received batch tree signature without TX graph",
+                                            "received batch-tree signature without transaction graph",
                                         ));
                                     }
                                 };
                             }
                             BatchTreeEventType::Connector => {
                                 return Err(Error::ark_server(
-                                    "received batch tree signature for connectors tree",
+                                    "received batch-tree signature for connector tree",
                                 ));
                             }
                         }
@@ -1500,14 +1502,13 @@ where
                             continue;
                         }
 
-                        let chunks = vtxo_graph_chunks.take().ok_or(Error::ark_server(
-                            "received tree signing started event without VTXO graph chunks",
+                        let chunks = vtxo_batch_tree_graph_chunks.take().ok_or(Error::ark_server(
+                            "received batch-tree signing started event without VTXO batch-tree graph chunks",
                         ))?;
-                        vtxo_graph = Some(
-                            TxGraph::new(chunks)
-                                .map_err(Error::from)
-                                .context("failed to build VTXO graph before generating nonces")?,
-                        );
+                        vtxo_batch_tree_graph =
+                            Some(TxGraph::new(chunks).map_err(Error::from).context(
+                                "failed to build VTXO batch-tree graph before generating nonces",
+                            )?);
 
                         tracing::info!(batch_id = e.id, "Batch signing started");
 
@@ -1525,7 +1526,9 @@ where
                             let own_cosigner_pk = own_cosigner_kp.public_key();
                             let nonce_tree = generate_nonce_tree(
                                 rng,
-                                vtxo_graph.as_ref().expect("VTXO graph"),
+                                vtxo_batch_tree_graph
+                                    .as_ref()
+                                    .expect("VTXO batch-tree graph"),
                                 own_cosigner_pk,
                                 &e.unsigned_commitment_tx,
                             )
@@ -1590,21 +1593,22 @@ where
 
                         agg_nonce_pks.insert(e.txid, agg_nonce_pk);
 
-                        if vtxo_graph.is_none() {
-                            let chunks = vtxo_graph_chunks.take().ok_or(Error::ark_server(
-                                "received tree nonces event without VTXO graph chunks",
+                        if vtxo_batch_tree_graph.is_none() {
+                            let chunks = vtxo_batch_tree_graph_chunks.take().ok_or(Error::ark_server(
+                                "received batch-tree nonces event without VTXO batch-tree graph chunks",
                             ))?;
-                            vtxo_graph = Some(
+                            vtxo_batch_tree_graph = Some(
                                 TxGraph::new(chunks)
                                     .map_err(Error::from)
-                                    .context("failed to build VTXO graph before tree signing")?,
+                                    .context("failed to build VTXO batch-tree graph before batch-tree signing")?,
                             );
                         }
-                        let vtxo_graph_ref = vtxo_graph.as_ref().expect("just populated");
+                        let vtxo_batch_tree_graph_ref =
+                            vtxo_batch_tree_graph.as_ref().expect("just populated");
 
-                        // Once we collect an aggregated nonce per transaction in our VTXO graph, we
-                        // can go ahead with signing and submitting.
-                        if agg_nonce_pks.len() == vtxo_graph_ref.nb_of_nodes() {
+                        // Once we collect an aggregated nonce per transaction in our VTXO
+                        // batch-tree graph, we can sign and submit our partial signatures.
+                        if agg_nonce_pks.len() == vtxo_batch_tree_graph_ref.nb_of_nodes() {
                             let cosigner_kp = own_cosigner_kps
                                 .iter()
                                 .find(|kp| kp.public_key().x_only_public_key().0 == cosigner_pk)
@@ -1631,7 +1635,7 @@ where
                                 .ok_or_else(|| Error::ad_hoc("missing batch expiry"))?;
 
                             let mut partial_sig_tree = PartialSigTree::default();
-                            for (txid, _) in vtxo_graph_ref.as_map() {
+                            for (txid, _) in vtxo_batch_tree_graph_ref.as_map() {
                                 let agg_nonce_pk = agg_nonce_pks.get(&txid).ok_or_else(|| {
                                     Error::ad_hoc(format!(
                                         "missing aggregated nonce PK for TX {txid}"
@@ -1644,12 +1648,12 @@ where
                                     ark_forfeit_pk,
                                     cosigner_kp,
                                     *agg_nonce_pk,
-                                    vtxo_graph_ref,
+                                    vtxo_batch_tree_graph_ref,
                                     unsigned_commitment_tx,
                                     our_nonce_tree,
                                 )
                                 .map_err(Error::from)
-                                .context("failed to sign VTXO tree")?;
+                                .context("failed to sign VTXO batch-tree transactions")?;
 
                                 partial_sig_tree.0.extend(sigs.0);
                             }
@@ -1662,7 +1666,7 @@ where
                                 )
                                 .await
                                 .map_err(Error::ark_server)
-                                .context("failed to submit VTXO tree signatures")?;
+                                .context("failed to submit VTXO batch-tree signatures")?;
                         }
                     }
                     StreamEvent::TreeNoncesAggregated(e) => {

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -12,7 +12,7 @@ use ark_core::build_unilateral_exit_tree_txids;
 use ark_core::script::extract_checksig_pubkeys;
 use ark_core::unilateral_exit;
 use ark_core::unilateral_exit::create_unilateral_exit_transaction;
-use ark_core::unilateral_exit::sign_unilateral_exit_tree;
+use ark_core::unilateral_exit::finalize_unilateral_exit_tree;
 use ark_core::unilateral_exit::UnilateralExitTree;
 use backon::ExponentialBuilder;
 use backon::Retryable;
@@ -38,9 +38,9 @@ where
     ///
     /// ### Returns
     ///
-    /// The tree as a `Vec<Vec<Transaction>>`, where each branch represents a path from
-    /// commitment transaction output to a spendable VTXO. Every transaction is fully signed,
-    /// but requires fee bumping through a P2A output.
+    /// The tree as a `Vec<Vec<Transaction>>`, where each branch represents a path from a
+    /// commitment transaction output to a spendable VTXO. Every transaction is finalized, but
+    /// requires fee bumping through a P2A output.
     pub async fn build_unilateral_exit_trees(&self) -> Result<Vec<Vec<Transaction>>, Error> {
         let (vtxo_list, _) = self
             .list_vtxos()
@@ -120,9 +120,9 @@ where
                 commitment_txs.push(commitment_tx);
             }
 
-            let signed_unilateral_exit_tree =
-                sign_unilateral_exit_tree(&unilateral_exit_tree, commitment_txs.as_slice())?;
-            branches.extend(signed_unilateral_exit_tree);
+            let finalized_unilateral_exit_tree =
+                finalize_unilateral_exit_tree(&unilateral_exit_tree, commitment_txs.as_slice())?;
+            branches.extend(finalized_unilateral_exit_tree);
         }
 
         Ok(branches)

--- a/ark-core/src/batch.rs
+++ b/ark-core/src/batch.rs
@@ -79,11 +79,11 @@ impl OnChainInput {
     }
 }
 
-/// A nonce key pair per tree transaction output that we are a part of in the batch.
+/// A nonce key pair per batch-tree transaction output that we are a part of in the batch.
 ///
 /// The [`musig::SecretNonce`] element of the tuple is an [`Option`] because it cannot be cloned or
-/// copied. When we are ready to sign a tree transaction, we call the method `take_sk` to move out
-/// of the [`Option`].
+/// copied. When we are ready to sign a batch-tree transaction, we call the method `take_sk` to move
+/// out of the [`Option`].
 #[allow(clippy::type_complexity)]
 pub struct NonceKps(HashMap<Txid, (Option<musig::SecretNonce>, musig::PublicNonce)>);
 
@@ -108,7 +108,8 @@ impl NonceKps {
     }
 }
 
-/// Generate a nonce key pair for each tree transaction output that we are a part of in the batch.
+/// Generate a nonce key pair for each batch-tree transaction output that we are a part of in the
+/// batch.
 pub fn generate_nonce_tree<R>(
     rng: &mut R,
     batch_tree_tx_graph: &TxGraph,
@@ -195,7 +196,7 @@ fn tree_tx_sighash(
     let prevouts = [previous_output];
     let prevouts = Prevouts::All(&prevouts);
 
-    // Here we are generating a key spend sighash, because batch tree outputs are signed by parties
+    // Here we are generating a key spend sighash, because batch-tree outputs are signed by parties
     // with VTXOs in this new batch. We use a musig key spend to efficiently coordinate with all the
     // parties.
     let tap_sighash = SighashCache::new(tx)
@@ -205,16 +206,17 @@ fn tree_tx_sighash(
     Ok(tap_sighash.to_raw_hash().to_byte_array())
 }
 
-/// Compute the aggregated nonce public key for a transaction in the VTXO tree.
+/// Compute the aggregated nonce public key for a transaction in the batch-tree.
 ///
-/// The [`TreeTxNoncePks`] holds the public nonces of all the cosigners of this transaction.
+/// The [`TreeTxNoncePks`] holds the public nonces of all the cosigners of this batch-tree
+/// transaction.
 pub fn aggregate_nonces(tree_tx_nonce_pks: TreeTxNoncePks) -> musig::AggregatedNonce {
     let pks = tree_tx_nonce_pks.to_pks();
     let ref_pks = pks.iter().collect::<Vec<_>>();
     musig::AggregatedNonce::new(&ref_pks)
 }
 
-/// Use `own_cosigner_kp` to sign each batch tree transaction output that we are a part, using
+/// Use `own_cosigner_kp` to sign each batch-tree transaction output that we are a part of, using
 /// `our_nonce_kps` to provide our share of each aggregate nonce.
 pub fn sign_batch_tree_tx(
     tree_txid: Txid,
@@ -241,14 +243,14 @@ pub fn sign_batch_tree_tx(
 
     let psbt = batch_tree_tx_map
         .get(&tree_txid)
-        .ok_or_else(|| Error::ad_hoc(format!("TXID {tree_txid} not found in batch tree map")))?;
+        .ok_or_else(|| Error::ad_hoc(format!("TXID {tree_txid} not found in batch-tree map")))?;
 
     let mut cosigner_pks = extract_cosigner_pks_from_vtxo_psbt(psbt)?;
     cosigner_pks.sort_by_key(|k| k.serialize());
 
     if !cosigner_pks.contains(&own_cosigner_pk) {
         return Err(Error::ad_hoc(
-            "own cosigner PK not found among tree transaction cosigner PKs",
+            "own cosigner PK not found among batch-tree transaction cosigner PKs",
         ));
     }
 

--- a/ark-core/src/intent.rs
+++ b/ark-core/src/intent.rs
@@ -459,7 +459,7 @@ impl IntentMessage {
 /// Encode witness elements in the format used by PSBT condition witness field.
 ///
 /// Format: [num_elements as varint] [len1 as varint] [elem1] [len2 as varint] [elem2] ...
-fn encode_witness(elements: &[Vec<u8>]) -> Vec<u8> {
+pub(crate) fn encode_witness(elements: &[Vec<u8>]) -> Vec<u8> {
     let mut result = Vec::new();
 
     // Write number of elements as compact size

--- a/ark-core/src/send.rs
+++ b/ark-core/src/send.rs
@@ -48,7 +48,7 @@ pub use issue_asset::SelfAssetIssuanceTransactions;
 pub use reissue_asset::build_asset_reissuance_transactions;
 pub use reissue_asset::AssetReissuanceTransactions;
 
-/// A VTXO to be spent into an unconfirmed VTXO.
+/// A VTXO to be spent into a pre-confirmed VTXO.
 #[derive(Debug, Clone)]
 pub struct VtxoInput {
     /// The script path that will be used to spend the [`Vtxo`].

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-/// An aggregate public nonce per shared internal (non-leaf) node in the VTXO tree.
+/// An aggregate public nonce per shared internal (non-leaf) node in the batch-tree.
 #[derive(Debug, Clone)]
 pub struct NoncePks(HashMap<Txid, musig::PublicNonce>);
 
@@ -68,7 +68,7 @@ impl NoncePks {
 }
 
 /// A public nonce per public key, where each public key corresponds to a party signing a
-/// transaction in the VTXO tree.
+/// transaction in the batch-tree.
 #[derive(Debug, Clone)]
 pub struct TreeTxNoncePks(pub HashMap<XOnlyPublicKey, musig::PublicNonce>);
 
@@ -114,7 +114,7 @@ impl TreeTxNoncePks {
     }
 }
 
-/// A Musig partial signature per shared internal (non-leaf) node in the VTXO tree.
+/// A Musig partial signature per shared internal (non-leaf) node in the batch-tree.
 #[derive(Debug, Clone, Default)]
 pub struct PartialSigTree(pub HashMap<Txid, musig::PartialSignature>);
 
@@ -370,8 +370,7 @@ pub struct VirtualTxOutPoint {
     pub expires_at: i64,
     pub amount: Amount,
     pub script: ScriptBuf,
-    /// A pre-confirmed VTXO spends from another VTXO and is not a leaf of the original VTXO tree
-    /// in a batch.
+    /// A pre-confirmed VTXO spends from another VTXO and is not a leaf of a batch-tree.
     pub is_preconfirmed: bool,
     pub is_swept: bool,
     pub is_unrolled: bool,

--- a/ark-core/src/tree_tx_output_script.rs
+++ b/ark-core/src/tree_tx_output_script.rs
@@ -7,7 +7,7 @@ use bitcoin::taproot::TaprootSpendInfo;
 use bitcoin::ScriptBuf;
 use bitcoin::XOnlyPublicKey;
 
-/// The script of an _internal_ node of the batch tree. By internal node we mean a non-leaf node.
+/// The script of an _internal_ node of the batch-tree. By internal node we mean a non-leaf node.
 ///
 /// This script allows the Ark server to sweep the entire output after the `vtxo_tree_expiry`
 /// seconds have passed from the time the output was included in a block.

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -366,6 +366,122 @@ pub fn build_unilateral_exit_tree_txids(
     Ok(vec![sorted])
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn txid(n: u8) -> Txid {
+        Txid::from_byte_array([n; 32])
+    }
+
+    fn chain(
+        txid: Txid,
+        tx_type: server::ChainedTxType,
+        spends: impl Into<Vec<Txid>>,
+    ) -> server::VtxoChain {
+        server::VtxoChain {
+            txid,
+            tx_type,
+            spends: spends.into(),
+            expires_at: 0,
+        }
+    }
+
+    fn exit_branch(chains: Vec<server::VtxoChain>, ark_txid: Txid) -> Vec<Txid> {
+        build_unilateral_exit_tree_txids(&server::VtxoChains { inner: chains }, ark_txid)
+            .expect("valid unilateral exit branch")
+            .pop()
+            .expect("one topological branch")
+    }
+
+    #[test]
+    fn unilateral_exit_txids_for_linear_chain_are_parent_first() {
+        let commitment = txid(1);
+        let tree = txid(2);
+        let ark = txid(3);
+
+        let branch = exit_branch(
+            vec![
+                chain(commitment, server::ChainedTxType::Commitment, []),
+                chain(tree, server::ChainedTxType::Tree, [commitment]),
+                chain(ark, server::ChainedTxType::Ark, [tree]),
+            ],
+            ark,
+        );
+
+        assert_eq!(branch, vec![tree, ark]);
+    }
+
+    #[test]
+    fn unilateral_exit_txids_deduplicate_merged_ancestor_dag() {
+        let commitment = txid(1);
+        let left = txid(2);
+        let right = txid(3);
+        let merge = txid(4);
+        let ark = txid(5);
+
+        let branch = exit_branch(
+            vec![
+                chain(commitment, server::ChainedTxType::Commitment, []),
+                chain(left, server::ChainedTxType::Tree, [commitment]),
+                chain(right, server::ChainedTxType::Tree, [commitment]),
+                chain(merge, server::ChainedTxType::Checkpoint, [left, right]),
+                chain(ark, server::ChainedTxType::Ark, [merge]),
+            ],
+            ark,
+        );
+
+        assert_eq!(branch, vec![left, right, merge, ark]);
+    }
+
+    #[test]
+    fn unilateral_exit_txids_avoid_exponential_path_enumeration() {
+        let commitment = txid(1);
+        let a1 = txid(2);
+        let b1 = txid(3);
+        let m1 = txid(4);
+        let a2 = txid(5);
+        let b2 = txid(6);
+        let m2 = txid(7);
+        let ark = txid(8);
+
+        let branch = exit_branch(
+            vec![
+                chain(commitment, server::ChainedTxType::Commitment, []),
+                chain(a1, server::ChainedTxType::Tree, [commitment]),
+                chain(b1, server::ChainedTxType::Tree, [commitment]),
+                chain(m1, server::ChainedTxType::Checkpoint, [a1, b1]),
+                chain(a2, server::ChainedTxType::Tree, [m1]),
+                chain(b2, server::ChainedTxType::Tree, [m1]),
+                chain(m2, server::ChainedTxType::Checkpoint, [a2, b2]),
+                chain(ark, server::ChainedTxType::Ark, [m2]),
+            ],
+            ark,
+        );
+
+        assert_eq!(branch, vec![a1, b1, m1, a2, b2, m2, ark]);
+    }
+
+    #[test]
+    fn unilateral_exit_txids_reject_cycles() {
+        let a = txid(1);
+        let b = txid(2);
+
+        let err = build_unilateral_exit_tree_txids(
+            &server::VtxoChains {
+                inner: vec![
+                    chain(a, server::ChainedTxType::Ark, [b]),
+                    chain(b, server::ChainedTxType::Checkpoint, [a]),
+                ],
+            },
+            a,
+        )
+        .expect_err("cycle should be rejected");
+
+        assert!(err.to_string().contains("cycle"));
+    }
+}
+
 /// The full path from a commitment transaction to a VTXO. The entire path must be published
 /// on-chain to execute a unilateral exit with this VTXO.
 ///

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -398,11 +398,13 @@ pub fn build_unilateral_exit_tree_txids(
     Ok(all_paths)
 }
 
-/// The full path from commitment transaction to VTXO. The entire path will need to be published
+/// The full path from a commitment transaction to a VTXO. The entire path must be published
 /// on-chain to execute a unilateral exit with this VTXO.
 ///
-/// We use the word "tree" because a VTXO may come from more than one path i.e. if its corresponding
-/// Ark transaction has more than one input!
+/// A branch may contain both batch-tree internal node transactions, which spend their parent via
+/// key path, and VTXO spend transactions, which spend a confirmed or pre-confirmed VTXO via script
+/// path. We use the word "tree" because a VTXO may come from more than one path, e.g. if its
+/// corresponding Ark transaction has more than one input.
 pub struct UnilateralExitTree {
     /// The commitment transactions from which this VTXO comes from.
     ///
@@ -437,7 +439,8 @@ impl UnilateralExitTree {
 ///
 /// This is intended for historical virtual transactions in a unilateral-exit branch. The caller
 /// provides the `witness_utxo` for the input being finalized, and this function materializes either
-/// the taproot key-spend witness or a satisfiable taproot script-spend witness.
+/// the taproot key-spend witness used by batch-tree internal nodes or a satisfiable taproot
+/// script-spend witness used when spending VTXOs.
 pub fn finalize_virtual_tx_input(
     mut psbt: Psbt,
     input_index: usize,
@@ -453,11 +456,11 @@ pub fn finalize_virtual_tx_input(
     let txid = psbt.unsigned_tx.compute_txid();
 
     if let Some(tap_key_sig) = input.tap_key_sig {
-        tracing::debug!(%txid, "Finalizing key spend for confirmed VTXO");
+        tracing::debug!(%txid, "Finalizing batch-tree internal node key spend");
 
         input.final_script_witness = Some(Witness::p2tr_key_spend(&tap_key_sig));
     } else {
-        tracing::debug!(%txid, "Finalizing script spend for pre-confirmed VTXO");
+        tracing::debug!(%txid, "Finalizing VTXO script spend");
 
         input.final_script_witness = Some(finalize_taproot_script_spend_witness(input)?);
     }
@@ -552,18 +555,19 @@ fn condition_witness_elements(input: &psbt::Input) -> Result<Vec<Vec<u8>>, Error
     Ok(elements)
 }
 
-/// Sign all the transactions needed to commit a VTXO on-chain.
-pub fn sign_unilateral_exit_tree(
+/// Finalize all virtual transactions needed to commit a VTXO on-chain.
+pub fn finalize_unilateral_exit_tree(
     unilateral_exit_tree: &UnilateralExitTree,
     commitment_txs: &[Transaction],
 ) -> Result<Vec<Vec<Transaction>>, Error> {
-    let mut signed_virtual_tx_branches = Vec::new();
+    let mut finalized_virtual_tx_branches = Vec::new();
     for unilateral_exit_branch in unilateral_exit_tree.inner.iter() {
-        let mut signed_unilateral_exit_branch = Vec::new();
+        let mut finalized_unilateral_exit_branch = Vec::new();
         for virtual_tx in unilateral_exit_branch.iter() {
             let psbt = virtual_tx.clone();
 
-            let vtxo_previous_output = psbt.unsigned_tx.input[VTXO_INPUT_INDEX].previous_output;
+            let virtual_tx_previous_output =
+                psbt.unsigned_tx.input[VTXO_INPUT_INDEX].previous_output;
 
             let witness_utxo = {
                 unilateral_exit_branch
@@ -571,8 +575,8 @@ pub fn sign_unilateral_exit_tree(
                     .map(|p| &p.unsigned_tx)
                     .chain(commitment_txs.iter())
                     .find_map(|other_psbt| {
-                        (other_psbt.compute_txid() == vtxo_previous_output.txid).then_some(
-                            other_psbt.output[vtxo_previous_output.vout as usize].clone(),
+                        (other_psbt.compute_txid() == virtual_tx_previous_output.txid).then_some(
+                            other_psbt.output[virtual_tx_previous_output.vout as usize].clone(),
                         )
                     })
             }
@@ -580,12 +584,12 @@ pub fn sign_unilateral_exit_tree(
 
             let tx = finalize_virtual_tx_input(psbt, VTXO_INPUT_INDEX, witness_utxo)?;
 
-            signed_unilateral_exit_branch.push(tx);
+            finalized_unilateral_exit_branch.push(tx);
         }
-        signed_virtual_tx_branches.push(signed_unilateral_exit_branch);
+        finalized_virtual_tx_branches.push(finalized_unilateral_exit_branch);
     }
 
-    Ok(signed_virtual_tx_branches)
+    Ok(finalized_virtual_tx_branches)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -558,6 +558,10 @@ pub fn finalize_virtual_tx_input(
 /// `CHECKSIG`/`CHECKSIGVERIFY` pubkey in the script. Signatures are pushed in reverse script order.
 /// Extra condition witness elements, such as VHTLC preimages, are read from the
 /// `VTXO_CONDITION_KEY` unknown input field and pushed after signatures.
+///
+/// Condition witness elements are therefore placed at the top of the initial script stack. This
+/// requires condition-checking opcodes, such as `OP_HASH160` or `OP_SIZE`, to appear before any
+/// `CHECKSIG`/`CHECKSIGVERIFY` opcode in the tapleaf script.
 pub fn finalize_taproot_script_spend_witness(input: &psbt::Input) -> Result<Witness, Error> {
     for (control_block, (script, leaf_version)) in input.tap_scripts.iter() {
         let leaf_hash = TapLeafHash::from_script(script, *leaf_version);

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -395,6 +395,27 @@ mod tests {
     }
 
     #[test]
+    fn condition_witness_elements_decode_encoded_witness() {
+        let elements = vec![
+            b"preimage".to_vec(),
+            Vec::new(),
+            vec![0; 253],
+            vec![1, 2, 3, 4],
+        ];
+        let mut input = psbt::Input::default();
+
+        input.unknown.insert(
+            psbt::raw::Key {
+                type_value: 222,
+                key: VTXO_CONDITION_KEY.to_vec(),
+            },
+            crate::intent::encode_witness(&elements),
+        );
+
+        assert_eq!(condition_witness_elements(&input).unwrap(), elements);
+    }
+
+    #[test]
     fn unilateral_exit_txids_for_linear_chain_are_parent_first() {
         let commitment = txid(1);
         let tree = txid(2);

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -592,6 +592,14 @@ pub fn finalize_unilateral_exit_tree(
     Ok(finalized_virtual_tx_branches)
 }
 
+#[deprecated(note = "use finalize_unilateral_exit_tree")]
+pub fn sign_unilateral_exit_tree(
+    unilateral_exit_tree: &UnilateralExitTree,
+    commitment_txs: &[Transaction],
+) -> Result<Vec<Vec<Transaction>>, Error> {
+    finalize_unilateral_exit_tree(unilateral_exit_tree, commitment_txs)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedUtxo {
     pub outpoint: OutPoint,

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -267,52 +267,50 @@ where
     Ok(tx)
 }
 
-/// Build the unilateral exit tree of TXIDs for a VTXO from a [`server::VtxoChains`].
+/// Build a topologically sorted unilateral exit branch of TXIDs for a VTXO from a
+/// [`server::VtxoChains`].
+///
+/// The returned branch contains every virtual transaction in the ancestor sub-DAG exactly once,
+/// ordered so every transaction appears after its virtual parents. This avoids enumerating every
+/// distinct root-to-leaf path, which can be exponential when a VTXO has many merged ancestors.
 pub fn build_unilateral_exit_tree_txids(
     vtxo_chains: &server::VtxoChains,
     // The TXID of the VTXO we want to commit on-chain.
     ark_txid: Txid,
 ) -> Result<Vec<Vec<Txid>>, Error> {
-    // Create a hash-map for quick lookups: TXID -> `VtxoChain`.
-    let mut chain_map: HashMap<Txid, &server::VtxoChain> = HashMap::new();
-    for vtxo_chain in &vtxo_chains.inner {
-        chain_map.insert(vtxo_chain.txid, vtxo_chain);
-    }
+    let chain_map = vtxo_chains
+        .inner
+        .iter()
+        .map(|vtxo_chain| (vtxo_chain.txid, vtxo_chain))
+        .collect::<HashMap<_, _>>();
 
-    /// Find all the paths from a virtual transaction to the root commitment transaction,
-    /// recursively.
-    fn find_paths_to_commitment(
+    fn visit_virtual_ancestors(
         current_txid: Txid,
         chain_map: &HashMap<Txid, &server::VtxoChain>,
-        current_path: &mut Vec<Txid>,
-        all_paths: &mut Vec<Vec<Txid>>,
+        visiting: &mut HashSet<Txid>,
         visited: &mut HashSet<Txid>,
-    ) -> Result<(), Error> {
-        // Safety check to prevent an infinite loop.
-        if current_path.len() > 1_000 {
-            return Err(Error::ad_hoc(
-                "chain traversal exceeded maximum depth of 1000",
-            ));
+        sorted: &mut Vec<Txid>,
+    ) -> Result<bool, Error> {
+        if visited.contains(&current_txid) {
+            return Ok(true);
         }
 
-        // Safety check to reject cycles.
-        if visited.contains(&current_txid) {
+        if !visiting.insert(current_txid) {
             return Err(Error::ad_hoc("chain traversal led to cycle"));
         }
-        visited.insert(current_txid);
 
-        // Add current TXID to path.
-        current_path.push(current_txid);
-
-        // Look through parent transactions to continue building up the chain(s).
         let chain = chain_map.get(&current_txid).ok_or_else(|| {
-            Error::ad_hoc(format!("could not find VtxoChain for TXID: {current_txid}",))
+            Error::ad_hoc(format!("could not find VtxoChain for TXID: {current_txid}"))
         })?;
-        // Check if any of the transactions spent by this virtual TX are the commitment transaction.
-        let mut reached_commitment = false;
 
+        if chain.spends.is_empty() {
+            return Err(Error::ad_hoc(format!(
+                "dead end reached at TXID {current_txid} with no commitment transaction"
+            )));
+        }
+
+        let mut reached_commitment = false;
         for &parent_txid in &chain.spends {
-            // Look up the parent transaction's chain to get its type
             let parent_chain = chain_map.get(&parent_txid).ok_or_else(|| {
                 Error::ad_hoc(format!(
                     "could not find VtxoChain for parent TXID: {parent_txid}",
@@ -321,22 +319,13 @@ pub fn build_unilateral_exit_tree_txids(
 
             match parent_chain.tx_type {
                 server::ChainedTxType::Commitment => {
-                    // We've reached our destination.
-                    all_paths.push(current_path.clone());
-
                     reached_commitment = true;
                 }
                 server::ChainedTxType::Ark
                 | server::ChainedTxType::Checkpoint
                 | server::ChainedTxType::Tree => {
-                    // Continue traversing virtual transactions up the tree.
-                    find_paths_to_commitment(
-                        parent_txid,
-                        chain_map,
-                        current_path,
-                        all_paths,
-                        visited,
-                    )?;
+                    reached_commitment |=
+                        visit_virtual_ancestors(parent_txid, chain_map, visiting, visited, sorted)?;
                 }
                 server::ChainedTxType::Unspecified => {
                     tracing::warn!(
@@ -345,57 +334,36 @@ pub fn build_unilateral_exit_tree_txids(
                          Treating it like a virtual TX"
                     );
 
-                    // Continue traversing virtual transactions up the tree.
-                    find_paths_to_commitment(
-                        parent_txid,
-                        chain_map,
-                        current_path,
-                        all_paths,
-                        visited,
-                    )?;
+                    reached_commitment |=
+                        visit_virtual_ancestors(parent_txid, chain_map, visiting, visited, sorted)?;
                 }
             }
         }
 
-        if !reached_commitment && chain.spends.is_empty() {
-            return Err(Error::ad_hoc(format!(
-                "dead end reached at TXID {current_txid} with no commitment transaction"
-            )));
-        }
+        visiting.remove(&current_txid);
+        visited.insert(current_txid);
+        sorted.push(current_txid);
 
-        visited.remove(&current_txid);
-        current_path.pop();
-        Ok(())
+        Ok(reached_commitment)
     }
 
-    let mut all_paths = Vec::new();
-    let mut current_path = Vec::new();
+    let mut visiting = HashSet::new();
     let mut visited = HashSet::new();
+    let mut sorted = Vec::new();
 
-    find_paths_to_commitment(
+    if !visit_virtual_ancestors(
         ark_txid,
         &chain_map,
-        &mut current_path,
-        &mut all_paths,
+        &mut visiting,
         &mut visited,
-    )?;
-
-    if all_paths.is_empty() {
+        &mut sorted,
+    )? {
         return Err(Error::ad_hoc(format!(
-            "no paths found from Ark TX {ark_txid} to commitment transaction",
+            "no path found from Ark TX {ark_txid} to commitment transaction",
         )));
     }
 
-    // Reverse each path so they go from root commitment TX to VTXO.
-    let all_paths: Vec<Vec<Txid>> = all_paths
-        .into_iter()
-        .map(|mut path| {
-            path.reverse();
-            path
-        })
-        .collect();
-
-    Ok(all_paths)
+    Ok(vec![sorted])
 }
 
 /// The full path from a commitment transaction to a VTXO. The entire path must be published

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -683,7 +683,11 @@ pub fn finalize_unilateral_exit_tree(
                         )
                     })
             }
-            .expect("witness UTXO in path");
+            .ok_or_else(|| {
+                Error::ad_hoc(format!(
+                    "no witness UTXO found for virtual TX outpoint {virtual_tx_previous_output}"
+                ))
+            })?;
 
             let tx = finalize_virtual_tx_input(psbt, VTXO_INPUT_INDEX, witness_utxo)?;
 

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -533,13 +533,32 @@ fn condition_witness_elements(input: &psbt::Input) -> Result<Vec<Vec<u8>>, Error
         .map_err(|e| Error::transaction(format!("failed to decode condition count: {e}")))?
         .0;
 
-    let mut elements = Vec::with_capacity(element_count as usize);
+    let count_end = usize::try_from(cursor.position())
+        .map_err(|_| Error::transaction("condition cursor position overflow"))?;
+    let remaining_after_count = condition_data.len().saturating_sub(count_end);
+    let element_count = usize::try_from(element_count)
+        .map_err(|_| Error::transaction("condition witness element count overflow"))?;
+
+    // Each element needs at least a compact-size length byte, even when the element itself is
+    // empty.
+    if element_count > remaining_after_count {
+        return Err(Error::transaction(format!(
+            "condition witness element count {element_count} exceeds remaining buffer size {remaining_after_count}"
+        )));
+    }
+
+    let mut elements = Vec::with_capacity(element_count);
     for _ in 0..element_count {
         let element_len = VarInt::consensus_decode(&mut cursor)
             .map_err(|e| Error::transaction(format!("failed to decode condition length: {e}")))?
-            .0 as usize;
-        let start = cursor.position() as usize;
-        let end = start + element_len;
+            .0;
+        let element_len = usize::try_from(element_len)
+            .map_err(|_| Error::transaction("condition witness element length overflow"))?;
+        let start = usize::try_from(cursor.position())
+            .map_err(|_| Error::transaction("condition cursor position overflow"))?;
+        let end = start
+            .checked_add(element_len)
+            .ok_or_else(|| Error::transaction("condition witness element end overflow"))?;
 
         if condition_data.len() < end {
             return Err(Error::transaction(format!(

--- a/ark-core/src/unilateral_exit.rs
+++ b/ark-core/src/unilateral_exit.rs
@@ -1,14 +1,16 @@
 use crate::anchor_output;
+use crate::script::extract_checksig_pubkeys;
 use crate::server;
 use crate::BoardingOutput;
 use crate::Error;
 use crate::ErrorContext;
+use crate::VTXO_CONDITION_KEY;
 use crate::VTXO_INPUT_INDEX;
 use bitcoin::absolute::LockTime;
+use bitcoin::consensus::Decodable;
 use bitcoin::hashes::Hash;
 use bitcoin::hex::DisplayHex;
 use bitcoin::key::Secp256k1;
-use bitcoin::opcodes::all::*;
 use bitcoin::psbt;
 use bitcoin::secp256k1;
 use bitcoin::secp256k1::schnorr;
@@ -28,6 +30,7 @@ use bitcoin::Transaction;
 use bitcoin::TxIn;
 use bitcoin::TxOut;
 use bitcoin::Txid;
+use bitcoin::VarInt;
 use bitcoin::Weight;
 use bitcoin::Witness;
 use bitcoin::XOnlyPublicKey;
@@ -429,6 +432,126 @@ impl UnilateralExitTree {
     }
 }
 
+/// Finalize a virtual transaction input using only the authorization data already present in the
+/// PSBT input.
+///
+/// This is intended for historical virtual transactions in a unilateral-exit branch. The caller
+/// provides the `witness_utxo` for the input being finalized, and this function materializes either
+/// the taproot key-spend witness or a satisfiable taproot script-spend witness.
+pub fn finalize_virtual_tx_input(
+    mut psbt: Psbt,
+    input_index: usize,
+    witness_utxo: TxOut,
+) -> Result<Transaction, Error> {
+    let input = psbt
+        .inputs
+        .get_mut(input_index)
+        .ok_or_else(|| Error::transaction(format!("missing PSBT input {input_index}")))?;
+
+    input.witness_utxo = Some(witness_utxo);
+
+    let txid = psbt.unsigned_tx.compute_txid();
+
+    if let Some(tap_key_sig) = input.tap_key_sig {
+        tracing::debug!(%txid, "Finalizing key spend for confirmed VTXO");
+
+        input.final_script_witness = Some(Witness::p2tr_key_spend(&tap_key_sig));
+    } else {
+        tracing::debug!(%txid, "Finalizing script spend for pre-confirmed VTXO");
+
+        input.final_script_witness = Some(finalize_taproot_script_spend_witness(input)?);
+    }
+
+    psbt.extract_tx().map_err(Error::transaction)
+}
+
+/// Build the final witness for a taproot script-spend input from its PSBT data.
+///
+/// The selected tapleaf is the first tap script for which signatures are available for every
+/// `CHECKSIG`/`CHECKSIGVERIFY` pubkey in the script. Signatures are pushed in reverse script order.
+/// Extra condition witness elements, such as VHTLC preimages, are read from the
+/// `VTXO_CONDITION_KEY` unknown input field and pushed after signatures.
+pub fn finalize_taproot_script_spend_witness(input: &psbt::Input) -> Result<Witness, Error> {
+    for (control_block, (script, leaf_version)) in input.tap_scripts.iter() {
+        let leaf_hash = TapLeafHash::from_script(script, *leaf_version);
+        let pubkeys = extract_checksig_pubkeys(script);
+
+        if pubkeys.is_empty() {
+            continue;
+        }
+
+        let signatures = pubkeys
+            .iter()
+            .map(|pk| {
+                input
+                    .tap_script_sigs
+                    .get(&(*pk, leaf_hash))
+                    .map(|sig| sig.to_vec())
+            })
+            .collect::<Option<Vec<_>>>();
+
+        let Some(signatures) = signatures else {
+            continue;
+        };
+
+        let mut witness = Witness::new();
+
+        for signature in signatures.into_iter().rev() {
+            witness.push(signature);
+        }
+
+        for element in condition_witness_elements(input)? {
+            witness.push(element);
+        }
+
+        witness.push(script.as_bytes());
+        witness.push(control_block.serialize());
+
+        return Ok(witness);
+    }
+
+    Err(Error::transaction(
+        "no satisfiable taproot script-spend leaf found in PSBT input",
+    ))
+}
+
+fn condition_witness_elements(input: &psbt::Input) -> Result<Vec<Vec<u8>>, Error> {
+    let condition_key = psbt::raw::Key {
+        type_value: 222,
+        key: VTXO_CONDITION_KEY.to_vec(),
+    };
+
+    let Some(condition_data) = input.unknown.get(&condition_key) else {
+        return Ok(Vec::new());
+    };
+
+    let mut cursor = std::io::Cursor::new(condition_data);
+    let element_count = VarInt::consensus_decode(&mut cursor)
+        .map_err(|e| Error::transaction(format!("failed to decode condition count: {e}")))?
+        .0;
+
+    let mut elements = Vec::with_capacity(element_count as usize);
+    for _ in 0..element_count {
+        let element_len = VarInt::consensus_decode(&mut cursor)
+            .map_err(|e| Error::transaction(format!("failed to decode condition length: {e}")))?
+            .0 as usize;
+        let start = cursor.position() as usize;
+        let end = start + element_len;
+
+        if condition_data.len() < end {
+            return Err(Error::transaction(format!(
+                "condition witness element too short: expected {element_len} bytes, got {}",
+                condition_data.len().saturating_sub(start)
+            )));
+        }
+
+        elements.push(condition_data[start..end].to_vec());
+        cursor.set_position(end as u64);
+    }
+
+    Ok(elements)
+}
+
 /// Sign all the transactions needed to commit a VTXO on-chain.
 pub fn sign_unilateral_exit_tree(
     unilateral_exit_tree: &UnilateralExitTree,
@@ -438,8 +561,7 @@ pub fn sign_unilateral_exit_tree(
     for unilateral_exit_branch in unilateral_exit_tree.inner.iter() {
         let mut signed_unilateral_exit_branch = Vec::new();
         for virtual_tx in unilateral_exit_branch.iter() {
-            let txid = virtual_tx.unsigned_tx.compute_txid();
-            let mut psbt = virtual_tx.clone();
+            let psbt = virtual_tx.clone();
 
             let vtxo_previous_output = psbt.unsigned_tx.input[VTXO_INPUT_INDEX].previous_output;
 
@@ -456,59 +578,7 @@ pub fn sign_unilateral_exit_tree(
             }
             .expect("witness UTXO in path");
 
-            psbt.inputs[VTXO_INPUT_INDEX].witness_utxo = Some(witness_utxo);
-
-            if let Some(tap_key_sig) = psbt.inputs[VTXO_INPUT_INDEX].tap_key_sig {
-                tracing::debug!(%txid, "Signing key spend for confirmed VTXO");
-
-                psbt.inputs[VTXO_INPUT_INDEX].final_script_witness =
-                    Some(Witness::p2tr_key_spend(&tap_key_sig));
-            } else if !psbt.inputs[VTXO_INPUT_INDEX].tap_script_sigs.is_empty() {
-                tracing::debug!(%txid, "Signing script spend for pre-confirmed VTXO");
-
-                // We always take the first script.
-                let tap_script = psbt.inputs[VTXO_INPUT_INDEX].tap_scripts.iter().next();
-                let tap_script_sigs = &psbt.inputs[VTXO_INPUT_INDEX].tap_script_sigs;
-
-                let (control_block, (script, _)) = tap_script.ok_or_else(|| {
-                    Error::transaction(format!("missing tapscripts in virtual TX {txid}"))
-                })?;
-
-                // Extract pubkeys from the 2-of-2 multisig script to determine signature order.
-                let (pk_0, pk_1) = extract_pubkeys_from_2of2_script(script)?;
-
-                // Compute the TapLeafHash for the script to look up signatures.
-                let leaf_hash = TapLeafHash::from_script(script, control_block.leaf_version);
-
-                // Look up signatures in the correct order based on the pubkeys in the script.
-                let sig_0 = tap_script_sigs.get(&(pk_0, leaf_hash)).ok_or_else(|| {
-                    Error::transaction(format!(
-                        "missing signature for first pubkey {} in virtual TX {txid}",
-                        pk_0
-                    ))
-                })?;
-                let sig_1 = tap_script_sigs.get(&(pk_1, leaf_hash)).ok_or_else(|| {
-                    Error::transaction(format!(
-                        "missing signature for second pubkey {} in virtual TX {txid}",
-                        pk_1
-                    ))
-                })?;
-
-                // Construct witness: [sig_1, sig_0, script, control_block].
-                let mut witness = Witness::new();
-                witness.push(sig_1.to_vec());
-                witness.push(sig_0.to_vec());
-                witness.push(script.as_bytes());
-                witness.push(control_block.serialize());
-
-                psbt.inputs[VTXO_INPUT_INDEX].final_script_witness = Some(witness);
-            } else {
-                return Err(Error::transaction(format!(
-                    "missing taproot key spend or script spend data in virtual TX {txid}"
-                )));
-            };
-
-            let tx = psbt.clone().extract_tx().map_err(Error::transaction)?;
+            let tx = finalize_virtual_tx_input(psbt, VTXO_INPUT_INDEX, witness_utxo)?;
 
             signed_unilateral_exit_branch.push(tx);
         }
@@ -636,70 +706,4 @@ fn find_anchor_outpoint(tx: &Transaction) -> Result<OutPoint, Error> {
     }
 
     Err(Error::transaction("anchor output not found in transaction"))
-}
-
-/// Extract the two [`XOnlyPublicKey`]s from a 2-of-2 multisig tapscript.
-///
-/// The script format is: <pk_0> CHECKSIGVERIFY <pk_1> CHECKSIG
-fn extract_pubkeys_from_2of2_script(
-    script: &ScriptBuf,
-) -> Result<(XOnlyPublicKey, XOnlyPublicKey), Error> {
-    let bytes = script.as_bytes();
-
-    // Expected format: [0x20] [32 bytes pk_0] [CHECKSIGVERIFY] [0x20] [32 bytes pk_1] [CHECKSIG]
-    // Minimum length: 1 + 32 + 1 + 1 + 32 + 1 = 68 bytes
-    if bytes.len() < 68 {
-        return Err(Error::transaction(format!(
-            "script too short to be 2-of-2 multisig: {} bytes",
-            bytes.len()
-        )));
-    }
-
-    // Check first push is 32 bytes
-    if bytes[0] != 0x20 {
-        return Err(Error::transaction(format!(
-            "expected OP_PUSHBYTES_32 (0x20) at position 0, got 0x{:02x}",
-            bytes[0]
-        )));
-    }
-
-    // Extract first pubkey (bytes 1-32)
-    let pk_0_bytes: [u8; 32] = bytes[1..33]
-        .try_into()
-        .map_err(|_| Error::transaction("failed to extract first pubkey bytes"))?;
-    let pk_0 = XOnlyPublicKey::from_slice(&pk_0_bytes)
-        .map_err(|e| Error::transaction(format!("invalid first pubkey: {e}")))?;
-
-    // Check CHECKSIGVERIFY at position 33
-    if bytes[33] != OP_CHECKSIGVERIFY.to_u8() {
-        return Err(Error::transaction(format!(
-            "expected OP_CHECKSIGVERIFY (0xad) at position 33, got 0x{:02x}",
-            bytes[33]
-        )));
-    }
-
-    // Check second push is 32 bytes at position 34
-    if bytes[34] != 0x20 {
-        return Err(Error::transaction(format!(
-            "expected OP_PUSHBYTES_32 (0x20) at position 34, got 0x{:02x}",
-            bytes[34]
-        )));
-    }
-
-    // Extract second pubkey (bytes 35-66)
-    let pk_1_bytes: [u8; 32] = bytes[35..67]
-        .try_into()
-        .map_err(|_| Error::transaction("failed to extract second pubkey bytes"))?;
-    let pk_1 = XOnlyPublicKey::from_slice(&pk_1_bytes)
-        .map_err(|e| Error::transaction(format!("invalid second pubkey: {e}")))?;
-
-    // Check CHECKSIG at position 67
-    if bytes[67] != OP_CHECKSIG.to_u8() {
-        return Err(Error::transaction(format!(
-            "expected OP_CHECKSIG (0xac) at position 67, got 0x{:02x}",
-            bytes[67]
-        )));
-    }
-
-    Ok((pk_0, pk_1))
 }

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -1,0 +1,193 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use ark_client::wallet::OnchainWallet;
+use ark_client::SwapAmount;
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::key::Secp256k1;
+use bitcoin::relative;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::Nigiri;
+use std::process::Stdio;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Child;
+use tokio::process::Command;
+
+mod common;
+
+#[tokio::test]
+#[ignore]
+pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
+    // Requires the Boltz regtest environment. See scripts/boltz-setup.sh.
+    init_tracing();
+
+    let nigiri = Arc::new(Nigiri::new());
+    let secp = Secp256k1::new();
+
+    let (alice, alice_wallet) =
+        set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+
+    // The unilateral exit transactions are fee-bumped through Alice's on-chain wallet.
+    let alice_onchain_address = alice.get_onchain_address().unwrap();
+    for _ in 0..5 {
+        nigiri
+            .faucet_fund(&alice_onchain_address, Amount::from_sat(100_000))
+            .await;
+    }
+
+    let invoice_amount = SwapAmount::invoice(Amount::from_sat(10_000));
+    let reverse_swap = alice
+        .get_ln_invoice(invoice_amount, None, None)
+        .await
+        .unwrap();
+
+    tracing::info!(
+        invoice = %reverse_swap.invoice,
+        swap_id = reverse_swap.swap_id,
+        "Generated Boltz reverse swap invoice"
+    );
+
+    let mut payment = start_ln_payment(&reverse_swap.invoice.to_string());
+
+    let claim = alice.wait_for_vhtlc(&reverse_swap.swap_id).await.unwrap();
+    wait_for_ln_payment(&mut payment).await;
+
+    wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: claim.claim_amount);
+
+    let unilateral_exit_trees = alice.build_unilateral_exit_trees().await.unwrap();
+    assert!(
+        !unilateral_exit_trees.is_empty(),
+        "expected a unilateral exit tree for the VTXO claimed from the VHTLC"
+    );
+
+    // Mine blocks regularly to ensure any transaction published by the Ark server confirms.
+    tokio::spawn({
+        let nigiri = nigiri.clone();
+        let alice_wallet = alice_wallet.clone();
+        async move {
+            loop {
+                nigiri.mine(1).await;
+                alice_wallet.sync().await.unwrap();
+
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    });
+
+    for (i, unilateral_exit_tree) in unilateral_exit_trees.iter().enumerate() {
+        while let Some(txid) = alice
+            .broadcast_next_unilateral_exit_node(unilateral_exit_tree)
+            .await
+            .expect("to broadcast unilateral exit node")
+        {
+            tracing::info!(i, %txid, "Broadcast virtual transaction");
+
+            // Each transaction needs a confirmation so the next transaction in the tree can use
+            // the P2A fee-bump output.
+            nigiri.mine(1).await;
+            alice_wallet.sync().await.unwrap();
+        }
+
+        tracing::debug!(i, "Finished with unilateral exit tree");
+    }
+
+    // Confirm the exited VTXO itself.
+    nigiri.mine(1).await;
+    alice_wallet.sync().await.unwrap();
+
+    wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: Amount::ZERO);
+
+    let mut max_block_height_offset = 0;
+    let mut max_blocktime_offset = 0;
+
+    match alice
+        .server_info
+        .unilateral_exit_delay
+        .to_relative_lock_time()
+        .expect("unilateral VTXO exit delay should be relative")
+    {
+        relative::LockTime::Blocks(height) => {
+            max_block_height_offset = height.value();
+        }
+        relative::LockTime::Time(time) => {
+            max_blocktime_offset = time.value() * 512;
+        }
+    };
+
+    nigiri.set_outpoint_block_height_offset(max_block_height_offset as u64);
+    nigiri.set_outpoint_blocktime_offset(max_blocktime_offset as u64);
+
+    let send_amount = claim.claim_amount - Amount::from_sat(1_000);
+    let (tx, prevouts) = alice
+        .create_send_on_chain_transaction(
+            bitcoin::Address::<NetworkUnchecked>::from_str(
+                "bcrt1q8df4sx3hz63tq44ve3q6tr4qz0q30usk5sntpt",
+            )
+            .unwrap()
+            .assume_checked(),
+            send_amount,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(tx.input.len(), prevouts.len());
+    assert!(
+        !prevouts.is_empty(),
+        "expected the unilaterally exited VTXO to be spendable on-chain"
+    );
+
+    for (i, prevout) in prevouts.iter().enumerate() {
+        let script_pubkey = prevout.script_pubkey.clone();
+        let amount = prevout.value;
+        let spent_outputs = prevouts
+            .iter()
+            .map(|o| bitcoinconsensus::Utxo {
+                script_pubkey: o.script_pubkey.as_bytes().as_ptr(),
+                script_pubkey_len: o.script_pubkey.len() as u32,
+                value: o.value.to_sat() as i64,
+            })
+            .collect::<Vec<_>>();
+
+        bitcoinconsensus::verify(
+            script_pubkey.as_bytes(),
+            amount.to_sat(),
+            bitcoin::consensus::serialize(&tx).as_slice(),
+            Some(&spent_outputs),
+            i,
+        )
+        .expect("valid input");
+    }
+}
+
+fn start_ln_payment(invoice: &str) -> Child {
+    // Boltz reverse swap invoices are settled only after Alice claims the VHTLC and reveals the
+    // preimage, so we must not wait for `payinvoice` before calling `wait_for_vhtlc`.
+    Command::new("docker")
+        .args([
+            "exec",
+            "lnd",
+            "lncli",
+            "--network=regtest",
+            "payinvoice",
+            "--force",
+            invoice,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to execute lncli payinvoice")
+}
+
+async fn wait_for_ln_payment(payment: &mut Child) {
+    let status = tokio::time::timeout(Duration::from_secs(30), payment.wait())
+        .await
+        .expect("LN payment did not complete after VHTLC claim")
+        .expect("failed to wait for lncli payinvoice");
+
+    assert!(status.success(), "failed to pay invoice: {status}");
+}

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -10,12 +10,12 @@ use bitcoin::Amount;
 use common::init_tracing;
 use common::set_up_client;
 use common::Nigiri;
-use std::process::Stdio;
+use std::process::Output;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::process::Child;
 use tokio::process::Command;
+use tokio::task::JoinHandle;
 
 mod common;
 
@@ -53,8 +53,23 @@ pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
 
     let mut payment = start_ln_payment(&reverse_swap.invoice.to_string());
 
-    let claim = alice.wait_for_vhtlc(&reverse_swap.swap_id).await.unwrap();
-    wait_for_ln_payment(&mut payment).await;
+    let claim = tokio::select! {
+        res = alice.wait_for_vhtlc(&reverse_swap.swap_id) => res.unwrap(),
+        payment_res = &mut payment => {
+            let output = payment_res
+                .expect("lncli payinvoice task panicked")
+                .expect("failed to wait for lncli payinvoice");
+            panic!(
+                "lncli payinvoice exited before the VHTLC was claimed: {}",
+                format_ln_payment_output(&output)
+            );
+        }
+        () = tokio::time::sleep(Duration::from_secs(120)) => {
+            payment.abort();
+            panic!("timed out waiting for Boltz to fund and claim the VHTLC");
+        }
+    };
+    wait_for_ln_payment(payment).await;
 
     wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: claim.claim_amount);
 
@@ -163,31 +178,45 @@ pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
     }
 }
 
-fn start_ln_payment(invoice: &str) -> Child {
+fn start_ln_payment(invoice: &str) -> JoinHandle<std::io::Result<Output>> {
     // Boltz reverse swap invoices are settled only after Alice claims the VHTLC and reveals the
     // preimage, so we must not wait for `payinvoice` before calling `wait_for_vhtlc`.
-    Command::new("docker")
-        .args([
-            "exec",
-            "lnd",
-            "lncli",
-            "--network=regtest",
-            "payinvoice",
-            "--force",
-            invoice,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
-        .expect("failed to execute lncli payinvoice")
+    let invoice = invoice.to_string();
+    tokio::spawn(async move {
+        Command::new("docker")
+            .args([
+                "exec",
+                "lnd",
+                "lncli",
+                "--network=regtest",
+                "payinvoice",
+                "--force",
+                &invoice,
+            ])
+            .output()
+            .await
+    })
 }
 
-async fn wait_for_ln_payment(payment: &mut Child) {
-    let status = tokio::time::timeout(Duration::from_secs(30), payment.wait())
+async fn wait_for_ln_payment(payment: JoinHandle<std::io::Result<Output>>) {
+    let output = tokio::time::timeout(Duration::from_secs(30), payment)
         .await
         .expect("LN payment did not complete after VHTLC claim")
+        .expect("lncli payinvoice task panicked")
         .expect("failed to wait for lncli payinvoice");
 
-    assert!(status.success(), "failed to pay invoice: {status}");
+    assert!(
+        output.status.success(),
+        "failed to pay invoice: {}",
+        format_ln_payment_output(&output)
+    );
+}
+
+fn format_ln_payment_output(output: &Output) -> String {
+    format!(
+        "status={} stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
 }


### PR DESCRIPTION
Fix #225.

This only expands the number of ancestor scripts that are supported, but I wonder if a better solution would be for the server to return ancestor virtual transactions that are already finalised. After all, the transaction has already been accepted into the virtual mempool, so the client here is only repeating what the original sender + Arkade had to do to publish it in the first place. It's possible that this feature already exists and I'm not aware of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated batch-tree handling and signing flows for batch transactions.
  * Refactored unilateral-exit processing to finalize exit transaction branches.

* **Documentation**
  * Standardized “batch-tree” terminology and clarified VTXO pre-confirmation details.

* **Tests**
  * Added an end-to-end regtest for reverse-swap unilateral exit scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/rust-sdk/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->