### PR TITLE
fix(grpc): set tls_config on manual endpoint connect

### DIFF
--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -117,8 +117,8 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
-        let endpoint = tonic::transport::Endpoint::from_shared(self.url.clone())
-            .map_err(Error::connect)?;
+        let endpoint =
+            tonic::transport::Endpoint::from_shared(self.url.clone()).map_err(Error::connect)?;
 
         #[cfg(any(feature = "tls-webpki-roots", feature = "tls-native-roots"))]
         let endpoint = {

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -117,11 +117,20 @@ impl Client {
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
-        let channel = tonic::transport::Endpoint::from_shared(self.url.clone())
-            .map_err(Error::connect)?
-            .connect()
-            .await
+        let endpoint = tonic::transport::Endpoint::from_shared(self.url.clone())
             .map_err(Error::connect)?;
+
+        #[cfg(any(feature = "tls-webpki-roots", feature = "tls-native-roots"))]
+        let endpoint = {
+            let tls = tonic::transport::ClientTlsConfig::new();
+            #[cfg(feature = "tls-webpki-roots")]
+            let tls = tls.with_webpki_roots();
+            #[cfg(feature = "tls-native-roots")]
+            let tls = tls.with_native_roots();
+            endpoint.tls_config(tls).map_err(Error::connect)?
+        };
+
+        let channel = endpoint.connect().await.map_err(Error::connect)?;
 
         let ark_service_client =
             ArkServiceClient::with_interceptor(channel.clone(), VersionInterceptor);


### PR DESCRIPTION
#229 switched `Client::connect` from the generated `Client::connect(url)` static to building the channel manually via `Endpoint::from_shared(url).connect()`, but the manual path does not apply TLS configuration. In tonic 0.14 the `tls-webpki-roots` / `tls-native-roots` feature flags pull in rustls without auto-configuring a `ClientTlsConfig`, so HTTPS Ark servers became unreachable in v0.9.1 with a generic transport error.

Apply `ClientTlsConfig` with webpki or native roots based on the enabled feature flag, gated so non-TLS builds remain unaffected.

Resolves #232.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gRPC client connection reliability by explicitly establishing the transport channel and surfacing clearer connection errors.
  * Added conditional TLS handling to support different root certificate configurations, reducing connection failures in secured environments.
  * Enhanced robustness during initial connection setup to improve overall startup stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/rust-sdk/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->