### PR TITLE
Do not put `submit_offchain_tx` behind feature flag

### DIFF
--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -152,8 +152,6 @@ where
         self.fetch_pending_offchain_txs().await
     }
 
-    // Test-only function
-
     /// Build, sign and submit an offchain transaction to the server without finalizing.
     ///
     /// This is primarily useful for testing pending transaction recovery flows.
@@ -161,7 +159,6 @@ where
     /// Returns the Ark TXID. The transaction will remain in a pending state on the server until
     /// [`Self::finalize_pending_offchain_tx`] or [`Self::continue_pending_offchain_txs`] completes
     /// it.
-    #[cfg(feature = "test-utils")]
     pub async fn submit_offchain_tx(
         &self,
         vtxo_inputs: Vec<VtxoInput>,


### PR DESCRIPTION
It can actually be useful for consumers to control what happens between submit and finalize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Off-chain transaction submission is now fully integrated into the stable public API and available by default. Previously accessible only when test utilities were explicitly enabled, this functionality is now part of the standard feature set, enabling users to manage virtual transactions without requiring additional configuration or feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->