### PR TITLE
Add crates release workflows

### DIFF
--- a/.github/workflows/create_release_crates.yml
+++ b/.github/workflows/create_release_crates.yml
@@ -1,0 +1,174 @@
+name: "Create crates release"
+run-name: "Release ${{ github.event.pull_request.head.ref }}"
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  release:
+    name: "Publish crates and create release"
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/crates-')
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Extract version from branch name
+        id: v
+        run: |
+          set -euo pipefail
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/crates-}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release branch/version: $BRANCH"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Validate required secrets
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not set."
+            exit 1
+          fi
+
+      - name: Verify crate versions
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.publish != []) | [.name, .version] | @tsv' \
+            | while IFS=$'\t' read -r name actual; do
+                if [ "$actual" != "$VERSION" ]; then
+                  echo "::error::$name is $actual, expected $VERSION"
+                  exit 1
+                fi
+              done
+
+      - name: Run tests
+        run: cargo test --workspace --all-features
+
+      - name: Publish crates to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          crate_published() {
+            local crate="$1"
+            curl -fsS "https://crates.io/api/v1/crates/$crate/$VERSION" >/dev/null 2>&1
+          }
+
+          wait_until_published() {
+            local crate="$1"
+            for attempt in {1..30}; do
+              if crate_published "$crate"; then
+                echo "$crate $VERSION is visible on crates.io"
+                return 0
+              fi
+              echo "Waiting for $crate $VERSION to appear on crates.io ($attempt/30)..."
+              sleep 10
+            done
+
+            echo "::error::$crate $VERSION did not appear on crates.io in time"
+            return 1
+          }
+
+          publish_crate() {
+            local crate="$1"
+
+            if crate_published "$crate"; then
+              echo "$crate $VERSION is already published; skipping"
+              return 0
+            fi
+
+            echo "::group::Publishing $crate $VERSION"
+            for attempt in {1..5}; do
+              if cargo publish -p "$crate"; then
+                echo "::endgroup::"
+                wait_until_published "$crate"
+                return 0
+              fi
+
+              echo "Publish attempt $attempt for $crate failed; retrying after crates.io index delay..."
+              sleep $((attempt * 30))
+            done
+
+            echo "::error::Failed to publish $crate $VERSION"
+            echo "::endgroup::"
+            return 1
+          }
+
+          # Leaf crates: no internal unpublished dependencies.
+          publish_crate ark-core
+          publish_crate ark-fees
+          publish_crate ark-script
+          publish_crate ark-introspector-client
+
+          # Mid-level crates.
+          publish_crate ark-grpc
+          publish_crate ark-rest
+          publish_crate ark-delegator
+
+          # Top-level crates.
+          publish_crate ark-client
+          publish_crate ark-bdk-wallet
+          publish_crate ark-rs
+
+      - name: Create tag
+        env:
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally"
+          else
+            git tag "$TAG" "${{ github.event.pull_request.merge_commit_sha }}"
+          fi
+
+          git push origin "$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.v.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --target "${{ github.event.pull_request.merge_commit_sha }}" \
+              --generate-notes
+          fi

--- a/.github/workflows/draft_release_crates.yml
+++ b/.github/workflows/draft_release_crates.yml
@@ -1,0 +1,161 @@
+name: "Draft crates release"
+run-name: "Draft crates ${{ inputs.version != '' && inputs.version || inputs.bump }} release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Which part of the current version to bump"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: "Explicit version to release, e.g. 0.9.2. Leave empty to use bump."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  draft:
+    name: "Draft crates release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute release version
+        id: v
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+              echo "::error::Invalid version: $VERSION"
+              exit 1
+            fi
+          else
+            CURRENT=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "ark-core") | .version')
+            IFS=. read -r MAJOR MINOR PATCH <<< "${CURRENT%%-*}"
+
+            case "${{ inputs.bump }}" in
+              patch) PATCH=$((PATCH + 1)) ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              *) echo "::error::Unknown bump: ${{ inputs.bump }}"; exit 1 ;;
+            esac
+
+            VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "branch=release/crates-$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Bump workspace crate versions
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          crates=(
+            ark-bdk-wallet
+            ark-client
+            ark-core
+            ark-delegator
+            ark-fees
+            ark-grpc
+            ark-rest
+            ark-script
+            ark-introspector-client
+            ark-rs
+          )
+
+          for crate in "${crates[@]}" ark-client-sample; do
+            perl -0pi -e 's/^version = "[^"]+"/version = "'"$VERSION"'"/m; s/(ark-[a-z-]+ = \{ path = "\.\.\/ark-[a-z-]+", version = ")[^"]+("[^}]*\})/${1}'"$VERSION"'$2/g' "$crate/Cargo.toml"
+          done
+
+          for file in README.md "${crates[@]/%//README.md}"; do
+            perl -0pi -e 's/(ark-[a-z-]+ = \{ version = ")[^"]+("[^}]*\})/${1}'"$VERSION"'$2/g; s/(ark-[a-z-]+ = ")[^"]+("\s*)/${1}'"$VERSION"'$2/g' "$file"
+          done
+
+          cargo metadata --format-version 1 --locked >/dev/null || cargo metadata --format-version 1 >/dev/null
+
+      - name: Validate release bump
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          cargo fmt --all
+          cargo check --workspace --all-features
+
+          cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.publish != []) | [.name, .version] | @tsv' \
+            | while IFS=$'\t' read -r name actual; do
+                if [ "$actual" != "$VERSION" ]; then
+                  echo "::error::$name is $actual, expected $VERSION"
+                  exit 1
+                fi
+              done
+
+      - name: Create release branch and commit
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+          BRANCH: ${{ steps.v.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore: prepare $VERSION release"
+          git push origin "$BRANCH" --force
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || github.token }}
+          VERSION: ${{ steps.v.outputs.version }}
+          BRANCH: ${{ steps.v.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          BODY=$(cat <<EOF
+          Release ark-rs crates v$VERSION.
+
+          Triggered by @${{ github.actor }} via ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+
+          Merging this PR will trigger the crates release workflow, which will:
+          1. Run the workspace test suite
+          2. Publish all public crates to crates.io in dependency order
+          3. Create and push tag \`v$VERSION\`
+          4. Create the GitHub release \`v$VERSION\`
+          EOF
+          )
+
+          gh pr create \
+            --reviewer "${{ github.actor }}" \
+            --title "Release crates version $VERSION" \
+            --head "$BRANCH" \
+            --body "$BODY"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to publish Rust crates to crates.io and create corresponding GitHub releases upon merge to release branches
  * Added automated workflow to draft release pull requests with version updates across the Rust workspace

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/rust-sdk/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->