### PR TITLE
Restore finalize pending offchain tx API

### DIFF
--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -111,6 +111,33 @@ where
 
     // Pending transactions
 
+    /// Finalize a specific pending offchain transaction.
+    ///
+    /// Fetches the pending transaction identified by `ark_txid` from the server, signs the
+    /// checkpoint transactions, and finalizes it.
+    ///
+    /// This is useful when you need fine-grained control over which pending transaction to
+    /// finalize (e.g. when a database tracks individual pending funding attempts).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no pending transaction with the given `ark_txid` is found, or if
+    /// signing / finalization fails.
+    pub async fn finalize_pending_offchain_tx(&self, ark_txid: Txid) -> Result<(), Error> {
+        let pending_txs = self.fetch_pending_offchain_txs().await?;
+
+        let pending_tx = pending_txs
+            .into_iter()
+            .find(|tx| tx.ark_txid == ark_txid)
+            .ok_or_else(|| {
+                Error::ad_hoc(format!(
+                    "no pending transaction found for ark txid {ark_txid}"
+                ))
+            })?;
+
+        self.sign_and_finalize_pending_tx(pending_tx).await
+    }
+
     /// Resume and finalize any pending (submitted but not finalized) offchain transactions.
     ///
     /// This handles the case where `send_vtxo` successfully submitted the transaction to the

--- a/e2e-tests/tests/e2e_finalize_pending_tx.rs
+++ b/e2e-tests/tests/e2e_finalize_pending_tx.rs
@@ -1,0 +1,120 @@
+#![allow(clippy::unwrap_used)]
+
+use ark_core::coin_select::select_vtxos;
+use ark_core::send::VtxoInput;
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::wait_until_balance;
+use common::Nigiri;
+use rand::thread_rng;
+use std::sync::Arc;
+
+mod common;
+
+/// Test that a specific pending offchain transaction can be recovered by txid.
+///
+/// Simulates a crash between submit and finalize by using `submit_offchain_tx` (which does
+/// not call finalize), then recovering only that transaction with `finalize_pending_offchain_tx`.
+#[tokio::test]
+#[ignore]
+pub async fn e2e_finalize_pending_tx() {
+    init_tracing();
+    let nigiri = Arc::new(Nigiri::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let (alice, _) = set_up_client("alice".to_string(), nigiri.clone(), secp.clone()).await;
+    let (bob, _) = set_up_client("bob".to_string(), nigiri.clone(), secp).await;
+
+    // Fund Alice via boarding.
+    let alice_fund_amount = Amount::ONE_BTC;
+    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    nigiri
+        .faucet_fund(&alice_boarding_address, alice_fund_amount)
+        .await;
+
+    alice.settle(&mut rng).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    wait_until_balance!(&alice, confirmed: alice_fund_amount);
+    tracing::info!("Alice has confirmed VTXO");
+
+    // Build VTXO inputs for the offchain tx.
+    let send_amount = Amount::from_sat(100_000);
+    let (bob_address, _) = bob.get_offchain_address().unwrap();
+
+    let (vtxo_list, script_pubkey_to_vtxo_map) = alice.list_vtxos().await.unwrap();
+
+    let spendable = vtxo_list
+        .spendable_offchain()
+        .map(|vtxo| ark_core::coin_select::VirtualTxOutPoint {
+            outpoint: vtxo.outpoint,
+            script_pubkey: vtxo.script.clone(),
+            expire_at: vtxo.expires_at,
+            amount: vtxo.amount,
+            assets: vtxo.assets.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    let selected = select_vtxos(spendable, send_amount, alice.server_info.dust, true).unwrap();
+
+    let vtxo_inputs: Vec<VtxoInput> = selected
+        .into_iter()
+        .map(|coin| {
+            let vtxo = script_pubkey_to_vtxo_map.get(&coin.script_pubkey).unwrap();
+            let (forfeit_script, control_block) = vtxo.forfeit_spend_info().unwrap();
+            VtxoInput::new(
+                forfeit_script,
+                None,
+                control_block,
+                vtxo.tapscripts(),
+                vtxo.script_pubkey(),
+                coin.amount,
+                coin.outpoint,
+                coin.assets,
+            )
+        })
+        .collect();
+
+    // Submit the offchain tx but do NOT finalize (simulating a crash).
+    let ark_txid = alice
+        .submit_offchain_tx(vtxo_inputs, bob_address, send_amount)
+        .await
+        .unwrap();
+
+    tracing::info!(%ark_txid, "Submitted offchain tx without finalizing (simulating crash)");
+
+    // Small delay for server to process the submission.
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let pending = alice.list_pending_offchain_txs().await.unwrap();
+    assert!(
+        pending.iter().any(|tx| tx.ark_txid == ark_txid),
+        "should find pending tx {ark_txid} before finalizing"
+    );
+
+    // Recover only the requested pending transaction.
+    alice.finalize_pending_offchain_tx(ark_txid).await.unwrap();
+
+    // Verify there is nothing left for the broad recovery API to finalize.
+    let finalized = alice.continue_pending_offchain_txs().await.unwrap();
+    assert!(
+        finalized.is_empty(),
+        "specific finalize should leave no pending txs, got {finalized:?}"
+    );
+
+    // Verify balances.
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    wait_until_balance!(
+        &alice,
+        pre_confirmed: alice_fund_amount - send_amount,
+    );
+    wait_until_balance!(
+        &bob,
+        pre_confirmed: send_amount,
+    );
+
+    tracing::info!("Balances verified after specific pending tx recovery");
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now finalize specific pending offchain transactions by transaction ID, enabling selective recovery of transactions after disruptions.

* **Tests**
  * Added end-to-end test for pending transaction recovery and crash-recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->