### PR TITLE
Invalidate info cache based on digest header + fix build header

### DIFF
--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -769,7 +769,7 @@ async fn run_command<K: KeyProvider + 'static>(
             unreachable!("pending future never resolves");
         }
         Commands::SendOnchain { address, amount } => {
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -798,7 +798,7 @@ async fn run_command<K: KeyProvider + 'static>(
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -1201,7 +1201,7 @@ async fn run_command<K: KeyProvider + 'static>(
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         Commands::EstimateFees { address, amount } => {
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let mut rng = thread_rng();
 
             // Try parsing as ArkAddress first, then as Bitcoin address
@@ -1293,7 +1293,7 @@ async fn run_command<K: KeyProvider + 'static>(
             let selected = ark_core::coin_select::select_vtxos(
                 spendable,
                 amount,
-                client.server_info.dust,
+                client.server_info()?.dust,
                 true,
             )
             .map_err(|e| anyhow!(e))?;
@@ -1426,7 +1426,7 @@ async fn run_command<K: KeyProvider + 'static>(
 
             let receiver = SendReceiver {
                 address: address.0,
-                amount: client.dust(),
+                amount: client.dust()?,
                 assets: vec![ark_core::server::Asset {
                     asset_id,
                     amount: *amount,

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -58,8 +58,12 @@ wasm-bindgen-futures = { version = "0.4" }
 tonic-build = { version = "0.14" }
 
 [dev-dependencies]
+ark-grpc = { path = "../ark-grpc", version = "0.9.2", default-features = false, features = ["test-utils"] }
+rustls = { version = "0.23", features = ["ring"] }
 tempfile = "3.8"
-tokio = { version = "1.41.0", features = ["macros", "rt"] }
+tokio = { version = "1.41.0", features = ["macros", "net", "rt-multi-thread", "sync"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic-prost = "0.14"
 
 [features]
 default = ["tls-native-roots"]

--- a/ark-client/src/asset.rs
+++ b/ark-client/src/asset.rs
@@ -51,17 +51,13 @@ where
             return Err(Error::ad_hoc("asset amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let (own_address, _) = self.get_offchain_address()?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
-        let selected_coins = select_vtxos(
-            spendable,
-            self.server_info.dust,
-            self.server_info.dust,
-            true,
-        )
-        .map_err(Error::from)
-        .context("failed to select coins for asset issuance")?;
+        let selected_coins = select_vtxos(spendable, server_info.dust, server_info.dust, true)
+            .map_err(Error::from)
+            .context("failed to select coins for asset issuance")?;
 
         let issuance_inputs = self.build_vtxo_inputs(selected_coins, &script_pubkey_to_vtxo_map)?;
         let (change_address, change_address_vtxo) = self.get_offchain_address()?;
@@ -74,7 +70,7 @@ where
             &own_address,
             &change_address,
             &issuance_inputs,
-            &self.server_info,
+            &server_info,
             amount,
             control_asset_config,
             metadata,
@@ -107,6 +103,7 @@ where
             return Err(Error::ad_hoc("reissue amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let asset_info = self
             .get_asset(asset_id)
             .await
@@ -130,8 +127,7 @@ where
             control_coins.iter().map(|coin| coin.outpoint).collect();
         let mut selected = control_coins;
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
-        let btc_shortfall = self
-            .server_info
+        let btc_shortfall = server_info
             .dust
             .checked_sub(btc_provided)
             .unwrap_or(Amount::ZERO);
@@ -143,7 +139,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for reissuance")?;
 
@@ -165,7 +161,7 @@ where
             &self_address,
             &change_address,
             &reissuance_inputs,
-            &self.server_info,
+            &server_info,
             asset_id,
             control_asset_id,
             amount,
@@ -192,6 +188,7 @@ where
             return Err(Error::ad_hoc("burn amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
         let (asset_coins, asset_change) = select_vtxos_for_asset(&spendable, amount, asset_id)
@@ -211,9 +208,9 @@ where
         }
 
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
-        let mut btc_needed = self.server_info.dust;
+        let mut btc_needed = server_info.dust;
         if carries_asset_change {
-            btc_needed += self.server_info.dust;
+            btc_needed += server_info.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -224,7 +221,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset burn")?;
 
@@ -243,7 +240,7 @@ where
             &own_address,
             &change_address,
             &burn_inputs,
-            &self.server_info,
+            &server_info,
             asset_id,
             amount,
         )

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -278,14 +278,10 @@ where
         let (boarding_inputs, vtxo_inputs, total_amount) =
             self.fetch_commitment_transaction_inputs().await?;
 
-        let onchain_fee = self
-            .fee_estimator
-            .eval_onchain_output(ark_fees::Output {
-                amount: to_amount.to_sat(),
-                script: to_address.script_pubkey().to_string(),
-            })
-            .map_err(Error::ad_hoc)?;
-        let onchain_fee = Amount::from_sat(onchain_fee.to_satoshis());
+        let onchain_fee = self.eval_onchain_output_fee(ark_fees::Output {
+            amount: to_amount.to_sat(),
+            script: to_address.script_pubkey().to_string(),
+        })?;
 
         // Fee comes out of change, not the send amount.
         let change_amount = total_amount
@@ -391,14 +387,10 @@ where
             .iter()
             .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.amount());
 
-        let onchain_fee = self
-            .fee_estimator
-            .eval_onchain_output(ark_fees::Output {
-                amount: to_amount.to_sat(),
-                script: to_address.script_pubkey().to_string(),
-            })
-            .map_err(Error::ad_hoc)?;
-        let onchain_fee = Amount::from_sat(onchain_fee.to_satoshis());
+        let onchain_fee = self.eval_onchain_output_fee(ark_fees::Output {
+            amount: to_amount.to_sat(),
+            script: to_address.script_pubkey().to_string(),
+        })?;
 
         // Fee comes out of change, not the send amount.
         let change_amount = total_input_amount
@@ -481,7 +473,7 @@ where
             return Err(Error::ad_hoc("no inputs to settle via delegate"));
         }
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let mut outputs = vec![intent::Output::Offchain(TxOut {
             value: total_amount,
@@ -579,7 +571,7 @@ where
         tracing::debug!(intent_id, "Registered delegated intent");
 
         let network_client = self.network_client();
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         #[derive(Debug, PartialEq, Eq)]
         enum Step {
@@ -1142,7 +1134,7 @@ where
                 .collect::<Vec<_>>()
         };
 
-        let dust = self.server_info.dust;
+        let dust = self.server_info()?.dust;
 
         let mut outputs = vec![];
 
@@ -1151,7 +1143,7 @@ where
                 to_address,
                 to_amount,
             } => {
-                if to_amount < self.server_info.dust {
+                if to_amount < dust {
                     return Err(Error::ad_hoc(format!(
                         "cannot settle into sub-dust VTXO: {to_amount} < {dust}"
                     )));
@@ -1332,7 +1324,7 @@ where
             .map(|i| i.outpoint())
             .collect::<Vec<_>>();
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let own_cosigner_kps = [cosigner_keypair];
         let own_cosigner_pks = own_cosigner_kps

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -540,12 +540,13 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -563,7 +564,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -580,7 +581,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -634,7 +635,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -708,12 +709,13 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -731,7 +733,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -748,7 +750,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut recoverable = vtxo_list.recoverable();
@@ -823,12 +825,13 @@ where
             .ok_or(Error::ad_hoc("submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -846,7 +849,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -863,7 +866,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -916,7 +919,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )?;
 
         // Sign the ark transaction with the sender's (user's) key.
@@ -1058,7 +1061,8 @@ where
             return Ok(());
         };
 
-        let server_signer: XOnlyPublicKey = self.server_info.signer_pk.into();
+        let server_info = self.server_info()?;
+        let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
         if recipient_address.server() != server_signer {
             return Err(Error::consumer(format!(
                 "recipient Arkade address belongs to a different server: expected {server_signer}, got {}",
@@ -1430,12 +1434,13 @@ where
         tracing::debug!(swap_id, "Claiming VHTLC with verified preimage");
 
         let timeout_block_heights = swap.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1453,7 +1458,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1472,7 +1477,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1522,7 +1527,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -1680,12 +1685,13 @@ where
         tracing::debug!("Ark transaction for swap found");
 
         let timeout_block_heights = swap.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1703,7 +1709,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1722,7 +1728,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1772,7 +1778,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2101,12 +2107,13 @@ where
                  (this swap's server lockup is on-chain BTC, not an Ark VHTLC)"
             ))
         })?;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.server_refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2124,7 +2131,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -2144,7 +2151,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             let vhtlc_outpoint = unspent.next().ok_or_else(|| {
@@ -2191,7 +2198,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2461,13 +2468,14 @@ where
         })?;
 
         let preimage_hash = ripemd160::Hash::hash(swap.preimage_hash.as_byte_array());
+        let server_info = self.server_info()?;
 
         // User's lockup VHTLC: sender=user(refund), receiver=server(claim)
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.server_claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2485,7 +2493,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -2504,7 +2512,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             unspent
@@ -2553,7 +2561,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &server_info,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -3390,11 +3398,12 @@ where
         preimage_hash: ripemd160::Hash,
         timeout_block_heights: &TimeoutBlockHeights,
     ) -> Result<VhtlcScript, Error> {
+        let server_info = self.server_info()?;
         VhtlcScript::new(
             VhtlcOptions {
                 sender: refund_public_key.inner.x_only_public_key().0,
                 receiver: claim_public_key.inner.x_only_public_key().0,
-                server: self.server_info.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -3412,7 +3421,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
     }

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -26,6 +26,8 @@ enum Kind {
     CoinSelect(CoinSelectError),
     /// An error related to actions within the wallet.
     Wallet(WalletError),
+    /// Ark server info changed while processing a request.
+    ServerInfoChanged(ServerInfoChangedError),
     /// An error thrown by a user of this library
     Consumer(ConsumerError),
 }
@@ -54,6 +56,9 @@ struct CoinSelectError {
 struct WalletError {
     source: Source,
 }
+
+#[derive(Debug)]
+struct ServerInfoChangedError;
 
 #[derive(Debug)]
 struct ConsumerError {
@@ -96,6 +101,59 @@ impl Error {
             source: source.into(),
         }))
     }
+
+    pub(crate) fn server_info_changed(source: impl Into<Error>) -> Self {
+        source
+            .into()
+            .context(Error::new(Kind::ServerInfoChanged(ServerInfoChangedError)))
+    }
+
+    pub fn is_server_info_changed(&self) -> bool {
+        let mut err = self;
+        loop {
+            if matches!(err.inner.kind, Kind::ServerInfoChanged(_)) {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
+    }
+
+    /// Returns `true` if this error chain contains an arkd build-version mismatch.
+    pub fn is_version_mismatch(&self) -> bool {
+        let mut err = self;
+        loop {
+            if err.inner.kind.is_version_mismatch() {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
+    }
+}
+
+impl Kind {
+    fn is_version_mismatch(&self) -> bool {
+        match self {
+            Kind::ArkServer(err) => {
+                err.source.is::<ark_grpc::Error>()
+                    && err
+                        .source
+                        .downcast_ref::<ark_grpc::Error>()
+                        .is_some_and(ark_grpc::Error::is_version_mismatch)
+            }
+            Kind::AdHoc(_)
+            | Kind::Core(_)
+            | Kind::CoinSelect(_)
+            | Kind::Wallet(_)
+            | Kind::ServerInfoChanged(_)
+            | Kind::Consumer(_) => false,
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -121,6 +179,7 @@ impl fmt::Display for Kind {
             Kind::Core(ref err) => err.fmt(f),
             Kind::CoinSelect(ref err) => err.fmt(f),
             Kind::Wallet(ref err) => err.fmt(f),
+            Kind::ServerInfoChanged(ref err) => err.fmt(f),
             Kind::Consumer(ref err) => err.fmt(f),
         }
     }
@@ -153,6 +212,12 @@ impl fmt::Display for CoinSelectError {
 impl fmt::Display for WalletError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.source.fmt(f)
+    }
+}
+
+impl fmt::Display for ServerInfoChangedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe")
     }
 }
 
@@ -274,7 +339,11 @@ where
 
 impl From<ark_grpc::Error> for Error {
     fn from(value: ark_grpc::Error) -> Self {
-        Self::ark_server(value)
+        if value.is_server_info_changed() {
+            Self::server_info_changed(Self::ark_server(value))
+        } else {
+            Self::ark_server(value)
+        }
     }
 }
 

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 
 pub mod error;
@@ -312,7 +313,11 @@ pub struct OfflineClient<B, W, S, K> {
 /// See [`OfflineClient`] docs for details.
 pub struct Client<B, W, S, K> {
     inner: OfflineClient<B, W, S, K>,
-    pub server_info: server::Info,
+    state: Arc<RwLock<ServerState>>,
+}
+
+struct ServerState {
+    server_info: server::Info,
     fee_estimator: ark_fees::Estimator,
 }
 
@@ -635,25 +640,19 @@ where
             "Connected to Ark server"
         );
 
-        let fee_estimator_config = server_info
-            .fees
-            .clone()
-            .map(|fees| ark_fees::Config {
-                intent_offchain_input_program: fees.intent_fee.offchain_input.unwrap_or_default(),
-                intent_onchain_input_program: fees.intent_fee.onchain_input.unwrap_or_default(),
-                intent_offchain_output_program: fees.intent_fee.offchain_output.unwrap_or_default(),
-                intent_onchain_output_program: fees.intent_fee.onchain_output.unwrap_or_default(),
-            })
-            .unwrap_or_default();
-
-        let fee_estimator =
-            ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)?;
-
-        let client = Client {
-            inner: self,
+        let fee_estimator = build_fee_estimator(&server_info)?;
+        let state = Arc::new(RwLock::new(ServerState {
             server_info,
             fee_estimator,
-        };
+        }));
+        let hook_state = state.clone();
+        self.network_client
+            .set_info_refresh_hook(move |server_info| {
+                update_server_state(&hook_state, server_info)
+                    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
+            });
+
+        let client = Client { inner: self, state };
 
         if let Err(error) = client.discover_keys(DEFAULT_GAP_LIMIT).await {
             tracing::warn!(?error, "Failed during key discovery");
@@ -663,6 +662,34 @@ where
     }
 }
 
+fn build_fee_estimator(server_info: &server::Info) -> Result<ark_fees::Estimator, Error> {
+    let fee_estimator_config = server_info
+        .fees
+        .clone()
+        .map(|fees| ark_fees::Config {
+            intent_offchain_input_program: fees.intent_fee.offchain_input.unwrap_or_default(),
+            intent_onchain_input_program: fees.intent_fee.onchain_input.unwrap_or_default(),
+            intent_offchain_output_program: fees.intent_fee.offchain_output.unwrap_or_default(),
+            intent_onchain_output_program: fees.intent_fee.onchain_output.unwrap_or_default(),
+        })
+        .unwrap_or_default();
+
+    ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)
+}
+
+fn update_server_state(
+    state: &Arc<RwLock<ServerState>>,
+    server_info: server::Info,
+) -> Result<(), Error> {
+    let fee_estimator = build_fee_estimator(&server_info)?;
+    let mut state = state
+        .write()
+        .map_err(|_| Error::ad_hoc("client server state lock poisoned"))?;
+    state.server_info = server_info;
+    state.fee_estimator = fee_estimator;
+    Ok(())
+}
+
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
@@ -670,6 +697,27 @@ where
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
+    /// Returns the latest cached Ark server info.
+    pub fn server_info(&self) -> Result<server::Info, Error> {
+        self.state
+            .read()
+            .map(|state| state.server_info.clone())
+            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
+    }
+
+    fn with_server_state<T>(&self, f: impl FnOnce(&ServerState) -> T) -> Result<T, Error> {
+        self.state
+            .read()
+            .map(|state| f(&state))
+            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
+    }
+
+    fn eval_onchain_output_fee(&self, output: ark_fees::Output) -> Result<Amount, Error> {
+        self.with_server_state(|state| state.fee_estimator.eval_onchain_output(output))?
+            .map(|fee| Amount::from_sat(fee.to_satoshis()))
+            .map_err(Error::ad_hoc)
+    }
+
     /// Returns the currently configured delegator pubkey, if any.
     pub fn delegator_pk(&self) -> Option<XOnlyPublicKey> {
         self.inner.delegator_pk()
@@ -688,7 +736,7 @@ where
     /// For HD wallets, this will derive a new address each time it's called.
     /// For static key providers, this will always return the same address.
     pub fn get_offchain_address(&self) -> Result<(ArkAddress, Vtxo), Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let server_signer = server_info.signer_pk.into();
         let owner = self
@@ -710,7 +758,7 @@ where
     /// historical delegator keys are set via `historical_delegator_pks` passed to
     /// [`OfflineClient::new`], addresses for those are included too.
     pub fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         let server_signer = server_info.signer_pk.into();
 
         let pks = self.inner.key_provider.get_cached_pks()?;
@@ -756,7 +804,7 @@ where
         server_signer: XOnlyPublicKey,
         owner: XOnlyPublicKey,
     ) -> Result<Vtxo, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         match self.inner.delegator_pk {
             Some(delegator) => Vtxo::new_with_delegator(
                 self.secp(),
@@ -794,7 +842,7 @@ where
             return Ok(0);
         }
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
 
         let mut start_index = 0u32;
@@ -894,7 +942,7 @@ where
 
     // At the moment we are always generating the same address.
     pub fn get_boarding_address(&self) -> Result<Address, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let boarding_output = self.inner.wallet.new_boarding_output(
             server_info.signer_pk.into(),
@@ -947,7 +995,7 @@ where
             .await
             .context("failed to get VTXOs for addresses")?;
 
-        let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
         Ok(vtxo_list)
     }
@@ -979,7 +1027,7 @@ where
             })
             .collect();
 
-        let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
         Ok((vtxo_list, script_pubkey_to_vtxo_map))
     }
@@ -1166,8 +1214,8 @@ where
     }
 
     /// The server's dust threshold amount.
-    pub fn dust(&self) -> Amount {
-        self.server_info.dust
+    pub fn dust(&self) -> Result<Amount, Error> {
+        Ok(self.server_info()?.dust)
     }
 
     pub fn network_client(&self) -> ark_grpc::Client {
@@ -1332,5 +1380,230 @@ where
             .get_subscription(subscription_id)
             .await
             .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod digest_guard_tests {
+    use super::*;
+    use ark_grpc::test_utils;
+    use bitcoin::key::Secp256k1;
+    use bitcoin::secp256k1::SecretKey;
+    use bitcoin::Address;
+    use std::convert::Infallible;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
+    use tokio::net::TcpListener;
+    use tonic::body::Body;
+    use tonic::codegen::http;
+    use tonic::codegen::Service;
+    use tonic::server::NamedService;
+    use tonic::server::UnaryService;
+
+    #[derive(Clone, Default)]
+    struct MockArkServer {
+        state: Arc<MockState>,
+    }
+
+    #[derive(Default)]
+    struct MockState {
+        get_info_calls: AtomicUsize,
+        list_vtxos_calls: AtomicUsize,
+    }
+
+    impl Service<http::Request<Body>> for MockArkServer {
+        type Response = http::Response<Body>;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+            match req.uri().path() {
+                "/ark.v1.ArkService/GetInfo" => {
+                    let method = GetInfoSvc {
+                        state: self.state.clone(),
+                    };
+                    Box::pin(async move {
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec);
+                        Ok(grpc.unary(method, req).await)
+                    })
+                }
+                "/ark.v1.IndexerService/GetVtxos" => {
+                    let method = ListVtxosSvc {
+                        state: self.state.clone(),
+                    };
+                    Box::pin(async move {
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec);
+                        Ok(grpc.unary(method, req).await)
+                    })
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(Body::empty())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+
+    impl NamedService for MockArkServer {
+        const NAME: &'static str = "ark.v1.ArkService";
+    }
+
+    #[derive(Clone)]
+    struct MockIndexerServer(MockArkServer);
+
+    impl Service<http::Request<Body>> for MockIndexerServer {
+        type Response = http::Response<Body>;
+        type Error = Infallible;
+        type Future = <MockArkServer as Service<http::Request<Body>>>::Future;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.0.poll_ready(cx)
+        }
+
+        fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+            self.0.call(req)
+        }
+    }
+
+    impl NamedService for MockIndexerServer {
+        const NAME: &'static str = "ark.v1.IndexerService";
+    }
+
+    #[derive(Clone)]
+    struct GetInfoSvc {
+        state: Arc<MockState>,
+    }
+
+    impl UnaryService<test_utils::GetInfoRequest> for GetInfoSvc {
+        type Response = test_utils::GetInfoResponse;
+        type Future = Pin<
+            Box<dyn Future<Output = Result<tonic::Response<Self::Response>, tonic::Status>> + Send>,
+        >;
+
+        fn call(&mut self, _request: tonic::Request<test_utils::GetInfoRequest>) -> Self::Future {
+            self.state.get_info_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(tonic::Response::new(info_response("fresh-digest"))) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct ListVtxosSvc {
+        state: Arc<MockState>,
+    }
+
+    impl UnaryService<test_utils::GetVtxosRequest> for ListVtxosSvc {
+        type Response = test_utils::GetVtxosResponse;
+        type Future = Pin<
+            Box<dyn Future<Output = Result<tonic::Response<Self::Response>, tonic::Status>> + Send>,
+        >;
+
+        fn call(&mut self, _request: tonic::Request<test_utils::GetVtxosRequest>) -> Self::Future {
+            self.state.list_vtxos_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Err(tonic::Status::failed_precondition(
+                    "DIGEST_MISMATCH: invalid digest header",
+                ))
+            })
+        }
+    }
+
+    fn info_response(digest: &str) -> test_utils::GetInfoResponse {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[1; 32]).unwrap();
+        let keypair = Keypair::from_secret_key(&secp, &secret_key);
+        let public_key = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+        let (xonly, _) = keypair.x_only_public_key();
+        let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
+
+        test_utils::GetInfoResponse {
+            version: "0.9.9".to_string(),
+            signer_pubkey: public_key.to_string(),
+            forfeit_pubkey: public_key.to_string(),
+            forfeit_address: address.to_string(),
+            checkpoint_tapscript: String::new(),
+            network: "regtest".to_string(),
+            session_duration: 60,
+            unilateral_exit_delay: 144,
+            boarding_exit_delay: 144,
+            utxo_min_amount: 0,
+            utxo_max_amount: 0,
+            vtxo_min_amount: 0,
+            vtxo_max_amount: 0,
+            dust: 1000,
+            fees: None,
+            scheduled_session: None,
+            deprecated_signers: Vec::new(),
+            service_status: Default::default(),
+            digest: digest.to_string(),
+            max_tx_weight: 0,
+            max_op_return_outputs: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn guarded_client_refreshes_info_and_does_not_retry_on_digest_mismatch() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mock = MockArkServer::default();
+        let state = mock.state.clone();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let indexer_mock = MockIndexerServer(mock.clone());
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(mock)
+                .add_service(indexer_mock)
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        let mut inner = ark_grpc::Client::new(format!("http://{addr}"));
+        inner.connect().await.unwrap();
+
+        let initial_info: server::Info = info_response("stale-digest").try_into().unwrap();
+        let cached_state = Arc::new(RwLock::new(ServerState {
+            server_info: initial_info,
+            fee_estimator: build_fee_estimator(&info_response("stale-digest").try_into().unwrap())
+                .unwrap(),
+        }));
+        let hook_state = cached_state.clone();
+        inner.set_info_refresh_hook(move |server_info| {
+            update_server_state(&hook_state, server_info)
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
+        });
+
+        let err = match inner
+            .list_vtxos(GetVtxosRequest::new_for_outpoints(&[OutPoint::null()]))
+            .await
+        {
+            Ok(_) => panic!("list_vtxos unexpectedly succeeded"),
+            Err(err) => err,
+        };
+
+        assert!(err.is_server_info_changed());
+        assert!(Error::from(err).is_server_info_changed());
+        assert_eq!(state.list_vtxos_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cached_state.read().unwrap().server_info.digest,
+            "fresh-digest"
+        );
     }
 }

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -18,6 +18,7 @@ use ark_core::send::sign_checkpoint_transaction;
 use ark_core::send::OffchainTransactions;
 use ark_core::send::SendReceiver;
 use ark_core::send::VtxoInput;
+use ark_core::server;
 use ark_core::server::PendingTx;
 use bitcoin::key::Secp256k1;
 use bitcoin::psbt;
@@ -192,12 +193,15 @@ where
         address: ark_core::ArkAddress,
         amount: Amount,
     ) -> Result<Txid, Error> {
+        let server_info = self.server_info()?;
         let receivers = vec![SendReceiver {
             address,
             amount,
             assets: Vec::new(),
         }];
-        let pending_tx = self.build_and_submit(vtxo_inputs, receivers).await?;
+        let pending_tx = self
+            .build_and_submit(vtxo_inputs, receivers, &server_info)
+            .await?;
         Ok(pending_tx.ark_txid)
     }
 
@@ -249,6 +253,7 @@ where
             })
             .collect::<Vec<_>>();
 
+        let server_info = self.server_info()?;
         let mut selected_outpoints = HashSet::new();
         let mut selected = Vec::new();
         let mut asset_changes: HashMap<AssetId, u64> = HashMap::new();
@@ -306,7 +311,7 @@ where
         }
 
         if !asset_changes.is_empty() {
-            btc_needed += self.server_info.dust;
+            btc_needed += server_info.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -318,7 +323,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset transfer")?;
 
@@ -501,13 +506,12 @@ where
         vtxo_inputs: Vec<VtxoInput>,
         receivers: Vec<SendReceiver>,
     ) -> Result<Txid, Error> {
-        Self::validate_selected_inputs_cover_receivers(
-            &vtxo_inputs,
-            &receivers,
-            self.server_info.dust,
-        )?;
+        let server_info = self.server_info()?;
+        Self::validate_selected_inputs_cover_receivers(&vtxo_inputs, &receivers, server_info.dust)?;
 
-        let pending_tx = self.build_and_submit(vtxo_inputs, receivers).await?;
+        let pending_tx = self
+            .build_and_submit(vtxo_inputs, receivers, &server_info)
+            .await?;
         let ark_txid = pending_tx.ark_txid;
 
         self.sign_and_finalize_pending_tx(pending_tx).await?;
@@ -557,13 +561,14 @@ where
         &self,
         inputs: Vec<VtxoInput>,
         receivers: Vec<SendReceiver>,
+        server_info: &server::Info,
     ) -> Result<PendingTx, Error> {
         let (change_address, change_address_vtxo) = self.get_offchain_address()?;
 
         let OffchainTransactions {
             ark_tx,
             checkpoint_txs,
-        } = build_asset_send_transactions(&receivers, &change_address, &inputs, &self.server_info)
+        } = build_asset_send_transactions(&receivers, &change_address, &inputs, server_info)
             .map_err(Error::from)
             .context("failed to build offchain asset-send transactions")?;
 
@@ -689,7 +694,7 @@ where
         // finalized. This is much cheaper than fetching all VTXOs when there
         // are no pending transactions (common case).
         let addresses = ark_addresses.iter().map(|(a, _)| *a);
-        let request = ark_core::server::GetVtxosRequest::new_for_addresses(addresses)
+        let request = server::GetVtxosRequest::new_for_addresses(addresses)
             .pending_only()
             .map_err(Error::from)?;
 

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -245,10 +245,11 @@ where
         to_address: Address,
         to_amount: Amount,
     ) -> Result<(Transaction, Vec<TxOut>), Error> {
-        if to_amount < self.server_info.dust {
+        let dust = self.server_info()?.dust;
+        if to_amount < dust {
             return Err(Error::ad_hoc(format!(
                 "invalid amount {to_amount}, must be greater than dust: {}",
-                self.server_info.dust,
+                dust,
             )));
         }
 

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -621,7 +621,15 @@ async fn delegate_vtxos<B, W, S, K>(
         .cloned()
         .collect();
 
-    let groups = group_by_expiry_day(&enriched, script_map, client.server_info.dust);
+    let server_info = match client.server_info() {
+        Ok(server_info) => server_info,
+        Err(e) => {
+            tracing::error!("Failed to read server info for delegation: {e}");
+            return;
+        }
+    };
+
+    let groups = group_by_expiry_day(&enriched, script_map, server_info.dust);
     if groups.is_empty() {
         tracing::debug!("No delegate-eligible VTXOs after enrichment/grouping; skipping");
         return;
@@ -647,7 +655,7 @@ async fn delegate_vtxos<B, W, S, K>(
     let mut handles = Vec::new();
 
     for (_day, group_vtxos) in groups {
-        let valid_at = calculate_valid_at(&group_vtxos, client.server_info.dust);
+        let valid_at = calculate_valid_at(&group_vtxos, server_info.dust);
 
         let mut vtxo_inputs = Vec::new();
         let mut total_amount = Amount::ZERO;
@@ -693,7 +701,7 @@ async fn delegate_vtxos<B, W, S, K>(
         }
         let net_amount = total_amount - fee;
 
-        if net_amount < client.server_info.dust {
+        if net_amount < server_info.dust {
             tracing::warn!(%net_amount, "Net amount after fee is below dust, skipping");
             continue;
         }
@@ -710,8 +718,8 @@ async fn delegate_vtxos<B, W, S, K>(
             script_pubkey: dest_script.clone(),
         }));
 
-        let server_info_forfeit_addr = client.server_info.forfeit_address.clone();
-        let dust = client.server_info.dust;
+        let server_info_forfeit_addr = server_info.forfeit_address.clone();
+        let dust = server_info.dust;
         let ds = Arc::clone(&delegator_state);
 
         let delegator = delegator.clone();

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -20,6 +20,24 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// arkd build version targeted by this SDK.
+///
+/// Sent in the `X-Build-Version`/`x-build-version` request header so arkd can
+/// reject clients that target an older incompatible server version. This is the
+/// arkd protocol target, not the Rust crate version.
+///
+/// Update this when the SDK intentionally targets a newer arkd compatibility
+/// baseline.
+pub const TARGET_ARKD_VERSION: &str = "0.9.9";
+
+/// Version of this SDK, as `rust-sdk/<crate version>`.
+///
+/// Sent in the `X-SDK-Version`/`x-sdk-version` request header so arkd can attribute
+/// traffic to this SDK and release. The version is resolved from the crate version at
+/// compile time, unlike [`TARGET_ARKD_VERSION`], which is the hand-maintained arkd
+/// compatibility target.
+pub const SDK_VERSION: &str = concat!("rust-sdk/", env!("CARGO_PKG_VERSION"));
+
 /// An aggregate public nonce per shared internal (non-leaf) node in the batch-tree.
 #[derive(Debug, Clone)]
 pub struct NoncePks(HashMap<Txid, musig::PublicNonce>);

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -55,6 +55,8 @@ use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
 use ark_core::server::VtxoChain;
 use ark_core::server::VtxoChains;
+use ark_core::server::SDK_VERSION;
+use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use ark_core::TxGraphChunk;
 use async_stream::stream;
@@ -74,28 +76,73 @@ use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::RwLock;
 
-#[derive(Clone, Copy)]
-struct VersionInterceptor;
+#[derive(Clone, Default)]
+struct HeaderState {
+    digest: Arc<RwLock<Option<String>>>,
+}
 
-impl tonic::service::Interceptor for VersionInterceptor {
+impl HeaderState {
+    fn set_digest(&self, digest: String) {
+        let digest = (!digest.is_empty()).then_some(digest);
+        match self.digest.write() {
+            Ok(mut guard) => *guard = digest,
+            Err(poisoned) => {
+                log::warn!("digest header state lock poisoned while updating; recovering");
+                *poisoned.into_inner() = digest;
+            }
+        }
+    }
+
+    fn digest(&self) -> Option<String> {
+        match self.digest.read() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                log::warn!("digest header state lock poisoned while reading; recovering");
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct HeaderInterceptor {
+    state: HeaderState,
+}
+
+impl tonic::service::Interceptor for HeaderInterceptor {
     fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
-        req.metadata_mut().insert(
+        let metadata = req.metadata_mut();
+        metadata.insert(
             "x-build-version",
-            tonic::metadata::MetadataValue::from_static(env!("CARGO_PKG_VERSION")),
+            tonic::metadata::MetadataValue::from_static(TARGET_ARKD_VERSION),
         );
+        metadata.insert(
+            "x-sdk-version",
+            tonic::metadata::MetadataValue::from_static(SDK_VERSION),
+        );
+
+        if let Some(digest) = self.state.digest() {
+            if let Ok(value) = tonic::metadata::MetadataValue::try_from(digest.as_str()) {
+                metadata.insert("x-digest", value);
+            }
+        }
+
         Ok(req)
     }
 }
 
 type InterceptedChannel =
-    tonic::codegen::InterceptedService<tonic::transport::Channel, VersionInterceptor>;
+    tonic::codegen::InterceptedService<tonic::transport::Channel, HeaderInterceptor>;
 
 #[derive(Clone)]
 pub struct Client {
     url: String,
     ark_client: Option<ArkServiceClient<InterceptedChannel>>,
     indexer_client: Option<IndexerServiceClient<InterceptedChannel>>,
+    header_state: HeaderState,
 }
 
 impl fmt::Debug for Client {
@@ -113,6 +160,7 @@ impl Client {
             url,
             ark_client: None,
             indexer_client: None,
+            header_state: HeaderState::default(),
         }
     }
 
@@ -132,9 +180,12 @@ impl Client {
 
         let channel = endpoint.connect().await.map_err(Error::connect)?;
 
+        let interceptor = HeaderInterceptor {
+            state: self.header_state.clone(),
+        };
         let ark_service_client =
-            ArkServiceClient::with_interceptor(channel.clone(), VersionInterceptor);
-        let indexer_client = IndexerServiceClient::with_interceptor(channel, VersionInterceptor);
+            ArkServiceClient::with_interceptor(channel.clone(), interceptor.clone());
+        let indexer_client = IndexerServiceClient::with_interceptor(channel, interceptor);
 
         self.ark_client = Some(ark_service_client);
         self.indexer_client = Some(indexer_client);
@@ -149,7 +200,9 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        response.into_inner().try_into()
+        let info: Info = response.into_inner().try_into()?;
+        self.header_state.set_digest(info.digest.clone());
+        Ok(info)
     }
 
     /// List VTXOs with pagination support.

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -70,10 +70,12 @@ use bitcoin::ScriptBuf;
 use bitcoin::SignedAmount;
 use bitcoin::Transaction;
 use bitcoin::Txid;
+use futures::Future;
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -137,19 +139,100 @@ impl tonic::service::Interceptor for HeaderInterceptor {
 type InterceptedChannel =
     tonic::codegen::InterceptedService<tonic::transport::Channel, HeaderInterceptor>;
 
+type InfoRefreshHook =
+    Arc<dyn Fn(Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>> + Send + Sync>;
+
+#[derive(Clone, Default)]
+struct SharedState {
+    headers: HeaderState,
+    info_refresh_hook: Arc<RwLock<Option<InfoRefreshHook>>>,
+}
+
+impl SharedState {
+    fn set_info_refresh_hook(&self, hook: InfoRefreshHook) {
+        match self.info_refresh_hook.write() {
+            Ok(mut guard) => *guard = Some(hook),
+            Err(poisoned) => {
+                log::warn!("info refresh hook lock poisoned while updating; recovering");
+                *poisoned.into_inner() = Some(hook);
+            }
+        }
+    }
+
+    /// Runs one RPC operation with digest-mismatch handling.
+    ///
+    /// If the server rejects the operation because our cached `/info` digest is stale,
+    /// this fetches fresh `/info` through the supplied Ark client, runs the refresh hook,
+    /// commits the new digest header, and returns `ServerInfoChanged` for the original
+    /// failure. The original operation is never retried automatically.
+    async fn guarded<T>(
+        &self,
+        info_client: ArkServiceClient<InterceptedChannel>,
+        op: impl Future<Output = Result<T, Error>>,
+    ) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let original = err;
+                let info = self.fetch_info_unguarded(info_client).await?;
+                let digest = info.digest.clone();
+
+                if let Some(hook) = self.info_refresh_hook() {
+                    hook(info).map_err(Error::conversion)?;
+                }
+
+                self.headers.set_digest(digest);
+                Err(Error::server_info_changed(original))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn info_refresh_hook(&self) -> Option<InfoRefreshHook> {
+        match self.info_refresh_hook.read() {
+            Ok(hook) => hook.clone(),
+            Err(poisoned) => {
+                log::warn!("info refresh hook lock poisoned while reading; recovering");
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+
+    async fn get_info_unguarded(
+        &self,
+        client: ArkServiceClient<InterceptedChannel>,
+    ) -> Result<Info, Error> {
+        let info = self.fetch_info_unguarded(client).await?;
+        self.headers.set_digest(info.digest.clone());
+        Ok(info)
+    }
+
+    async fn fetch_info_unguarded(
+        &self,
+        mut client: ArkServiceClient<InterceptedChannel>,
+    ) -> Result<Info, Error> {
+        let response = client
+            .get_info(GetInfoRequest {})
+            .await
+            .map_err(Error::request)?;
+
+        response.into_inner().try_into()
+    }
+}
+
 #[derive(Clone)]
 pub struct Client {
     url: String,
-    ark_client: Option<ArkServiceClient<InterceptedChannel>>,
-    indexer_client: Option<IndexerServiceClient<InterceptedChannel>>,
-    header_state: HeaderState,
+    ark: Option<guarded::Ark>,
+    indexer: Option<guarded::Indexer>,
+    shared: SharedState,
 }
 
 impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client")
             .field("url", &self.url)
-            .field("connected", &self.ark_client.is_some())
+            .field("connected", &self.ark.is_some())
             .finish()
     }
 }
@@ -158,10 +241,20 @@ impl Client {
     pub fn new(url: String) -> Self {
         Self {
             url,
-            ark_client: None,
-            indexer_client: None,
-            header_state: HeaderState::default(),
+            ark: None,
+            indexer: None,
+            shared: SharedState::default(),
         }
+    }
+
+    pub fn set_info_refresh_hook(
+        &mut self,
+        hook: impl Fn(Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+            + Send
+            + Sync
+            + 'static,
+    ) {
+        self.shared.set_info_refresh_hook(Arc::new(hook));
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
@@ -181,28 +274,26 @@ impl Client {
         let channel = endpoint.connect().await.map_err(Error::connect)?;
 
         let interceptor = HeaderInterceptor {
-            state: self.header_state.clone(),
+            state: self.shared.headers.clone(),
         };
         let ark_service_client =
             ArkServiceClient::with_interceptor(channel.clone(), interceptor.clone());
         let indexer_client = IndexerServiceClient::with_interceptor(channel, interceptor);
 
-        self.ark_client = Some(ark_service_client);
-        self.indexer_client = Some(indexer_client);
+        self.ark = Some(guarded::Ark::new(
+            ark_service_client.clone(),
+            self.shared.clone(),
+        ));
+        self.indexer = Some(guarded::Indexer::new(
+            indexer_client,
+            ark_service_client,
+            self.shared.clone(),
+        ));
         Ok(())
     }
 
-    pub async fn get_info(&mut self) -> Result<Info, Error> {
-        let mut client = self.ark_client()?;
-
-        let response = client
-            .get_info(GetInfoRequest {})
-            .await
-            .map_err(Error::request)?;
-
-        let info: Info = response.into_inner().try_into()?;
-        self.header_state.set_digest(info.digest.clone());
-        Ok(info)
+    pub async fn get_info(&self) -> Result<Info, Error> {
+        self.ark()?.get_info().await
     }
 
     /// List VTXOs with pagination support.
@@ -215,12 +306,14 @@ impl Client {
             });
         }
 
-        let mut client = self.indexer_client()?;
-
-        let response = client
-            .get_vtxos(generated::ark::v1::GetVtxosRequest::from(request))
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .get_vtxos(generated::ark::v1::GetVtxosRequest::from(request))
+                    .await
+            })
+            .await?;
 
         let inner = response.into_inner();
 
@@ -240,17 +333,15 @@ impl Client {
     }
 
     pub async fn register_intent(&self, intent: ark_core::intent::Intent) -> Result<String, Error> {
-        let mut client = self.ark_client()?;
-
         let intent = intent.try_into()?;
         let request = RegisterIntentRequest {
             intent: Some(intent),
         };
 
-        let response = client
-            .register_intent(request)
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .ark()?
+            .request(move |mut client| async move { client.register_intent(request).await })
+            .await?;
 
         let intent_id = response.into_inner().intent_id;
 
@@ -262,8 +353,6 @@ impl Client {
         ark_tx: Psbt,
         checkpoint_txs: Vec<Psbt>,
     ) -> Result<SubmitOffchainTxResponse, Error> {
-        let mut client = self.ark_client()?;
-
         let base64 = base64::engine::GeneralPurpose::new(
             &base64::alphabet::STANDARD,
             base64::engine::GeneralPurposeConfig::new(),
@@ -276,13 +365,17 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .collect();
 
-        let res = client
-            .submit_tx(generated::ark::v1::SubmitTxRequest {
-                signed_ark_tx: ark_tx,
-                checkpoint_txs,
+        let res = self
+            .ark()?
+            .request(move |mut client| async move {
+                client
+                    .submit_tx(generated::ark::v1::SubmitTxRequest {
+                        signed_ark_tx: ark_tx,
+                        checkpoint_txs,
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let res = res.into_inner();
 
@@ -312,8 +405,6 @@ impl Client {
         txid: Txid,
         checkpoint_txs: Vec<Psbt>,
     ) -> Result<FinalizeOffchainTxResponse, Error> {
-        let mut client = self.ark_client()?;
-
         let base64 = base64::engine::GeneralPurpose::new(
             &base64::alphabet::STANDARD,
             base64::engine::GeneralPurposeConfig::new(),
@@ -324,13 +415,16 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .collect();
 
-        client
-            .finalize_tx(generated::ark::v1::FinalizeTxRequest {
-                ark_txid: txid.to_string(),
-                final_checkpoint_txs: checkpoint_txs,
+        self.ark()?
+            .request(move |mut client| async move {
+                client
+                    .finalize_tx(generated::ark::v1::FinalizeTxRequest {
+                        ark_txid: txid.to_string(),
+                        final_checkpoint_txs: checkpoint_txs,
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         Ok(FinalizeOffchainTxResponse {})
     }
@@ -339,18 +433,20 @@ impl Client {
         &self,
         intent: ark_core::intent::Intent,
     ) -> Result<Vec<ark_core::server::PendingTx>, Error> {
-        let mut client = self.ark_client()?;
-
         let intent: Intent = intent.try_into()?;
 
-        let res = client
-            .get_pending_tx(generated::ark::v1::GetPendingTxRequest {
-                identifier: Some(
-                    generated::ark::v1::get_pending_tx_request::Identifier::Intent(intent),
-                ),
+        let res = self
+            .ark()?
+            .request(move |mut client| async move {
+                client
+                    .get_pending_tx(generated::ark::v1::GetPendingTxRequest {
+                        identifier: Some(
+                            generated::ark::v1::get_pending_tx_request::Identifier::Intent(intent),
+                        ),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let inner = res.into_inner();
         let base64 = base64::engine::GeneralPurpose::new(
@@ -386,12 +482,13 @@ impl Client {
     }
 
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
-        let mut client = self.ark_client()?;
-
-        client
-            .confirm_registration(ConfirmRegistrationRequest { intent_id })
-            .await
-            .map_err(Error::request)?;
+        self.ark()?
+            .request(move |mut client| async move {
+                client
+                    .confirm_registration(ConfirmRegistrationRequest { intent_id })
+                    .await
+            })
+            .await?;
 
         Ok(())
     }
@@ -402,16 +499,17 @@ impl Client {
         cosigner_pubkey: PublicKey,
         pub_nonce_tree: NoncePks,
     ) -> Result<(), Error> {
-        let mut client = self.ark_client()?;
-
-        client
-            .submit_tree_nonces(SubmitTreeNoncesRequest {
-                batch_id: batch_id.to_string(),
-                pubkey: cosigner_pubkey.to_string(),
-                tree_nonces: pub_nonce_tree.encode(),
+        self.ark()?
+            .request(move |mut client| async move {
+                client
+                    .submit_tree_nonces(SubmitTreeNoncesRequest {
+                        batch_id: batch_id.to_string(),
+                        pubkey: cosigner_pubkey.to_string(),
+                        tree_nonces: pub_nonce_tree.encode(),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         Ok(())
     }
@@ -422,16 +520,17 @@ impl Client {
         cosigner_pk: PublicKey,
         partial_sig_tree: PartialSigTree,
     ) -> Result<(), Error> {
-        let mut client = self.ark_client()?;
-
-        client
-            .submit_tree_signatures(SubmitTreeSignaturesRequest {
-                batch_id: batch_id.to_string(),
-                pubkey: cosigner_pk.to_string(),
-                tree_signatures: partial_sig_tree.encode(),
+        self.ark()?
+            .request(move |mut client| async move {
+                client
+                    .submit_tree_signatures(SubmitTreeSignaturesRequest {
+                        batch_id: batch_id.to_string(),
+                        pubkey: cosigner_pk.to_string(),
+                        tree_signatures: partial_sig_tree.encode(),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         Ok(())
     }
@@ -441,8 +540,6 @@ impl Client {
         signed_forfeit_txs: Vec<Psbt>,
         signed_commitment_tx: Option<Psbt>,
     ) -> Result<(), Error> {
-        let mut client = self.ark_client()?;
-
         let base64 = base64::engine::GeneralPurpose::new(
             &base64::alphabet::STANDARD,
             base64::engine::GeneralPurposeConfig::new(),
@@ -452,16 +549,19 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .unwrap_or_default();
 
-        client
-            .submit_signed_forfeit_txs(SubmitSignedForfeitTxsRequest {
-                signed_forfeit_txs: signed_forfeit_txs
-                    .iter()
-                    .map(|psbt| base64.encode(psbt.serialize()))
-                    .collect(),
-                signed_commitment_tx,
+        self.ark()?
+            .request(move |mut client| async move {
+                client
+                    .submit_signed_forfeit_txs(SubmitSignedForfeitTxsRequest {
+                        signed_forfeit_txs: signed_forfeit_txs
+                            .iter()
+                            .map(|psbt| base64.encode(psbt.serialize()))
+                            .collect(),
+                        signed_commitment_tx,
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         Ok(())
     }
@@ -470,12 +570,14 @@ impl Client {
         &self,
         topics: Vec<String>,
     ) -> Result<impl Stream<Item = Result<StreamEvent, Error>> + Unpin, Error> {
-        let mut client = self.ark_client()?;
-
-        let response = client
-            .get_event_stream(GetEventStreamRequest { topics })
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .ark()?
+            .request(move |mut client| async move {
+                client
+                    .get_event_stream(GetEventStreamRequest { topics })
+                    .await
+            })
+            .await?;
         let mut stream = response.into_inner();
 
         let stream = stream! {
@@ -505,12 +607,14 @@ impl Client {
     pub async fn get_tx_stream(
         &self,
     ) -> Result<impl Stream<Item = Result<StreamTransactionData, Error>> + Unpin, Error> {
-        let mut client = self.ark_client()?;
-
-        let response = client
-            .get_transactions_stream(GetTransactionsStreamRequest {})
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .ark()?
+            .request(|mut client| async move {
+                client
+                    .get_transactions_stream(GetTransactionsStreamRequest {})
+                    .await
+            })
+            .await?;
 
         let mut stream = response.into_inner();
 
@@ -543,18 +647,22 @@ impl Client {
         outpoint: Option<OutPoint>,
         size_and_index: Option<(i32, i32)>,
     ) -> Result<VtxoChainResponse, Error> {
-        let mut client = self.indexer_client()?;
-        let response = client
-            .get_vtxo_chain(generated::ark::v1::GetVtxoChainRequest {
-                outpoint: outpoint.map(|o| generated::ark::v1::IndexerOutpoint {
-                    txid: o.txid.to_string(),
-                    vout: o.vout,
-                }),
-                page: size_and_index
-                    .map(|(size, index)| generated::ark::v1::IndexerPageRequest { size, index }),
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .get_vtxo_chain(generated::ark::v1::GetVtxoChainRequest {
+                        outpoint: outpoint.map(|o| generated::ark::v1::IndexerOutpoint {
+                            txid: o.txid.to_string(),
+                            vout: o.vout,
+                        }),
+                        page: size_and_index.map(|(size, index)| {
+                            generated::ark::v1::IndexerPageRequest { size, index }
+                        }),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
         let result = response.try_into()?;
         Ok(result)
@@ -565,15 +673,19 @@ impl Client {
         txids: Vec<String>,
         size_and_index: Option<(i32, i32)>,
     ) -> Result<VirtualTxsResponse, Error> {
-        let mut client = self.indexer_client()?;
-        let response = client
-            .get_virtual_txs(generated::ark::v1::GetVirtualTxsRequest {
-                txids,
-                page: size_and_index
-                    .map(|(size, index)| generated::ark::v1::IndexerPageRequest { size, index }),
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .get_virtual_txs(generated::ark::v1::GetVirtualTxsRequest {
+                        txids,
+                        page: size_and_index.map(|(size, index)| {
+                            generated::ark::v1::IndexerPageRequest { size, index }
+                        }),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
         let result = response.try_into()?;
         Ok(result)
@@ -593,7 +705,6 @@ impl Client {
         scripts: Vec<ArkAddress>,
         subscription_id: Option<String>,
     ) -> Result<String, Error> {
-        let mut client = self.indexer_client()?;
         let scripts = scripts
             .iter()
             .map(|address| address.to_p2tr_script_pubkey().to_hex_string())
@@ -602,13 +713,17 @@ impl Client {
         // For new subscription we expect empty string ("") here
         let subscription_id = subscription_id.unwrap_or_default();
 
-        let response = client
-            .subscribe_for_scripts(SubscribeForScriptsRequest {
-                scripts,
-                subscription_id,
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .subscribe_for_scripts(SubscribeForScriptsRequest {
+                        scripts,
+                        subscription_id,
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let response = response.into_inner();
 
@@ -621,19 +736,21 @@ impl Client {
         scripts: Vec<ArkAddress>,
         subscription_id: String,
     ) -> Result<(), Error> {
-        let mut client = self.indexer_client()?;
         let scripts = scripts
             .iter()
             .map(|address| address.to_p2tr_script_pubkey().to_hex_string())
             .collect::<Vec<_>>();
 
-        let _ = client
-            .unsubscribe_for_scripts(UnsubscribeForScriptsRequest {
-                subscription_id,
-                scripts,
+        self.indexer()?
+            .request(move |mut client| async move {
+                client
+                    .unsubscribe_for_scripts(UnsubscribeForScriptsRequest {
+                        subscription_id,
+                        scripts,
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         Ok(())
     }
@@ -643,12 +760,14 @@ impl Client {
         &self,
         subscription_id: String,
     ) -> Result<impl Stream<Item = Result<SubscriptionResponse, Error>> + Unpin, Error> {
-        let mut client = self.indexer_client()?;
-
-        let response = client
-            .get_subscription(GetSubscriptionRequest { subscription_id })
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .get_subscription(GetSubscriptionRequest { subscription_id })
+                    .await
+            })
+            .await?;
 
         let mut stream = response.into_inner();
 
@@ -682,29 +801,33 @@ impl Client {
         &self,
         intent: ark_core::intent::Intent,
     ) -> Result<SignedAmount, Error> {
-        let mut client = self.ark_client()?;
-
         let intent = intent.try_into()?;
-        let response = client
-            .estimate_intent_fee(EstimateIntentFeeRequest {
-                intent: Some(intent),
+        let response = self
+            .ark()?
+            .request(move |mut client| async move {
+                client
+                    .estimate_intent_fee(EstimateIntentFeeRequest {
+                        intent: Some(intent),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
 
         Ok(SignedAmount::from_sat(response.fee))
     }
 
     pub async fn get_asset(&self, asset_id: AssetId) -> Result<AssetInfo, Error> {
-        let mut client = self.indexer_client()?;
-
-        let response = client
-            .get_asset(generated::ark::v1::GetAssetRequest {
-                asset_id: asset_id.to_string(),
+        let response = self
+            .indexer()?
+            .request(move |mut client| async move {
+                client
+                    .get_asset(generated::ark::v1::GetAssetRequest {
+                        asset_id: asset_id.to_string(),
+                    })
+                    .await
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let inner = response.into_inner();
 
@@ -725,12 +848,12 @@ impl Client {
         })
     }
 
-    fn ark_client(&self) -> Result<ArkServiceClient<InterceptedChannel>, Error> {
-        // Cloning an `ArkServiceClient<Channel>` is cheap.
-        self.ark_client.clone().ok_or(Error::not_connected())
+    fn ark(&self) -> Result<guarded::Ark, Error> {
+        self.ark.clone().ok_or(Error::not_connected())
     }
-    fn indexer_client(&self) -> Result<IndexerServiceClient<InterceptedChannel>, Error> {
-        self.indexer_client.clone().ok_or(Error::not_connected())
+
+    fn indexer(&self) -> Result<guarded::Indexer, Error> {
+        self.indexer.clone().ok_or(Error::not_connected())
     }
 }
 
@@ -1349,6 +1472,110 @@ impl From<GetVtxosRequest> for generated::ark::v1::GetVtxosRequest {
                 after: value.after().unwrap_or(0) as i64,
                 before: value.before().unwrap_or(0) as i64,
             },
+        }
+    }
+}
+
+mod guarded {
+    //! Guarded wrappers around the generated tonic clients.
+    //!
+    //! `Client` methods use these wrappers instead of storing or cloning generated clients
+    //! directly. `request` is the only normal RPC escape hatch: it clones the generated
+    //! client, runs the closure's future, and routes the result through `SharedState` so a
+    //! digest mismatch refreshes `/info` and updates the shared digest/header state.
+    //!
+    //! Each `request` closure must perform exactly one non-`GetInfo` gRPC call and return
+    //! that call's `tonic::Status` unchanged. Do not batch multiple RPCs, call `GetInfo`,
+    //! swallow errors, or synthesize fallback successes inside the closure. Guarding is
+    //! scoped to a single failed operation, and digest-mismatch refresh intentionally does
+    //! not retry that operation.
+
+    use super::InterceptedChannel;
+    use super::SharedState;
+    use crate::generated::ark::v1::ark_service_client::ArkServiceClient;
+    use crate::generated::ark::v1::indexer_service_client::IndexerServiceClient;
+    use crate::Error;
+    use ark_core::server::Info;
+    use futures::Future;
+
+    #[derive(Clone)]
+    pub(super) struct Ark {
+        raw: ArkServiceClient<InterceptedChannel>,
+        shared: SharedState,
+    }
+
+    impl Ark {
+        pub(super) fn new(raw: ArkServiceClient<InterceptedChannel>, shared: SharedState) -> Self {
+            Self { raw, shared }
+        }
+
+        /// Runs one Ark service RPC through the digest guard.
+        ///
+        /// The closure must perform exactly one non-`GetInfo` gRPC call and return that
+        /// call's `tonic::Status` unchanged. Do not batch multiple RPCs, call `GetInfo`,
+        /// swallow errors, or synthesize fallback successes inside the closure. A digest
+        /// mismatch refreshes `/info` and returns `ServerInfoChanged`; the failed RPC is
+        /// not retried automatically.
+        pub(super) async fn request<T, F, Fut>(&self, f: F) -> Result<T, Error>
+        where
+            F: FnOnce(ArkServiceClient<InterceptedChannel>) -> Fut,
+            Fut: Future<Output = Result<T, tonic::Status>>,
+        {
+            let client = self.raw.clone();
+            let info_client = self.raw.clone();
+
+            self.shared
+                .guarded(info_client, async move {
+                    f(client).await.map_err(Error::request)
+                })
+                .await
+        }
+
+        pub(super) async fn get_info(&self) -> Result<Info, Error> {
+            self.shared.get_info_unguarded(self.raw.clone()).await
+        }
+    }
+
+    #[derive(Clone)]
+    pub(super) struct Indexer {
+        raw: IndexerServiceClient<InterceptedChannel>,
+        info_client: ArkServiceClient<InterceptedChannel>,
+        shared: SharedState,
+    }
+
+    impl Indexer {
+        pub(super) fn new(
+            raw: IndexerServiceClient<InterceptedChannel>,
+            info_client: ArkServiceClient<InterceptedChannel>,
+            shared: SharedState,
+        ) -> Self {
+            Self {
+                raw,
+                info_client,
+                shared,
+            }
+        }
+
+        /// Runs one Indexer service RPC through the digest guard.
+        ///
+        /// The closure must perform exactly one non-`GetInfo` gRPC call and return that
+        /// call's `tonic::Status` unchanged. Do not batch multiple RPCs, call `GetInfo`,
+        /// swallow errors, or synthesize fallback successes inside the closure. A digest
+        /// mismatch refreshes `/info` and returns `ServerInfoChanged`; the failed RPC is
+        /// not retried automatically.
+        pub(super) async fn request<T, F, Fut>(&self, f: F) -> Result<T, Error>
+        where
+            F: FnOnce(IndexerServiceClient<InterceptedChannel>) -> Fut,
+            Fut: Future<Output = Result<T, tonic::Status>>,
+        {
+            let client = self.raw.clone();
+            let info_client = self.info_client.clone();
+
+            self.shared
+                .guarded(info_client, async move {
+                    f(client).await.map_err(Error::request)
+                })
+                .await
         }
     }
 }

--- a/ark-grpc/src/error.rs
+++ b/ark-grpc/src/error.rs
@@ -20,6 +20,7 @@ enum Kind {
     Conversion,
     EventStreamDisconnect,
     EventStream,
+    ServerInfoChanged,
 }
 
 impl Error {
@@ -58,6 +59,14 @@ impl Error {
         Error::new(Kind::EventStream).with(source)
     }
 
+    pub(crate) fn server_info_changed(source: impl Into<Source>) -> Self {
+        Error::new(Kind::ServerInfoChanged).with(source)
+    }
+
+    pub fn is_server_info_changed(&self) -> bool {
+        matches!(self.inner.kind, Kind::ServerInfoChanged)
+    }
+
     /// Returns `true` if the server rejected the request because the SDK
     /// version is too old.
     pub fn is_version_mismatch(&self) -> bool {
@@ -65,6 +74,19 @@ impl Error {
             if let Some(status) = source.downcast_ref::<tonic::Status>() {
                 return status.code() == tonic::Code::FailedPrecondition
                     && status.message().contains("BUILD_VERSION_TOO_OLD");
+            }
+        }
+        false
+    }
+
+    /// Returns `true` if the server rejected the request because the cached
+    /// `/info` digest is stale.
+    pub(crate) fn is_digest_mismatch(&self) -> bool {
+        if let Some(source) = &self.inner.source {
+            if let Some(status) = source.downcast_ref::<tonic::Status>() {
+                return status.code() == tonic::Code::FailedPrecondition
+                    && (status.message().contains("DIGEST_MISMATCH")
+                        || status.message().contains("invalid digest header"));
             }
         }
         false
@@ -78,6 +100,7 @@ impl Error {
             Kind::Conversion => "failed to convert between types",
             Kind::EventStreamDisconnect => "got disconnected from event stream",
             Kind::EventStream => "error via event stream",
+            Kind::ServerInfoChanged => "Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe",
         }
     }
 }
@@ -151,5 +174,26 @@ mod tests {
     fn is_version_mismatch_false_when_no_source() {
         let err = Error::not_connected();
         assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_for_matching_status() {
+        let status = tonic::Status::failed_precondition("invalid digest header");
+        let err = Error::request(status);
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_for_error_code_in_message() {
+        let status = tonic::Status::failed_precondition("DIGEST_MISMATCH");
+        let err = Error::request(status);
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_false_for_other_failed_precondition() {
+        let status = tonic::Status::failed_precondition("something else");
+        let err = Error::request(status);
+        assert!(!err.is_digest_mismatch());
     }
 }

--- a/ark-grpc/src/test_utils.rs
+++ b/ark-grpc/src/test_utils.rs
@@ -6,6 +6,10 @@
 pub use crate::generated::ark::v1::admin_service_client::AdminServiceClient;
 pub use crate::generated::ark::v1::CreateNoteRequest;
 pub use crate::generated::ark::v1::CreateNoteResponse;
+pub use crate::generated::ark::v1::GetInfoRequest;
+pub use crate::generated::ark::v1::GetInfoResponse;
+pub use crate::generated::ark::v1::GetVtxosRequest;
+pub use crate::generated::ark::v1::GetVtxosResponse;
 use ark_core::ArkNote;
 
 /// Default admin service URL (arkd runs admin on port 7071).

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -33,6 +33,8 @@ use ark_core::server::SubmitOffchainTxResponse;
 use ark_core::server::SubscriptionResponse;
 use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
+use ark_core::server::SDK_VERSION;
+use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use bitcoin::base64;
 use bitcoin::base64::Engine;
@@ -42,9 +44,10 @@ use bitcoin::Txid;
 use futures::stream;
 use futures::Stream;
 use futures::StreamExt;
+use std::sync::RwLock;
 
 pub struct Client {
-    configuration: apis::configuration::Configuration,
+    configuration: RwLock<apis::configuration::Configuration>,
 }
 
 pub struct ListVtxosResponse {
@@ -52,33 +55,66 @@ pub struct ListVtxosResponse {
     pub page: Option<IndexerPage>,
 }
 
+fn build_reqwest_client(digest: Option<&str>) -> Result<reqwest::Client, Error> {
+    let mut default_headers = reqwest::header::HeaderMap::new();
+    default_headers.insert(
+        "X-Build-Version",
+        reqwest::header::HeaderValue::from_static(TARGET_ARKD_VERSION),
+    );
+    default_headers.insert(
+        "X-SDK-Version",
+        reqwest::header::HeaderValue::from_static(SDK_VERSION),
+    );
+    if let Some(digest) = digest {
+        default_headers.insert(
+            "X-Digest",
+            reqwest::header::HeaderValue::from_str(digest).map_err(Error::request)?,
+        );
+    }
+
+    reqwest::Client::builder()
+        .default_headers(default_headers)
+        .build()
+        .map_err(Error::request)
+}
+
 impl Client {
     pub fn new(ark_server_url: String) -> Result<Self, Error> {
-        let mut default_headers = reqwest::header::HeaderMap::new();
-        default_headers.insert(
-            "X-Build-Version",
-            reqwest::header::HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
-        );
-        let client = reqwest::Client::builder()
-            .default_headers(default_headers)
-            .build()
-            .map_err(Error::request)?;
-
         let configuration = apis::configuration::Configuration {
             base_path: ark_server_url,
-            client,
+            client: build_reqwest_client(None)?,
             ..Default::default()
         };
 
-        Ok(Self { configuration })
+        Ok(Self {
+            configuration: RwLock::new(configuration),
+        })
+    }
+
+    fn configuration(&self) -> Result<apis::configuration::Configuration, Error> {
+        self.configuration
+            .read()
+            .map(|configuration| configuration.clone())
+            .map_err(|_| Error::request("REST client configuration lock poisoned"))
+    }
+
+    fn update_digest(&self, digest: &str) -> Result<(), Error> {
+        let mut configuration = self
+            .configuration
+            .write()
+            .map_err(|_| Error::request("REST client configuration lock poisoned"))?;
+        configuration.client = build_reqwest_client((!digest.is_empty()).then_some(digest))?;
+        Ok(())
     }
 
     pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
-        let info = ark_service_get_info(&self.configuration)
+        let configuration = self.configuration()?;
+        let info = ark_service_get_info(&configuration)
             .await
             .map_err(Error::request)?;
 
-        let info = info.try_into()?;
+        let info: ark_core::server::Info = info.try_into()?;
+        self.update_digest(&info.digest)?;
 
         Ok(info)
     }
@@ -101,7 +137,7 @@ impl Client {
             .collect();
 
         let res = ark_service_submit_tx(
-            &self.configuration,
+            &self.configuration()?,
             models::SubmitTxRequest {
                 signed_ark_tx: Some(ark_tx),
                 checkpoint_txs,
@@ -150,7 +186,7 @@ impl Client {
             .collect();
 
         ark_service_finalize_tx(
-            &self.configuration,
+            &self.configuration()?,
             models::FinalizeTxRequest {
                 ark_txid: Some(txid.to_string()),
                 final_checkpoint_txs: checkpoint_txs,
@@ -206,7 +242,7 @@ impl Client {
         let after = request.after().map(|b| b as i64);
 
         let response = indexer_service_get_vtxos(
-            &self.configuration,
+            &self.configuration()?,
             scripts,
             outpoints,
             spendable_only,
@@ -252,7 +288,7 @@ impl Client {
         let proof = base64.encode(&bytes);
 
         let response = ark_service_register_intent(
-            &self.configuration,
+            &self.configuration()?,
             models::RegisterIntentRequest {
                 intent: Some(Intent {
                     proof: Some(proof),
@@ -284,7 +320,7 @@ impl Client {
 
         let proof = base64.encode(&bytes);
         ark_service_delete_intent(
-            &self.configuration,
+            &self.configuration()?,
             models::DeleteIntentRequest {
                 intent: Some(Intent {
                     proof: Some(proof),
@@ -302,8 +338,10 @@ impl Client {
         &self,
         topics: Vec<String>,
     ) -> Result<impl Stream<Item = Result<StreamEvent, Error>> + Unpin, Error> {
+        let configuration = self.configuration()?;
+
         // Build the URL with query parameters
-        let mut url = format!("{}/v1/batch/events", self.configuration.base_path);
+        let mut url = format!("{}/v1/batch/events", configuration.base_path);
         if !topics.is_empty() {
             let query_params: Vec<String> = topics
                 .iter()
@@ -313,8 +351,8 @@ impl Client {
         }
 
         // Create the request for SSE
-        let client = &self.configuration.client;
-        let request = client
+        let request = configuration
+            .client
             .get(&url)
             .header("Accept", "text/event-stream")
             .send()
@@ -379,7 +417,7 @@ impl Client {
     }
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
         ark_service_confirm_registration(
-            &self.configuration,
+            &self.configuration()?,
             ConfirmRegistrationRequest {
                 intent_id: Some(intent_id),
             },
@@ -399,7 +437,7 @@ impl Client {
         let tree_nonces = pub_nonce_tree.encode();
 
         ark_service_submit_tree_nonces(
-            &self.configuration,
+            &self.configuration()?,
             SubmitTreeNoncesRequest {
                 batch_id: Some(batch_id.to_string()),
                 pubkey: Some(cosigner_pubkey.to_string()),
@@ -421,7 +459,7 @@ impl Client {
         let tree_signatures = partial_sig_tree.encode();
 
         ark_service_submit_tree_signatures(
-            &self.configuration,
+            &self.configuration()?,
             SubmitTreeSignaturesRequest {
                 batch_id: Some(batch_id.to_string()),
                 pubkey: Some(cosigner_pk.to_string()),
@@ -449,7 +487,7 @@ impl Client {
             .unwrap_or_default();
 
         ark_service_submit_signed_forfeit_txs(
-            &self.configuration,
+            &self.configuration()?,
             SubmitSignedForfeitTxsRequest {
                 signed_forfeit_txs: signed_forfeit_txs
                     .iter()
@@ -487,7 +525,7 @@ impl Client {
         let subscription_id = subscription_id.unwrap_or_default();
 
         let response = indexer_service_subscribe_for_scripts(
-            &self.configuration,
+            &self.configuration()?,
             SubscribeForScriptsRequest {
                 scripts: Some(scripts),
                 subscription_id: Some(subscription_id),
@@ -515,7 +553,7 @@ impl Client {
             .collect::<Vec<_>>();
 
         let _ = indexer_service_unsubscribe_for_scripts(
-            &self.configuration,
+            &self.configuration()?,
             UnsubscribeForScriptsRequest {
                 subscription_id: Some(subscription_id),
                 scripts: Some(scripts),
@@ -531,15 +569,17 @@ impl Client {
         &self,
         subscription_id: String,
     ) -> Result<impl Stream<Item = Result<SubscriptionResponse, Error>> + Unpin, Error> {
+        let configuration = self.configuration()?;
+
         // Build the URL with subscription_id parameter
         let url = format!(
             "{}/v1/script/subscription/{subscription_id}",
-            self.configuration.base_path,
+            configuration.base_path,
         );
 
         // Create the request for SSE
-        let client = &self.configuration.client;
-        let request = client
+        let request = configuration
+            .client
             .get(&url)
             .header("Accept", "text/event-stream")
             .send()
@@ -613,7 +653,7 @@ impl Client {
         let (size, index) = size_and_index
             .map(|(sz, indx)| (Some(sz), Some(indx)))
             .unwrap_or_default();
-        let response = indexer_service_get_virtual_txs(&self.configuration, txids, size, index)
+        let response = indexer_service_get_virtual_txs(&self.configuration()?, txids, size, index)
             .await
             .map_err(Error::request)?;
 

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -42,12 +42,23 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::Psbt;
 use bitcoin::Txid;
 use futures::stream;
+use futures::Future;
 use futures::Stream;
 use futures::StreamExt;
+use std::error::Error as StdError;
+use std::sync::Arc;
 use std::sync::RwLock;
+
+type InfoRefreshHook = Arc<
+    dyn Fn(ark_core::server::Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+        + Send
+        + Sync,
+>;
 
 pub struct Client {
     configuration: RwLock<apis::configuration::Configuration>,
+    digest: RwLock<Option<String>>,
+    info_refresh_hook: Option<InfoRefreshHook>,
 }
 
 pub struct ListVtxosResponse {
@@ -88,7 +99,19 @@ impl Client {
 
         Ok(Self {
             configuration: RwLock::new(configuration),
+            digest: RwLock::new(None),
+            info_refresh_hook: None,
         })
+    }
+
+    pub fn set_info_refresh_hook(
+        &mut self,
+        hook: impl Fn(ark_core::server::Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+            + Send
+            + Sync
+            + 'static,
+    ) {
+        self.info_refresh_hook = Some(Arc::new(hook));
     }
 
     fn configuration(&self) -> Result<apis::configuration::Configuration, Error> {
@@ -99,23 +122,84 @@ impl Client {
     }
 
     fn update_digest(&self, digest: &str) -> Result<(), Error> {
+        let normalized = (!digest.is_empty()).then(|| digest.to_owned());
+
+        {
+            let current = self
+                .digest
+                .read()
+                .map_err(|_| Error::request("REST client digest lock poisoned"))?;
+            if *current == normalized {
+                return Ok(());
+            }
+        }
+
+        // Lock-ordering invariant: when both write locks are held, acquire
+        // `configuration` before `digest`. This is the only path that takes both.
+        // If another thread races past the unchanged check, the worst case is a
+        // redundant reqwest client rebuild; correctness is unchanged.
         let mut configuration = self
             .configuration
             .write()
             .map_err(|_| Error::request("REST client configuration lock poisoned"))?;
-        configuration.client = build_reqwest_client((!digest.is_empty()).then_some(digest))?;
+        configuration.client = build_reqwest_client(normalized.as_deref())?;
+
+        let mut current = self
+            .digest
+            .write()
+            .map_err(|_| Error::request("REST client digest lock poisoned"))?;
+        *current = normalized;
         Ok(())
     }
 
-    pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
+    async fn guarded<T>(&self, op: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let original = err;
+                self.refresh_after_digest_mismatch().await?;
+                Err(Error::server_info_changed(original))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn refresh_on_digest_mismatch(&self, err: Error) -> Error {
+        if !err.is_digest_mismatch() {
+            return err;
+        }
+
+        match self.refresh_after_digest_mismatch().await {
+            Ok(()) => Error::server_info_changed(err),
+            Err(refresh_err) => refresh_err,
+        }
+    }
+
+    async fn refresh_after_digest_mismatch(&self) -> Result<(), Error> {
+        let info = self.fetch_info_unguarded().await?;
+        let digest = info.digest.clone();
+
+        if let Some(hook) = &self.info_refresh_hook {
+            hook(info).map_err(Error::conversion)?;
+        }
+
+        // Commit the transport digest only after the hook updates higher-level state.
+        // If the hook fails, leave the old digest in place so the next request refreshes again.
+        self.update_digest(&digest)
+    }
+
+    async fn fetch_info_unguarded(&self) -> Result<ark_core::server::Info, Error> {
         let configuration = self.configuration()?;
         let info = ark_service_get_info(&configuration)
             .await
             .map_err(Error::request)?;
 
-        let info: ark_core::server::Info = info.try_into()?;
-        self.update_digest(&info.digest)?;
+        info.try_into().map_err(Error::conversion)
+    }
 
+    pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
+        let info = self.fetch_info_unguarded().await?;
+        self.update_digest(&info.digest)?;
         Ok(info)
     }
 
@@ -136,15 +220,20 @@ impl Client {
             .map(|tx| Some(base64.encode(tx.serialize())))
             .collect();
 
-        let res = ark_service_submit_tx(
-            &self.configuration()?,
-            models::SubmitTxRequest {
-                signed_ark_tx: Some(ark_tx),
-                checkpoint_txs,
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let res = self
+            .guarded(async {
+                ark_service_submit_tx(
+                    &configuration,
+                    models::SubmitTxRequest {
+                        signed_ark_tx: Some(ark_tx),
+                        checkpoint_txs,
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let signed_ark_tx = res.final_ark_tx;
         let signed_ark_tx = signed_ark_tx.ok_or(Error::request("Signed ark tx not received"))?;
@@ -185,15 +274,19 @@ impl Client {
             .map(|tx| Some(base64.encode(tx.serialize())))
             .collect();
 
-        ark_service_finalize_tx(
-            &self.configuration()?,
-            models::FinalizeTxRequest {
-                ark_txid: Some(txid.to_string()),
-                final_checkpoint_txs: checkpoint_txs,
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_finalize_tx(
+                &configuration,
+                models::FinalizeTxRequest {
+                    ark_txid: Some(txid.to_string()),
+                    final_checkpoint_txs: checkpoint_txs,
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(FinalizeOffchainTxResponse {})
     }
@@ -241,21 +334,26 @@ impl Client {
         let before = request.before().map(|b| b as i64);
         let after = request.after().map(|b| b as i64);
 
-        let response = indexer_service_get_vtxos(
-            &self.configuration()?,
-            scripts,
-            outpoints,
-            spendable_only,
-            spent_only,
-            recoverable_only,
-            pending_only,
-            before,
-            after,
-            page_period_size,
-            page_period_index,
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_get_vtxos(
+                    &configuration,
+                    scripts,
+                    outpoints,
+                    spendable_only,
+                    spent_only,
+                    recoverable_only,
+                    pending_only,
+                    before,
+                    after,
+                    page_period_size,
+                    page_period_index,
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let vtxos = response.vtxos.ok_or(Error::request("VTXOs not received"))?;
         let vtxos = vtxos
@@ -287,17 +385,22 @@ impl Client {
 
         let proof = base64.encode(&bytes);
 
-        let response = ark_service_register_intent(
-            &self.configuration()?,
-            models::RegisterIntentRequest {
-                intent: Some(Intent {
-                    proof: Some(proof),
-                    message: Some(message),
-                }),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                ark_service_register_intent(
+                    &configuration,
+                    models::RegisterIntentRequest {
+                        intent: Some(Intent {
+                            proof: Some(proof),
+                            message: Some(message),
+                        }),
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
         let intent_id = response
             .intent_id
             .ok_or(Error::request("Could not get intent id"))?;
@@ -319,17 +422,21 @@ impl Client {
         let bytes = proof.serialize();
 
         let proof = base64.encode(&bytes);
-        ark_service_delete_intent(
-            &self.configuration()?,
-            models::DeleteIntentRequest {
-                intent: Some(Intent {
-                    proof: Some(proof),
-                    message: Some(message),
-                }),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_delete_intent(
+                &configuration,
+                models::DeleteIntentRequest {
+                    intent: Some(Intent {
+                        proof: Some(proof),
+                        message: Some(message),
+                    }),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -359,12 +466,15 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        // Check if the request was successful
+        // Check if the request was successful. Read the body (not just the status) so a
+        // DIGEST_MISMATCH marker is visible and can trigger the same refresh path as unary calls.
         if !request.status().is_success() {
-            return Err(Error::request(format!(
-                "Event stream request failed with status: {}",
-                request.status()
-            )));
+            let status = request.status();
+            let body = request.text().await.unwrap_or_default();
+            let err = Error::request(format!(
+                "Event stream request failed with status {status}: {body}"
+            ));
+            return Err(self.refresh_on_digest_mismatch(err).await);
         }
 
         // Convert the response into a byte stream using async chunks
@@ -416,14 +526,18 @@ impl Client {
         Ok(Box::pin(stream))
     }
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
-        ark_service_confirm_registration(
-            &self.configuration()?,
-            ConfirmRegistrationRequest {
-                intent_id: Some(intent_id),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_confirm_registration(
+                &configuration,
+                ConfirmRegistrationRequest {
+                    intent_id: Some(intent_id),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -436,16 +550,20 @@ impl Client {
     ) -> Result<(), Error> {
         let tree_nonces = pub_nonce_tree.encode();
 
-        ark_service_submit_tree_nonces(
-            &self.configuration()?,
-            SubmitTreeNoncesRequest {
-                batch_id: Some(batch_id.to_string()),
-                pubkey: Some(cosigner_pubkey.to_string()),
-                tree_nonces: Some(tree_nonces),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_tree_nonces(
+                &configuration,
+                SubmitTreeNoncesRequest {
+                    batch_id: Some(batch_id.to_string()),
+                    pubkey: Some(cosigner_pubkey.to_string()),
+                    tree_nonces: Some(tree_nonces),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -458,16 +576,20 @@ impl Client {
     ) -> Result<(), Error> {
         let tree_signatures = partial_sig_tree.encode();
 
-        ark_service_submit_tree_signatures(
-            &self.configuration()?,
-            SubmitTreeSignaturesRequest {
-                batch_id: Some(batch_id.to_string()),
-                pubkey: Some(cosigner_pk.to_string()),
-                tree_signatures: Some(tree_signatures),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_tree_signatures(
+                &configuration,
+                SubmitTreeSignaturesRequest {
+                    batch_id: Some(batch_id.to_string()),
+                    pubkey: Some(cosigner_pk.to_string()),
+                    tree_signatures: Some(tree_signatures),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -486,18 +608,22 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .unwrap_or_default();
 
-        ark_service_submit_signed_forfeit_txs(
-            &self.configuration()?,
-            SubmitSignedForfeitTxsRequest {
-                signed_forfeit_txs: signed_forfeit_txs
-                    .iter()
-                    .map(|psbt| Some(base64.encode(psbt.serialize())))
-                    .collect(),
-                signed_commitment_tx: Some(signed_commitment_tx),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_signed_forfeit_txs(
+                &configuration,
+                SubmitSignedForfeitTxsRequest {
+                    signed_forfeit_txs: signed_forfeit_txs
+                        .iter()
+                        .map(|psbt| Some(base64.encode(psbt.serialize())))
+                        .collect(),
+                    signed_commitment_tx: Some(signed_commitment_tx),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -524,15 +650,20 @@ impl Client {
         // For new subscription we expect empty string ("") here
         let subscription_id = subscription_id.unwrap_or_default();
 
-        let response = indexer_service_subscribe_for_scripts(
-            &self.configuration()?,
-            SubscribeForScriptsRequest {
-                scripts: Some(scripts),
-                subscription_id: Some(subscription_id),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_subscribe_for_scripts(
+                    &configuration,
+                    SubscribeForScriptsRequest {
+                        scripts: Some(scripts),
+                        subscription_id: Some(subscription_id),
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let subscription_id = response
             .subscription_id
@@ -552,15 +683,19 @@ impl Client {
             .map(|address| address.to_p2tr_script_pubkey().to_hex_string())
             .collect::<Vec<_>>();
 
-        let _ = indexer_service_unsubscribe_for_scripts(
-            &self.configuration()?,
-            UnsubscribeForScriptsRequest {
-                subscription_id: Some(subscription_id),
-                scripts: Some(scripts),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            indexer_service_unsubscribe_for_scripts(
+                &configuration,
+                UnsubscribeForScriptsRequest {
+                    subscription_id: Some(subscription_id),
+                    scripts: Some(scripts),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -586,12 +721,15 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        // Check if the request was successful
+        // Check if the request was successful. Read the body (not just the status) so a
+        // DIGEST_MISMATCH marker is visible and can trigger the same refresh path as unary calls.
         if !request.status().is_success() {
-            return Err(Error::request(format!(
-                "Subscription stream request failed with status: {}",
-                request.status()
-            )));
+            let status = request.status();
+            let body = request.text().await.unwrap_or_default();
+            let err = Error::request(format!(
+                "Subscription stream request failed with status {status}: {body}"
+            ));
+            return Err(self.refresh_on_digest_mismatch(err).await);
         }
 
         // Convert the response into a byte stream using async chunks
@@ -653,9 +791,14 @@ impl Client {
         let (size, index) = size_and_index
             .map(|(sz, indx)| (Some(sz), Some(indx)))
             .unwrap_or_default();
-        let response = indexer_service_get_virtual_txs(&self.configuration()?, txids, size, index)
-            .await
-            .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_get_virtual_txs(&configuration, txids, size, index)
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let base64 = &base64::engine::GeneralPurpose::new(
             &base64::alphabet::STANDARD,
@@ -682,5 +825,53 @@ impl Client {
                 total: a.total.unwrap_or_default(),
             }),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    #[tokio::test]
+    async fn guarded_passes_through_non_digest_error() {
+        let mut client = Client::new("http://127.0.0.1:1".to_string()).unwrap();
+        let hook_fired = Arc::new(AtomicBool::new(false));
+        let flag = hook_fired.clone();
+        client.set_info_refresh_hook(move |_info| {
+            flag.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let err = client
+            .guarded(async { Err::<(), _>(Error::request("connection refused")) })
+            .await
+            .expect_err("should surface the original error");
+
+        assert!(!err.is_server_info_changed());
+        assert!(!err.is_digest_mismatch());
+        assert!(!hook_fired.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn guarded_detects_digest_mismatch_and_attempts_refresh() {
+        let mut client = Client::new("http://127.0.0.1:1".to_string()).unwrap();
+        let hook_fired = Arc::new(AtomicBool::new(false));
+        let flag = hook_fired.clone();
+        client.set_info_refresh_hook(move |_info| {
+            flag.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let err = client
+            .guarded(async { Err::<(), _>(Error::request("DIGEST_MISMATCH")) })
+            .await
+            .expect_err("digest mismatch should trigger a refresh that fails on a closed port");
+
+        // The refetch failed, so we get its request error instead of ServerInfoChanged.
+        // The hook only fires after a successful refetch.
+        assert!(!err.is_server_info_changed());
+        assert!(!hook_fired.load(Ordering::SeqCst));
     }
 }

--- a/ark-rest/src/error.rs
+++ b/ark-rest/src/error.rs
@@ -17,6 +17,7 @@ struct ErrorImpl {
 enum Kind {
     Request,
     Conversion,
+    ServerInfoChanged,
 }
 
 impl Error {
@@ -39,11 +40,36 @@ impl Error {
         Error::new(Kind::Conversion).with(source)
     }
 
+    pub(crate) fn server_info_changed(source: impl Into<Source>) -> Self {
+        Error::new(Kind::ServerInfoChanged).with(source)
+    }
+
+    /// Returns `true` if the failed operation triggered a digest-mismatch refresh of the
+    /// cached `/info`. The original request was not retried.
+    pub fn is_server_info_changed(&self) -> bool {
+        matches!(self.inner.kind, Kind::ServerInfoChanged)
+    }
+
     /// Returns `true` if the server rejected the request because the SDK
     /// version is too old.
     pub fn is_version_mismatch(&self) -> bool {
+        self.source_contains_any(&["BUILD_VERSION_TOO_OLD"])
+    }
+
+    /// Returns `true` if the server rejected the request because the cached
+    /// `/info` digest is stale.
+    pub(crate) fn is_digest_mismatch(&self) -> bool {
+        matches!(self.inner.kind, Kind::Request)
+            && self.source_contains_any(&["DIGEST_MISMATCH", "invalid digest header"])
+    }
+
+    fn source_contains_any(&self, markers: &[&str]) -> bool {
         if let Some(source) = &self.inner.source {
-            return source.to_string().contains("BUILD_VERSION_TOO_OLD");
+            let display = source.to_string();
+            let debug = format!("{source:?}");
+            return markers
+                .iter()
+                .any(|marker| display.contains(marker) || debug.contains(marker));
         }
         false
     }
@@ -52,6 +78,7 @@ impl Error {
         match &self.inner.kind {
             Kind::Request => "request failed",
             Kind::Conversion => "failed to convert between types",
+            Kind::ServerInfoChanged => "Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe",
         }
     }
 }
@@ -111,5 +138,47 @@ mod tests {
     fn is_version_mismatch_false_when_no_source() {
         let err = Error::new(Kind::Request);
         assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_when_source_contains_marker() {
+        let err = Error::request("DIGEST_MISMATCH: invalid digest header");
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_when_generated_error_content_contains_marker() {
+        let source = crate::apis::Error::<()>::ResponseError(crate::apis::ResponseContent {
+            status: reqwest::StatusCode::PRECONDITION_FAILED,
+            content: "DIGEST_MISMATCH: invalid digest header".to_string(),
+            entity: None,
+        });
+        let err = Error::request(source);
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_false_for_other_errors() {
+        let err = Error::request("connection refused");
+        assert!(!err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_server_info_changed_true_for_server_info_changed_kind() {
+        let err = Error::server_info_changed("DIGEST_MISMATCH");
+        assert!(err.is_server_info_changed());
+    }
+
+    #[test]
+    fn server_info_changed_is_not_classified_as_digest_mismatch() {
+        let err = Error::server_info_changed(Error::request("DIGEST_MISMATCH"));
+        assert!(err.is_server_info_changed());
+        assert!(!err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_server_info_changed_false_for_other_errors() {
+        let err = Error::request("DIGEST_MISMATCH");
+        assert!(!err.is_server_info_changed());
     }
 }

--- a/docs/guarded-grpc-client-design.md
+++ b/docs/guarded-grpc-client-design.md
@@ -1,0 +1,260 @@
+# Guarded gRPC Client Design
+
+## Problem
+
+`ark_grpc::Client` wraps generated tonic clients for Ark and Indexer RPCs. Most RPCs need digest-mismatch handling:
+
+1. run the requested RPC,
+2. if arkd rejects it because the cached `/info` digest is stale, fetch fresh `/info`,
+3. update the digest header and the higher-level client state via the refresh hook,
+4. return `ServerInfoChanged` without retrying the original operation.
+
+The current pattern relies on each method remembering to wrap the raw generated client call in `guarded(...)`. That is easy to forget when adding a new RPC method.
+
+## Goal
+
+Make guarded execution the normal and obvious path for every RPC, while keeping the unguarded path available only for `/info` bootstrap/refresh.
+
+This design should:
+
+- prevent accidental direct use of raw generated tonic clients in normal RPC methods,
+- keep the existing no-automatic-retry behavior,
+- keep the implementation straightforward and local to `ark-grpc`,
+- avoid exposing internal refresh hooks or unguarded methods as public API.
+
+## Design
+
+Introduce wrapper newtypes for the generated tonic clients:
+
+- `guarded::Ark`
+- `guarded::Indexer`
+
+`ark_grpc::Client` stores these wrappers instead of exposing or using raw generated clients directly.
+
+```rust
+pub struct Client {
+    url: String,
+    ark: Option<guarded::Ark>,
+    indexer: Option<guarded::Indexer>,
+    shared: SharedState,
+}
+```
+
+The wrappers live in a child module and keep the generated tonic clients private:
+
+```rust
+mod guarded {
+    use super::*;
+
+    #[derive(Clone)]
+    pub(super) struct Ark {
+        raw: ArkServiceClient<InterceptedChannel>,
+        shared: SharedState,
+    }
+
+    #[derive(Clone)]
+    pub(super) struct Indexer {
+        raw: IndexerServiceClient<InterceptedChannel>,
+        info_client: ArkServiceClient<InterceptedChannel>,
+        shared: SharedState,
+    }
+}
+```
+
+Normal RPC execution goes through `request(...)` on the wrapper. The closure receives a cloned generated client, but the wrapper always runs the returned future through the shared guard.
+
+```rust
+impl guarded::Ark {
+    pub(super) async fn request<T, F, Fut>(&self, f: F) -> Result<T, Error>
+    where
+        F: FnOnce(ArkServiceClient<InterceptedChannel>) -> Fut,
+        Fut: Future<Output = Result<T, tonic::Status>>,
+    {
+        let client = self.raw.clone();
+        let info_client = self.raw.clone();
+
+        self.shared
+            .guarded(info_client, async move {
+                f(client).await.map_err(Error::request)
+            })
+            .await
+    }
+
+    pub(super) async fn get_info(&self) -> Result<Info, Error> {
+        self.shared.get_info_unguarded(self.raw.clone()).await
+    }
+}
+
+impl guarded::Indexer {
+    pub(super) async fn request<T, F, Fut>(&self, f: F) -> Result<T, Error>
+    where
+        F: FnOnce(IndexerServiceClient<InterceptedChannel>) -> Fut,
+        Fut: Future<Output = Result<T, tonic::Status>>,
+    {
+        let client = self.raw.clone();
+        let info_client = self.info_client.clone();
+
+        self.shared
+            .guarded(info_client, async move {
+                f(client).await.map_err(Error::request)
+            })
+            .await
+    }
+}
+```
+
+`Indexer` also stores an Ark service client (`info_client`) because digest refresh requires calling `GetInfo`, even when the failed operation was an Indexer RPC.
+
+## Shared state
+
+Move digest header state and the refresh hook into a shared state object cloned by both wrappers.
+
+```rust
+#[derive(Clone, Default)]
+struct SharedState {
+    headers: HeaderState,
+    info_refresh_hook: Arc<RwLock<Option<InfoRefreshHook>>>,
+}
+```
+
+The shared guard owns the digest-mismatch behavior:
+
+```rust
+impl SharedState {
+    async fn guarded<T>(
+        &self,
+        info_client: ArkServiceClient<InterceptedChannel>,
+        op: impl Future<Output = Result<T, Error>>,
+    ) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let original = err;
+                let info = self.fetch_info_unguarded(info_client).await?;
+                let digest = info.digest.clone();
+
+                if let Some(hook) = self.info_refresh_hook() {
+                    hook(info).map_err(Error::conversion)?;
+                }
+
+                self.headers.set_digest(digest);
+                Err(Error::server_info_changed(original))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn info_refresh_hook(&self) -> Option<InfoRefreshHook> {
+        match self.info_refresh_hook.read() {
+            Ok(hook) => hook.clone(),
+            Err(poisoned) => {
+                log::warn!("info refresh hook lock poisoned while reading; recovering");
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+
+    async fn get_info_unguarded(
+        &self,
+        client: ArkServiceClient<InterceptedChannel>,
+    ) -> Result<Info, Error> {
+        let info = self.fetch_info_unguarded(client).await?;
+        self.headers.set_digest(info.digest.clone());
+        Ok(info)
+    }
+
+    async fn fetch_info_unguarded(
+        &self,
+        mut client: ArkServiceClient<InterceptedChannel>,
+    ) -> Result<Info, Error> {
+        let response = client
+            .get_info(GetInfoRequest {})
+            .await
+            .map_err(Error::request)?;
+
+        response.into_inner().try_into()
+    }
+}
+```
+
+Implementation detail: pass the Ark service client used for refresh into `guarded(...)`. `guarded::Ark` passes a clone of its Ark client; `guarded::Indexer` passes its dedicated `info_client`. This keeps the refresh path explicit and avoids ambiguity when an Indexer RPC fails. During digest-mismatch refresh, fetch `/info` without committing the digest header, run the refresh hook, and only then update the digest header. If the hook fails, the header remains stale along with the higher-level client state, so the next request will still refresh rather than sending a fresh digest with stale local state. The refresh hook accessor should recover from a poisoned lock (or return an error) rather than silently skipping the hook. The important invariant is that refresh uses only the unguarded `/info` path and does not recursively go through the guarded request path.
+
+## Example method after refactor
+
+Before:
+
+```rust
+let mut client = self.indexer_client()?;
+
+let response = self
+    .guarded(async {
+        client
+            .get_asset(request)
+            .await
+            .map_err(Error::request)
+    })
+    .await?;
+```
+
+After:
+
+```rust
+let response = self
+    .indexer()?
+    .request(|mut client| async move {
+        client.get_asset(request).await
+    })
+    .await?;
+```
+
+The public method no longer needs to remember `guarded(...)`; it can only obtain a guarded wrapper.
+
+## How this prevents skipping the guard
+
+The design changes the local API shape:
+
+1. Raw generated clients are fields inside `guarded::Ark` and `guarded::Indexer`.
+2. Normal `ark_grpc::Client` methods receive only wrapper values via `ark()?` / `indexer()?`.
+3. The wrapper exposes `request(...)` as the normal RPC escape hatch.
+4. `request(...)` always calls `SharedState::guarded(...)` with the Ark client used for digest refresh.
+5. The only unguarded path is `get_info_unguarded(...)`, used for bootstrap/refresh.
+
+This makes skipping the guard much harder to do accidentally. Adding a new RPC should follow one recognizable pattern: choose `ark()?.request(...)` or `indexer()?.request(...)`.
+
+## Clippy guardrail
+
+Add a lint rule to catch accidental direct calls to raw client accessors if any remain during migration:
+
+```toml
+disallowed-methods = [
+  { path = "ark_grpc::client::Client::ark_client", reason = "use guarded::Ark::request so digest mismatches are guarded" },
+  { path = "ark_grpc::client::Client::indexer_client", reason = "use guarded::Indexer::request so digest mismatches are guarded" },
+]
+```
+
+If those accessors are removed entirely after the wrapper refactor, this lint becomes unnecessary. If they remain as private helpers, allow the lint only at intentional bootstrap/wrapper construction sites.
+
+## Invariants
+
+- `GetInfo` bootstrap/refresh is the only unguarded RPC.
+- All Ark service RPCs, except `GetInfo`, go through `guarded::Ark::request`.
+- All Indexer service RPCs go through `guarded::Indexer::request`.
+- `request(...)` closures are an escape hatch over the full generated client. They should perform exactly one non-`GetInfo` RPC and propagate errors; they must not catch errors and return fallback success values.
+- The closure rule above is review-enforced. If stronger compile-time enforcement becomes necessary, replace `request(...)` with concrete wrapper methods or narrower service-specific traits.
+- Digest mismatch refresh updates both the request header state and the high-level client state via the refresh hook; the digest header is committed only after the hook succeeds.
+- The original failed operation is not retried automatically.
+
+## Tradeoffs
+
+Benefits:
+
+- Reduces the chance of forgetting digest guarding on new RPCs.
+- Keeps digest refresh behavior centralized.
+- Avoids adding many concrete wrapper methods.
+- Keeps the generated tonic clients out of normal `Client` method bodies.
+
+Costs:
+
+- Adds a small wrapper layer around generated clients.
+- Uses generic closures, so reviewers should still check that closures do not call `GetInfo`, perform multiple RPCs, or swallow errors.
+- Requires careful handling of the unguarded `/info` path to avoid recursive refresh behavior.

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -120,7 +120,8 @@ pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
     let mut max_blocktime_offset = 0;
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()
         .expect("unilateral VTXO exit delay should be relative")

--- a/e2e-tests/tests/e2e_assets.rs
+++ b/e2e-tests/tests/e2e_assets.rs
@@ -133,7 +133,7 @@ pub async fn e2e_assets() {
     let send_txid = alice
         .send(vec![SendReceiver {
             address: bob_address,
-            amount: alice.dust(),
+            amount: alice.dust().unwrap(),
             assets: vec![ark_core::server::Asset {
                 asset_id: issued_asset_id,
                 amount: send_amount,

--- a/e2e-tests/tests/e2e_continue_pending_tx.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx.rs
@@ -57,7 +57,13 @@ pub async fn e2e_continue_pending_tx() {
         })
         .collect::<Vec<_>>();
 
-    let selected = select_vtxos(spendable, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
 
     let vtxo_inputs: Vec<VtxoInput> = selected
         .into_iter()

--- a/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
@@ -110,8 +110,13 @@ pub async fn e2e_continue_pending_tx_multi_input() {
         })
         .collect::<Vec<_>>();
 
-    let selected =
-        select_vtxos(spendable_coins, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable_coins,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
     assert_eq!(
         selected.len(),
         2,

--- a/e2e-tests/tests/e2e_finalize_pending_tx.rs
+++ b/e2e-tests/tests/e2e_finalize_pending_tx.rs
@@ -57,7 +57,13 @@ pub async fn e2e_finalize_pending_tx() {
         })
         .collect::<Vec<_>>();
 
-    let selected = select_vtxos(spendable, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
 
     let vtxo_inputs: Vec<VtxoInput> = selected
         .into_iter()

--- a/e2e-tests/tests/e2e_multisig_delegate.rs
+++ b/e2e-tests/tests/e2e_multisig_delegate.rs
@@ -80,10 +80,10 @@ pub async fn e2e_multisig_delegate() {
         MsigOutputTaprootOptions {
             alice_pk: alice_msig_output_pk.into(),
             bob_pk: bob_msig_output_pk.into(),
-            server_pk: alice.server_info.signer_pk.into(),
-            unilateral_exit_delay: alice.server_info.unilateral_exit_delay,
+            server_pk: alice.server_info().unwrap().signer_pk.into(),
+            unilateral_exit_delay: alice.server_info().unwrap().unilateral_exit_delay,
         },
-        alice.server_info.network,
+        alice.server_info().unwrap().network,
     )
     .unwrap();
 
@@ -117,7 +117,7 @@ pub async fn e2e_multisig_delegate() {
         OutPoint { txid, vout: 0 },
         // TODO: This should be modelled in the output type. I think it's supposed to be the
         // highest sequence number of all leaves, but I'm not sure.
-        alice.server_info.unilateral_exit_delay,
+        alice.server_info().unwrap().unilateral_exit_delay,
         None,
         TxOut {
             value: msig_output_amount,
@@ -138,8 +138,8 @@ pub async fn e2e_multisig_delegate() {
             script_pubkey: msig_output.script_pubkey(),
         })],
         bob_delegate_cosigner_pk,
-        &alice.server_info.forfeit_address,
-        alice.server_info.dust,
+        &alice.server_info().unwrap().forfeit_address,
+        alice.server_info().unwrap().dust,
     )
     .unwrap();
 
@@ -197,7 +197,7 @@ pub async fn e2e_multisig_delegate() {
         .await
         .unwrap();
 
-    let vtxo_list = VtxoList::new(alice.server_info.dust, virtual_tx_outpoints);
+    let vtxo_list = VtxoList::new(alice.server_info().unwrap().dust, virtual_tx_outpoints);
 
     assert_eq!(vtxo_list.all_unspent().count(), 1);
     assert_eq!(vtxo_list.spent().count(), 1);
@@ -208,7 +208,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(settled_msig_outpoint.is_preconfirmed);
     assert!(!settled_msig_outpoint.is_swept);
     assert!(!settled_msig_outpoint.is_unrolled);
-    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info.dust));
+    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
     assert_eq!(settled_msig_outpoint.settled_by, Some(commitment_txid));
 
     let new_msig_outpoint = &vtxo_list.all_unspent().next().unwrap();
@@ -217,7 +217,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(!new_msig_outpoint.is_preconfirmed);
     assert!(!new_msig_outpoint.is_swept);
     assert!(!new_msig_outpoint.is_unrolled);
-    assert!(!new_msig_outpoint.is_recoverable(alice.server_info.dust));
+    assert!(!new_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
     assert!(new_msig_outpoint
         .commitment_txids
         .contains(&commitment_txid));

--- a/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
@@ -26,7 +26,8 @@ pub async fn send_onchain_boarding_output() {
     // To be able to spend a boarding output it needs to have been confirmed for at least
     // `boarding_exit_delay`.
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()
         .expect("boarding exit delay should be relative")

--- a/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
@@ -128,7 +128,8 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
     let mut max_blocktime_offset = 0;
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()
         .expect("unilateral VTXO exit delay should be relative")
@@ -142,7 +143,8 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
     };
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()
         .expect("boarding exit delay should be relative")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatically refresh cached server info on digest mismatches (gRPC and REST) and surface a “server info changed” error.
  * Added request metadata for build/SDK versions and a refresh hook after successful server refresh.
  * Added helpers to detect server-info and version/digest mismatch errors.
* **Bug Fixes**
  * Use fresh server-provided dust and fee parameters during transaction building and batch operations.
* **API Changes**
  * `dust()` now returns `Result` instead of a plain value.
* **Documentation / Tests**
  * Added guarded-client design documentation and updated e2e tests to use fallible server-info access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->