### PR TITLE
feat: server signer rotation support

### DIFF
--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -49,6 +49,7 @@ backon = { version = "1", features = ["gloo-timers-sleep"] }
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 getrandom = { version = "0.2", features = ["wasm-bindgen", "js"] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
+js-sys = { version = "0.3" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tonic-prost = "0.14"
 tonic-web-wasm-client = { version = "0.6", default-features = false }

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -45,7 +45,6 @@ use bitcoin::TxOut;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use futures::StreamExt;
-use jiff::Timestamp;
 use rand::CryptoRng;
 use rand::Rng;
 use std::collections::HashMap;
@@ -1011,7 +1010,7 @@ where
         // To track unique outpoints and prevent duplicates
         let mut seen_outpoints = std::collections::HashSet::new();
 
-        let now = Timestamp::now();
+        let now_secs = super::unix_now();
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {
@@ -1039,7 +1038,6 @@ where
                     // Skip boarding outputs whose server key is past its cooperative-sign
                     // cutoff — the operator won't co-sign the old key's forfeit path.
                     // These must be recovered via unilateral exit (send_on_chain).
-                    let now_secs = now.as_second();
                     if self
                         .server_info
                         .is_signer_past_cutoff_at(boarding_output.server_pk(), now_secs)
@@ -1049,7 +1047,7 @@ where
 
                     // Only include confirmed boarding outputs with an _inactive_ exit path.
                     if !boarding_output.can_be_claimed_unilaterally_by_owner(
-                        now.as_duration().try_into().map_err(Error::ad_hoc)?,
+                        std::time::Duration::from_secs(now_secs as u64),
                         std::time::Duration::from_secs(*confirmation_blocktime),
                         *confirmations,
                     ) {
@@ -1068,7 +1066,7 @@ where
         }
 
         let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
-        let now = Timestamp::now().as_second();
+        let now = super::unix_now();
         let dust = self.server_info.dust;
 
         // Exclude VTXOs under a past-cutoff deprecated signer that still require a forfeit.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1057,13 +1057,33 @@ where
         }
 
         let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
+        let now = Timestamp::now().as_second();
+        let dust = self.server_info.dust;
+
+        // Exclude VTXOs under a past-cutoff deprecated signer that still require a forfeit.
+        // The operator won't co-sign the forfeit for the old key, which would brick the whole
+        // batch intent. They wait until expiry (is_recoverable) before joining a batch.
+        let is_excluded = |v: &&ark_core::server::VirtualTxOutPoint| -> bool {
+            if v.is_recoverable(dust) {
+                return false; // recoverable = no forfeit needed, always safe to include
+            }
+            script_pubkey_to_vtxo_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    self.server_info
+                        .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                })
+                .unwrap_or(false)
+        };
 
         total_amount += vtxo_list
             .all_unspent()
+            .filter(|v| !is_excluded(v))
             .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.amount);
 
         let vtxo_inputs = vtxo_list
             .all_unspent()
+            .filter(|v| !is_excluded(v))
             .map(|virtual_tx_outpoint| {
                 let vtxo = script_pubkey_to_vtxo_map
                     .get(&virtual_tx_outpoint.script)

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1036,6 +1036,17 @@ where
                         continue;
                     }
 
+                    // Skip boarding outputs whose server key is past its cooperative-sign
+                    // cutoff — the operator won't co-sign the old key's forfeit path.
+                    // These must be recovered via unilateral exit (send_on_chain).
+                    let now_secs = now.as_second();
+                    if self
+                        .server_info
+                        .is_signer_past_cutoff_at(boarding_output.server_pk(), now_secs)
+                    {
+                        continue;
+                    }
+
                     // Only include confirmed boarding outputs with an _inactive_ exit path.
                     if !boarding_output.can_be_claimed_unilaterally_by_owner(
                         now.as_duration().try_into().map_err(Error::ad_hoc)?,

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -62,11 +62,18 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
+        self.settle_at(super::unix_now(), rng).await
+    }
+
+    pub(crate) async fn settle_at<R>(&self, now: i64, rng: &mut R) -> Result<Option<Txid>, Error>
+    where
+        R: Rng + CryptoRng + Clone,
+    {
         // Get off-chain address and send all funds to this address, no change output 🦄
         let (to_address, _) = self.get_offchain_address()?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+            self.fetch_commitment_transaction_inputs(now).await?;
 
         tracing::debug!(
             offchain_adress = %to_address.encode(),
@@ -124,8 +131,9 @@ where
     {
         let (to_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, mut total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, mut total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         // Convert arknotes to intent inputs and add their value to total
         let note_inputs: Vec<intent::Input> = notes
@@ -198,8 +206,9 @@ where
         // Get off-chain address and send all funds to this address, no change output.
         let (to_address, _) = self.get_offchain_address()?;
 
-        let (all_boarding_inputs, all_vtxo_inputs, _) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (all_boarding_inputs, all_vtxo_inputs, _) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         // Filter boarding inputs to only those specified.
         let boarding_inputs: Vec<_> = all_boarding_inputs
@@ -274,8 +283,9 @@ where
     {
         let (change_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let onchain_fee = self
             .fee_estimator
@@ -470,7 +480,9 @@ where
         let (to_address, _) = self.get_offchain_address()?;
 
         // Simply collect all VTXOs that can be settled.
-        let (_, vtxo_inputs, _) = self.fetch_commitment_transaction_inputs().await?;
+        let (_, vtxo_inputs, _) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let total_amount = vtxo_inputs
             .iter()
@@ -1000,6 +1012,7 @@ where
     /// upcoming batch.
     pub(crate) async fn fetch_commitment_transaction_inputs(
         &self,
+        now: i64,
     ) -> Result<(Vec<batch::OnChainInput>, Vec<intent::Input>, Amount), Error> {
         // Get all known boarding outputs.
         let boarding_outputs = self.inner.wallet.get_boarding_outputs()?;
@@ -1010,7 +1023,7 @@ where
         // To track unique outpoints and prevent duplicates
         let mut seen_outpoints = std::collections::HashSet::new();
 
-        let now_secs = super::unix_now();
+        let now_secs = now;
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -3206,18 +3206,12 @@ where
         mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
         expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        let network = self.server_info.network;
-        for server_key in self.server_info.all_server_keys() {
-            let opts = mk_opts(server_key)?;
-            let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
-            if &vhtlc.address() == expected_address {
-                return Ok(vhtlc);
-            }
-        }
-        Err(Error::ad_hoc(format!(
-            "VHTLC script could not be reconstructed for address {expected_address}: \
-             does not match current or any deprecated server key"
-        )))
+        reconstruct_vhtlc_from_keys(
+            self.server_info.all_server_keys(),
+            self.server_info.network,
+            mk_opts,
+            expected_address,
+        )
     }
 
     /// Reconstruct a [`VhtlcScript`] from swap data fields, trying current + deprecated signers.
@@ -4234,6 +4228,30 @@ struct ChainSwapSideDetails {
     bip21: Option<String>,
 }
 
+/// Iterate `server_keys` in order, building a [`VhtlcScript`] for each one, and return the
+/// first whose address matches `expected_address`.
+///
+/// Extracted from [`Client::reconstruct_vhtlc_for_address`] so the key-iteration logic can be
+/// tested without a full [`Client`] instance.
+pub(crate) fn reconstruct_vhtlc_from_keys(
+    server_keys: impl Iterator<Item = XOnlyPublicKey>,
+    network: bitcoin::Network,
+    mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
+    expected_address: &ArkAddress,
+) -> Result<VhtlcScript, Error> {
+    for server_key in server_keys {
+        let opts = mk_opts(server_key)?;
+        let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
+        if &vhtlc.address() == expected_address {
+            return Ok(vhtlc);
+        }
+    }
+    Err(Error::ad_hoc(format!(
+        "VHTLC script could not be reconstructed for address {expected_address}: \
+         does not match current or any deprecated server key"
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4500,5 +4518,171 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("640"), "unexpected error message: {msg}");
         assert!(msg.contains("639"), "unexpected error message: {msg}");
+    }
+
+    // ── reconstruct_vhtlc_from_keys ─────────────────────────────────────────
+
+    /// Build a [`VhtlcOptions`] from the first fixture in vhtlc.json (CSV > 16).
+    /// Keys and expected address are taken verbatim from the JSON fixture so the test
+    /// is independent of any client-side logic.
+    fn fixture_opts(server: XOnlyPublicKey) -> VhtlcOptions {
+        let sender = XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+            )
+            .unwrap()
+            .inner,
+        );
+        let receiver = XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+            )
+            .unwrap()
+            .inner,
+        );
+        VhtlcOptions {
+            sender,
+            receiver,
+            server,
+            preimage_hash: ripemd160::Hash::from_str("4d487dd3753a89bc9fe98401d1196523058251fc")
+                .unwrap(),
+            refund_locktime: 265,
+            unilateral_claim_delay: bitcoin::Sequence::from_height(17),
+            unilateral_refund_delay: bitcoin::Sequence::from_height(144),
+            unilateral_refund_without_receiver_delay: bitcoin::Sequence::from_height(144),
+        }
+    }
+
+    fn fixture_server_xonly() -> XOnlyPublicKey {
+        XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+            )
+            .unwrap()
+            .inner,
+        )
+    }
+
+    // Expected Ark address from the fixture (vhtlc.json CSV > 16 case, testnet).
+    const FIXTURE_ADDRESS: &str = "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63";
+
+    // A second server key that produces a different address for the same other params.
+    fn wrong_server_xonly() -> XOnlyPublicKey {
+        XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "0206988651c7fbe41747bb21b54ced0a183f4d658e007ee8fdb23fbbfccb8e0c55",
+            )
+            .unwrap()
+            .inner,
+        )
+    }
+
+    #[test]
+    fn reconstruct_matches_with_single_current_key() {
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let vhtlc = reconstruct_vhtlc_from_keys(
+            std::iter::once(server),
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .unwrap();
+
+        assert_eq!(vhtlc.address(), expected);
+    }
+
+    #[test]
+    fn reconstruct_skips_wrong_key_and_finds_deprecated() {
+        let wrong = wrong_server_xonly();
+        let correct = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        // Iterator: wrong key first, correct key second (simulates signer rotation).
+        let keys = [wrong, correct].into_iter();
+        let vhtlc = reconstruct_vhtlc_from_keys(
+            keys,
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .unwrap();
+
+        assert_eq!(vhtlc.address(), expected);
+    }
+
+    #[test]
+    fn reconstruct_errors_when_no_key_matches() {
+        let wrong = wrong_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let err = reconstruct_vhtlc_from_keys(
+            std::iter::once(wrong),
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .err()
+        .expect("should have failed");
+
+        assert!(
+            err.to_string()
+                .contains("does not match current or any deprecated server key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reconstruct_propagates_mk_opts_error() {
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let err = reconstruct_vhtlc_from_keys(
+            std::iter::once(server),
+            bitcoin::Network::Testnet,
+            |_| Err(Error::ad_hoc("options error")),
+            &expected,
+        )
+        .err()
+        .expect("should have failed");
+
+        assert!(
+            err.to_string().contains("options error"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn build_vhtlc_script_sender_is_refund_receiver_is_claim() {
+        // Verify the key-role mapping: build_vhtlc_script(claim, refund, ...) must produce the
+        // same address as a manually-constructed VhtlcOptions{sender=refund, receiver=claim}.
+        let claim_pk = PublicKey::from_str(
+            "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+        )
+        .unwrap();
+        let refund_pk = PublicKey::from_str(
+            "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+        )
+        .unwrap();
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let opts = VhtlcOptions {
+            sender: refund_pk.inner.x_only_public_key().0,
+            receiver: claim_pk.inner.x_only_public_key().0,
+            server,
+            preimage_hash: ripemd160::Hash::from_str("4d487dd3753a89bc9fe98401d1196523058251fc")
+                .unwrap(),
+            refund_locktime: 265,
+            unilateral_claim_delay: bitcoin::Sequence::from_height(17),
+            unilateral_refund_delay: bitcoin::Sequence::from_height(144),
+            unilateral_refund_without_receiver_delay: bitcoin::Sequence::from_height(144),
+        };
+        let manual_vhtlc =
+            VhtlcScript::new(opts, bitcoin::Network::Testnet).expect("valid options");
+
+        // The manual construction produces the expected fixture address.
+        assert_eq!(manual_vhtlc.address(), expected);
     }
 }

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -541,39 +541,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -709,39 +707,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -824,39 +820,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -1431,40 +1425,37 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
+            &swap.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap.vhtlc_address
-            )));
-        }
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
@@ -1681,40 +1672,37 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
+            &swap.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap.vhtlc_address
-            )));
-        }
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
@@ -2102,42 +2090,40 @@ where
             ))
         })?;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.server_refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
-        let vhtlc_address = vhtlc.address();
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
-        if vhtlc_address != expected_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match server lockup address ({expected_address})"
-            )));
-        }
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.server_refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
+            },
+            &expected_address,
+        )?;
+        let vhtlc_address = vhtlc.address();
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -2463,41 +2449,40 @@ where
         let preimage_hash = ripemd160::Hash::hash(swap.preimage_hash.as_byte_array());
 
         // User's lockup VHTLC: sender=user(refund), receiver=server(claim)
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.server_claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
-        let vhtlc_address = vhtlc.address();
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
-        if vhtlc_address != expected_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match user lockup address ({expected_address})"
-            )));
-        }
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.server_claim_public_key.into(),
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
+            },
+            &expected_address,
+        )?;
+        let vhtlc_address = vhtlc.address();
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -3382,39 +3367,67 @@ where
 
     // Private helpers for pending VHTLC recovery.
 
-    /// Reconstruct a [`VhtlcScript`] from swap data fields.
+    /// Try to reconstruct a [`VhtlcScript`] that matches `expected_address` by trying the current
+    /// server signer and all deprecated signers in order. Returns the first match.
+    ///
+    /// This handles the case where the server rotated its signing key after a swap was created:
+    /// the VHTLC was built with the old key, so we must try deprecated keys to find the right one.
+    fn reconstruct_vhtlc_for_address(
+        &self,
+        mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
+        expected_address: &ArkAddress,
+    ) -> Result<VhtlcScript, Error> {
+        let network = self.server_info.network;
+        for server_key in self.server_info.all_server_keys() {
+            let opts = mk_opts(server_key)?;
+            let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
+            if &vhtlc.address() == expected_address {
+                return Ok(vhtlc);
+            }
+        }
+        Err(Error::ad_hoc(format!(
+            "VHTLC script could not be reconstructed for address {expected_address}: \
+             does not match current or any deprecated server key"
+        )))
+    }
+
+    /// Reconstruct a [`VhtlcScript`] from swap data fields, trying current + deprecated signers.
     fn build_vhtlc_script(
         &self,
         claim_public_key: PublicKey,
         refund_public_key: PublicKey,
         preimage_hash: ripemd160::Hash,
         timeout_block_heights: &TimeoutBlockHeights,
+        expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        VhtlcScript::new(
-            VhtlcOptions {
-                sender: refund_public_key.inner.x_only_public_key().0,
-                receiver: claim_public_key.inner.x_only_public_key().0,
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
+        let unilateral_claim_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_claim as i64,
         )
-        .map_err(Error::ad_hoc)
+        .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_refund as i64,
+        )
+        .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_refund_without_receiver as i64,
+        )
+        .map_err(|e| Error::ad_hoc(format!("invalid refund without receiver timeout: {e}")))?;
+
+        self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: refund_public_key.inner.x_only_public_key().0,
+                    receiver: claim_public_key.inner.x_only_public_key().0,
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
+                })
+            },
+            expected_address,
+        )
     }
 
     /// Collect info about all active (non-terminal) VHTLCs from swap storage.
@@ -3499,15 +3512,8 @@ where
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
+                &swap.vhtlc_address,
             )?;
-
-            if vhtlc.address() != swap.vhtlc_address {
-                tracing::warn!(
-                    swap_id = swap.id,
-                    "VHTLC address mismatch for submarine swap, skipping"
-                );
-                continue;
-            }
 
             // For submarine swaps, the user is the sender (refund key).
             // Use refund_without_receiver_script as the intent proof — it only requires
@@ -3549,15 +3555,8 @@ where
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
+                &swap.vhtlc_address,
             )?;
-
-            if vhtlc.address() != swap.vhtlc_address {
-                tracing::warn!(
-                    swap_id = swap.id,
-                    "VHTLC address mismatch for reverse swap, skipping"
-                );
-                continue;
-            }
 
             // For reverse swaps, the user is the receiver (claim key).
             // Use claim_script as the intent proof — we need to sign with the receiver key.

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -552,9 +552,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -718,9 +716,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -831,9 +827,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -1436,9 +1430,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -1683,9 +1675,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -2104,9 +2094,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -2463,9 +2451,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -3400,18 +3386,17 @@ where
         timeout_block_heights: &TimeoutBlockHeights,
         expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        let unilateral_claim_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_claim as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_refund as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_refund_without_receiver as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid refund without receiver timeout: {e}")))?;
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
 
         self.reconstruct_vhtlc_for_address(
             |server| {
@@ -3507,13 +3492,23 @@ where
                 continue;
             }
 
-            let vhtlc = self.build_vhtlc_script(
+            let vhtlc = match self.build_vhtlc_script(
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
                 &swap.vhtlc_address,
-            )?;
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        swap_id = swap.id,
+                        error = %e,
+                        "VHTLC reconstruction failed for submarine swap, skipping"
+                    );
+                    continue;
+                }
+            };
 
             // For submarine swaps, the user is the sender (refund key).
             // Use refund_without_receiver_script as the intent proof — it only requires
@@ -3550,13 +3545,23 @@ where
                 continue;
             }
 
-            let vhtlc = self.build_vhtlc_script(
+            let vhtlc = match self.build_vhtlc_script(
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
                 &swap.vhtlc_address,
-            )?;
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        swap_id = swap.id,
+                        error = %e,
+                        "VHTLC reconstruction failed for reverse swap, skipping"
+                    );
+                    continue;
+                }
+            };
 
             // For reverse swaps, the user is the receiver (claim key).
             // Use claim_script as the intent proof — we need to sign with the receiver key.

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -541,6 +541,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -549,22 +561,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -705,6 +704,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -713,22 +724,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -816,6 +814,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -824,22 +834,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -1419,6 +1416,18 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -1427,22 +1436,9 @@ where
                     server,
                     preimage_hash: swap.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap.vhtlc_address,
@@ -1664,6 +1660,18 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -1672,22 +1680,9 @@ where
                     server,
                     preimage_hash: swap.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap.vhtlc_address,
@@ -2083,6 +2078,18 @@ where
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -2091,22 +2098,9 @@ where
                     server,
                     preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &expected_address,
@@ -2440,6 +2434,18 @@ where
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -2448,22 +2454,9 @@ where
                     server,
                     preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &expected_address,

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -539,33 +539,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -702,33 +680,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -766,10 +722,10 @@ where
 
         let vhtlc_input = intent::Input::new(
             vhtlc_outpoint.outpoint,
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+            parse_sequence_number(swap_data.timeout_block_heights.unilateral_refund as i64)
                 .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
             Some(absolute::LockTime::from_consensus(
-                timeout_block_heights.refund,
+                swap_data.timeout_block_heights.refund,
             )),
             TxOut {
                 value: refund_amount,
@@ -812,33 +768,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -1414,33 +1348,11 @@ where
 
         tracing::debug!(swap_id, "Claiming VHTLC with verified preimage");
 
-        let timeout_block_heights = swap.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.refund_public_key,
+            swap.preimage_hash,
+            &swap.timeout_block_heights,
             &swap.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -1658,33 +1570,11 @@ where
 
         tracing::debug!("Ark transaction for swap found");
 
-        let timeout_block_heights = swap.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.refund_public_key,
+            swap.preimage_hash,
+            &swap.timeout_block_heights,
             &swap.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -2078,31 +1968,11 @@ where
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.server_refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.server_refund_public_key,
+            preimage_hash,
+            &timeout_block_heights,
             &expected_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -2434,31 +2304,11 @@ where
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.server_claim_public_key.into(),
-                    server,
-                    preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.server_claim_public_key,
+            swap.refund_public_key,
+            preimage_hash,
+            &timeout_block_heights,
             &expected_address,
         )?;
         let vhtlc_address = vhtlc.address();

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -58,8 +58,9 @@ where
     {
         let (change_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let change_amount = total_amount.checked_sub(to_amount).ok_or_else(|| {
             Error::coin_select(format!(
@@ -126,8 +127,9 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         tracing::info!(
             %to_address,

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1142,12 +1142,17 @@ where
             })
         };
 
-        let migratable_vtxos = vtxo_list.spendable_offchain().any(|v| {
-            script_map
-                .get(&v.script)
-                .map(|vtxo| is_pre_cutoff_deprecated(vtxo.server_pk()))
-                .unwrap_or(false)
-        });
+        // Collect outpoints of VTXOs under pre-cutoff deprecated signers.
+        let deprecated_vtxo_outpoints: HashSet<OutPoint> = vtxo_list
+            .spendable_offchain()
+            .filter(|v| {
+                script_map
+                    .get(&v.script)
+                    .map(|vtxo| is_pre_cutoff_deprecated(vtxo.server_pk()))
+                    .unwrap_or(false)
+            })
+            .map(|v| v.outpoint)
+            .collect();
 
         let migratable_boarding = self
             .inner
@@ -1156,21 +1161,53 @@ where
             .into_iter()
             .any(|bo| is_pre_cutoff_deprecated(bo.server_pk()));
 
-        if !migratable_vtxos && !migratable_boarding {
+        if deprecated_vtxo_outpoints.is_empty() && !migratable_boarding {
             tracing::debug!("No migratable deprecated-signer VTXOs or boarding outputs found");
             return Ok(None);
         }
 
         tracing::info!(
-            migratable_vtxos,
+            migratable_vtxos = deprecated_vtxo_outpoints.len(),
             migratable_boarding,
             "Found pre-cutoff deprecated-signer outputs; settling to current signer"
         );
 
-        // settle_at(now) uses the same timestamp as the pre-check above, so a VTXO that
-        // passes the migration gate cannot be silently excluded by a clock tick between
-        // the two evaluations.
-        self.settle_at(now, rng).await
+        let (to_address, _) = self.get_offchain_address()?;
+
+        // fetch_commitment_transaction_inputs uses the same `now` snapshot as the pre-check
+        // above (TOCTOU fix) and already excludes past-cutoff VTXOs.
+        let (boarding_inputs, vtxo_inputs, _) =
+            self.fetch_commitment_transaction_inputs(now).await?;
+
+        // Keep only deprecated-signer inputs — leave current-signer VTXOs untouched.
+        let boarding_inputs: Vec<_> = boarding_inputs
+            .into_iter()
+            .filter(|i| is_pre_cutoff_deprecated(i.boarding_output().server_pk()))
+            .collect();
+        let vtxo_inputs: Vec<_> = vtxo_inputs
+            .into_iter()
+            .filter(|i| deprecated_vtxo_outpoints.contains(&i.outpoint()))
+            .collect();
+
+        let total_amount = boarding_inputs.iter().map(|i| i.amount()).sum::<Amount>()
+            + vtxo_inputs.iter().map(|i| i.amount()).sum::<Amount>();
+
+        if boarding_inputs.is_empty() && vtxo_inputs.is_empty() {
+            tracing::debug!("All deprecated-signer outputs were excluded (past cutoff)");
+            return Ok(None);
+        }
+
+        self.join_next_batch(
+            rng,
+            boarding_inputs,
+            vtxo_inputs,
+            batch::BatchOutputType::Board {
+                to_address,
+                to_amount: total_amount,
+            },
+        )
+        .await
+        .map(Some)
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1087,7 +1087,10 @@ where
 
         // Aggregate asset balances from spendable (non-past-cutoff) VTXOs only.
         let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
-        for vtxo in vtxo_list.spendable_offchain().filter(|v| !is_past_cutoff(v)) {
+        for vtxo in vtxo_list
+            .spendable_offchain()
+            .filter(|v| !is_past_cutoff(v))
+        {
             for asset in &vtxo.assets {
                 let total = asset_balances
                     .get(&asset.asset_id)

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1167,9 +1167,10 @@ where
             "Found pre-cutoff deprecated-signer outputs; settling to current signer"
         );
 
-        // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)
-        // and fetch_commitment_transaction_inputs() filters out past-cutoff ones automatically.
-        self.settle(rng).await
+        // settle_at(now) uses the same timestamp as the pre-check above, so a VTXO that
+        // passes the migration gate cannot be silently excluded by a clock tick between
+        // the two evaluations.
+        self.settle_at(now, rng).await
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -825,7 +825,9 @@ where
         }
 
         let server_info = &self.server_info;
-        let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
+        // Discover against current + all deprecated signers so that user keys used before a
+        // rotation are still found when recovering from seed.
+        let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
 
         let mut start_index = 0u32;
         let mut discovered_count = 0u32;
@@ -849,30 +851,31 @@ where
 
                 let owner_pk = kp.x_only_public_key().0;
 
-                let mut addresses =
-                    Vec::with_capacity(1 + self.inner.historical_delegator_pks.len());
+                let mut addresses = Vec::new();
 
-                // Default (2-leaf) address.
-                let default_vtxo = Vtxo::new_default(
-                    self.secp(),
-                    server_signer,
-                    owner_pk,
-                    server_info.unilateral_exit_delay,
-                    server_info.network,
-                )?;
-                addresses.push(default_vtxo.to_ark_address());
-
-                // Delegate (3-leaf) addresses for each known delegator.
-                for dpk in &self.inner.historical_delegator_pks {
-                    let delegate_vtxo = Vtxo::new_with_delegator(
+                for server_signer in &all_server_keys {
+                    // Default (2-leaf) address.
+                    let default_vtxo = Vtxo::new_default(
                         self.secp(),
-                        server_signer,
+                        *server_signer,
                         owner_pk,
-                        *dpk,
                         server_info.unilateral_exit_delay,
                         server_info.network,
                     )?;
-                    addresses.push(delegate_vtxo.to_ark_address());
+                    addresses.push(default_vtxo.to_ark_address());
+
+                    // Delegate (3-leaf) addresses for each known delegator.
+                    for dpk in &self.inner.historical_delegator_pks {
+                        let delegate_vtxo = Vtxo::new_with_delegator(
+                            self.secp(),
+                            *server_signer,
+                            owner_pk,
+                            *dpk,
+                            server_info.unilateral_exit_delay,
+                            server_info.network,
+                        )?;
+                        addresses.push(delegate_vtxo.to_ark_address());
+                    }
                 }
 
                 batch.push((index, kp, addresses));

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1114,10 +1114,11 @@ where
     /// Sweep VTXOs and boarding outputs under deprecated server signers (before their cutoff)
     /// to the current signer.
     ///
-    /// This joins the next available batch and settles all inputs — current-signer and
-    /// pre-cutoff deprecated-signer alike — to a fresh current-signer address. Past-cutoff
-    /// VTXOs and boarding outputs are excluded from the batch automatically (the operator
-    /// won't co-sign the old key) and will become recoverable after expiry.
+    /// Internally this calls [`Self::settle`], which settles **all** unspent VTXOs and boarding
+    /// outputs in a single batch — not just the deprecated-signer ones. Current-signer VTXOs are
+    /// included too, which consolidates the wallet but does incur settlement fees on outputs that
+    /// would otherwise not need to move. Past-cutoff VTXOs and boarding outputs are excluded
+    /// automatically (the operator won't co-sign the old key) and become recoverable after expiry.
     ///
     /// Returns `None` when there are no migratable VTXOs or boarding outputs (nothing to do).
     pub async fn migrate_deprecated_signer_vtxos<R>(

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1108,14 +1108,15 @@ where
         })
     }
 
-    /// Sweep VTXOs under deprecated server signers (before their cutoff) to the current signer.
+    /// Sweep VTXOs and boarding outputs under deprecated server signers (before their cutoff)
+    /// to the current signer.
     ///
-    /// This joins the next available batch and settles all VTXOs — current-signer and
-    /// deprecated-signer alike — to a fresh current-signer address. Only before-cutoff
-    /// deprecated VTXOs are truly "migrated"; past-cutoff ones are excluded from the batch
-    /// automatically (they cannot be co-signed) and will become recoverable after expiry.
+    /// This joins the next available batch and settles all inputs — current-signer and
+    /// pre-cutoff deprecated-signer alike — to a fresh current-signer address. Past-cutoff
+    /// VTXOs and boarding outputs are excluded from the batch automatically (the operator
+    /// won't co-sign the old key) and will become recoverable after expiry.
     ///
-    /// Returns `None` when there are no migratable VTXOs (nothing to do).
+    /// Returns `None` when there are no migratable VTXOs or boarding outputs (nothing to do).
     pub async fn migrate_deprecated_signer_vtxos<R>(
         &self,
         rng: &mut R,
@@ -1130,26 +1131,36 @@ where
         let now = unix_now();
         let (vtxo_list, script_map) = self.list_vtxos().await?;
 
-        let migratable = vtxo_list.spendable_offchain().any(|v| {
+        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| {
+            self.server_info.deprecated_signers.iter().any(|ds| {
+                ds.pk.x_only_public_key().0 == server_pk
+                    && (ds.cutoff_date == 0 || ds.cutoff_date > now)
+            })
+        };
+
+        let migratable_vtxos = vtxo_list.spendable_offchain().any(|v| {
             script_map
                 .get(&v.script)
-                .map(|vtxo| {
-                    let server_pk = vtxo.server_pk();
-                    self.server_info.deprecated_signers.iter().any(|ds| {
-                        let ds_pk: XOnlyPublicKey = ds.pk.x_only_public_key().0;
-                        ds_pk == server_pk && (ds.cutoff_date == 0 || ds.cutoff_date > now)
-                    })
-                })
+                .map(|vtxo| is_pre_cutoff_deprecated(vtxo.server_pk()))
                 .unwrap_or(false)
         });
 
-        if !migratable {
-            tracing::debug!("No migratable deprecated-signer VTXOs found");
+        let migratable_boarding = self
+            .inner
+            .wallet
+            .get_boarding_outputs()?
+            .into_iter()
+            .any(|bo| is_pre_cutoff_deprecated(bo.server_pk()));
+
+        if !migratable_vtxos && !migratable_boarding {
+            tracing::debug!("No migratable deprecated-signer VTXOs or boarding outputs found");
             return Ok(None);
         }
 
         tracing::info!(
-            "Found VTXOs under pre-cutoff deprecated signers; settling to current signer"
+            migratable_vtxos,
+            migratable_boarding,
+            "Found pre-cutoff deprecated-signer outputs; settling to current signer"
         );
 
         // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -336,6 +336,10 @@ pub struct OffChainBalance {
     pre_confirmed: Amount,
     confirmed: Amount,
     recoverable: Amount,
+    /// Funds under a deprecated server signer whose cooperative-sign cutoff has passed.
+    /// These VTXOs cannot be spent offchain (operator won't co-sign the old key) and are not yet
+    /// recoverable (not expired). They will become recoverable once their VTXO expiry passes.
+    pending_recovery: Amount,
     asset_balances: HashMap<AssetId, u64>,
 }
 
@@ -353,8 +357,14 @@ impl OffChainBalance {
         self.recoverable
     }
 
+    /// Funds locked under a deprecated signer past its cutoff — cannot be spent offchain,
+    /// waiting for VTXO expiry to become recoverable. Still counted in `total()`.
+    pub fn pending_recovery(&self) -> Amount {
+        self.pending_recovery
+    }
+
     pub fn total(&self) -> Amount {
-        self.pre_confirmed + self.confirmed + self.recoverable
+        self.pre_confirmed + self.confirmed + self.recoverable + self.pending_recovery
     }
 
     /// Asset balances keyed by asset ID.
@@ -390,6 +400,22 @@ pub trait Blockchain {
         &self,
         txs: &[&Transaction],
     ) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
+/// Current time as unix seconds. Uses `js_sys::Date` on wasm32, `std::time` elsewhere.
+fn unix_now() -> i64 {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("valid duration")
+            .as_secs() as i64
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        (js_sys::Date::now() / 1000.0) as i64
+    }
 }
 
 impl<B, W, S, K> OfflineClient<B, W, S, K>
@@ -711,38 +737,42 @@ where
     /// [`OfflineClient::new`], addresses for those are included too.
     pub fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
         let server_info = &self.server_info;
-        let server_signer = server_info.signer_pk.into();
-
         let pks = self.inner.key_provider.get_cached_pks()?;
+
+        // Build addresses for current signer + all deprecated signers so VTXOs under any
+        // known server key are discovered and visible in the balance.
+        let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
 
         let mut results = Vec::new();
 
         for owner_pk in &pks {
-            // Always include the default (2-leaf) address.
-            let default_vtxo = Vtxo::new_default(
-                self.secp(),
-                server_signer,
-                *owner_pk,
-                server_info.unilateral_exit_delay,
-                server_info.network,
-            )?;
-            results.push((default_vtxo.to_ark_address(), default_vtxo));
-
-            // Include delegate addresses for all known delegator keys.
-            let mut seen = HashSet::new();
-            for dpk in &self.inner.historical_delegator_pks {
-                if !seen.insert(dpk) {
-                    continue;
-                }
-                let delegate_vtxo = Vtxo::new_with_delegator(
+            for server_signer in &all_server_keys {
+                // Default (2-leaf) address.
+                let default_vtxo = Vtxo::new_default(
                     self.secp(),
-                    server_signer,
+                    *server_signer,
                     *owner_pk,
-                    *dpk,
                     server_info.unilateral_exit_delay,
                     server_info.network,
                 )?;
-                results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                results.push((default_vtxo.to_ark_address(), default_vtxo));
+
+                // Delegate addresses for all known delegator keys.
+                let mut seen = HashSet::new();
+                for dpk in &self.inner.historical_delegator_pks {
+                    if !seen.insert(dpk) {
+                        continue;
+                    }
+                    let delegate_vtxo = Vtxo::new_with_delegator(
+                        self.secp(),
+                        *server_signer,
+                        *owner_pk,
+                        *dpk,
+                        server_info.unilateral_exit_delay,
+                        server_info.network,
+                    )?;
+                    results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                }
             }
         }
 
@@ -910,9 +940,25 @@ where
     }
 
     pub fn get_boarding_addresses(&self) -> Result<Vec<Address>, Error> {
-        let address = self.get_boarding_address()?;
+        let server_info = &self.server_info;
+        let mut addresses = Vec::new();
 
-        Ok(vec![address])
+        // Current signer boarding address.
+        addresses.push(self.get_boarding_address()?);
+
+        // Deprecated signer boarding addresses — for watch/history only.
+        // The spend path (settle) deliberately stays current-signer-only;
+        // deprecated-signer boarding recovery is handled via migrate_deprecated_signer_vtxos().
+        for ds in &server_info.deprecated_signers {
+            let boarding_output = self.inner.wallet.new_boarding_output(
+                ds.pk.x_only_public_key().0,
+                server_info.boarding_exit_delay,
+                server_info.network,
+            )?;
+            addresses.push(boarding_output.address().clone());
+        }
+
+        Ok(addresses)
     }
 
     pub async fn get_virtual_tx_outpoints(
@@ -1002,23 +1048,43 @@ where
     }
 
     pub async fn offchain_balance(&self) -> Result<OffChainBalance, Error> {
-        let (vtxo_list, _) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let (vtxo_list, script_map) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let now = unix_now();
+
+        let is_past_cutoff = |v: &VirtualTxOutPoint| {
+            script_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    self.server_info
+                        .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                })
+                .unwrap_or(false)
+        };
 
         let pre_confirmed = vtxo_list
             .pre_confirmed()
+            .filter(|v| !is_past_cutoff(v))
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
         let confirmed = vtxo_list
             .confirmed()
+            .filter(|v| !is_past_cutoff(v))
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
         let recoverable = vtxo_list
             .recoverable()
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
-        // Aggregate asset balances from all spendable VTXOs.
+        // Spendable offchain VTXOs under a past-cutoff deprecated signer: operator won't
+        // co-sign, so they're stuck until the VTXO expires and becomes recoverable.
+        let pending_recovery = vtxo_list
+            .spendable_offchain()
+            .filter(|v| is_past_cutoff(v))
+            .fold(Amount::ZERO, |acc, x| acc + x.amount);
+
+        // Aggregate asset balances from spendable (non-past-cutoff) VTXOs only.
         let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
-        for vtxo in vtxo_list.spendable_offchain() {
+        for vtxo in vtxo_list.spendable_offchain().filter(|v| !is_past_cutoff(v)) {
             for asset in &vtxo.assets {
                 let total = asset_balances
                     .get(&asset.asset_id)
@@ -1034,8 +1100,58 @@ where
             pre_confirmed,
             confirmed,
             recoverable,
+            pending_recovery,
             asset_balances,
         })
+    }
+
+    /// Sweep VTXOs under deprecated server signers (before their cutoff) to the current signer.
+    ///
+    /// This joins the next available batch and settles all VTXOs — current-signer and
+    /// deprecated-signer alike — to a fresh current-signer address. Only before-cutoff
+    /// deprecated VTXOs are truly "migrated"; past-cutoff ones are excluded from the batch
+    /// automatically (they cannot be co-signed) and will become recoverable after expiry.
+    ///
+    /// Returns `None` when there are no migratable VTXOs (nothing to do).
+    pub async fn migrate_deprecated_signer_vtxos<R>(
+        &self,
+        rng: &mut R,
+    ) -> Result<Option<Txid>, Error>
+    where
+        R: rand::Rng + rand::CryptoRng + Clone,
+    {
+        if self.server_info.deprecated_signers.is_empty() {
+            return Ok(None);
+        }
+
+        let now = unix_now();
+        let (vtxo_list, script_map) = self.list_vtxos().await?;
+
+        let migratable = vtxo_list.spendable_offchain().any(|v| {
+            script_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    let server_pk = vtxo.server_pk();
+                    self.server_info.deprecated_signers.iter().any(|ds| {
+                        let ds_pk: XOnlyPublicKey = ds.pk.x_only_public_key().0;
+                        ds_pk == server_pk && (ds.cutoff_date == 0 || ds.cutoff_date > now)
+                    })
+                })
+                .unwrap_or(false)
+        });
+
+        if !migratable {
+            tracing::debug!("No migratable deprecated-signer VTXOs found");
+            return Ok(None);
+        }
+
+        tracing::info!(
+            "Found VTXOs under pre-cutoff deprecated signers; settling to current signer"
+        );
+
+        // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)
+        // and fetch_commitment_transaction_inputs() filters out past-cutoff ones automatically.
+        self.settle(rng).await
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -238,8 +238,19 @@ where
             .await
             .context("failed to get spendable VTXOs")?;
 
+        let now = crate::unix_now();
         let spendable = vtxo_list
             .spendable_offchain()
+            // Exclude VTXOs under a past-cutoff deprecated signer: operator won't co-sign.
+            .filter(|v| {
+                !script_pubkey_to_vtxo_map
+                    .get(&v.script)
+                    .map(|vtxo| {
+                        self.server_info
+                            .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                    })
+                    .unwrap_or(false)
+            })
             .map(|vtxo| VirtualTxOutPoint {
                 outpoint: vtxo.outpoint,
                 script_pubkey: vtxo.script.clone(),

--- a/ark-core/src/boarding_output.rs
+++ b/ark-core/src/boarding_output.rs
@@ -81,6 +81,10 @@ impl BoardingOutput {
         self.owner
     }
 
+    pub fn server_pk(&self) -> XOnlyPublicKey {
+        self.server
+    }
+
     pub fn script_pubkey(&self) -> ScriptBuf {
         self.address.script_pubkey()
     }

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -484,6 +484,25 @@ pub struct DeprecatedSigner {
     pub cutoff_date: i64,
 }
 
+impl Info {
+    /// Returns all known server signing keys: the current signer followed by all deprecated ones.
+    pub fn all_server_keys(&self) -> impl Iterator<Item = XOnlyPublicKey> + '_ {
+        std::iter::once(self.signer_pk.x_only_public_key().0)
+            .chain(self.deprecated_signers.iter().map(|ds| ds.pk.x_only_public_key().0))
+    }
+
+    /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has
+    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "no cutoff" and is never
+    /// treated as past.
+    pub fn is_signer_past_cutoff_at(&self, server_pk: XOnlyPublicKey, now_unix_secs: i64) -> bool {
+        self.deprecated_signers.iter().any(|ds| {
+            ds.cutoff_date != 0
+                && ds.cutoff_date <= now_unix_secs
+                && ds.pk.x_only_public_key().0 == server_pk
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StreamStartedEvent {
     pub id: String,

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -799,3 +799,137 @@ pub fn parse_fee_amount(amount_str: Option<String>) -> Amount {
         .map(Amount::from_sat)
         .unwrap_or(Amount::ZERO)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::address::NetworkUnchecked;
+    use bitcoin::secp256k1::PublicKey;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    // Well-known compressed secp256k1 public keys used as test fixtures.
+    const PK_A: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const PK_B: &str = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+    const PK_C: &str = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+    const PK_UNRELATED: &str = "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4";
+
+    fn pk(hex: &str) -> PublicKey {
+        PublicKey::from_str(hex).unwrap()
+    }
+
+    fn xonly(hex: &str) -> XOnlyPublicKey {
+        pk(hex).x_only_public_key().0
+    }
+
+    fn make_info(current_hex: &str, deprecated: Vec<(&str, i64)>) -> Info {
+        let dummy_address: bitcoin::Address<NetworkUnchecked> =
+            "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+                .parse()
+                .unwrap();
+        Info {
+            version: "1".into(),
+            signer_pk: pk(current_hex),
+            forfeit_pk: pk(current_hex),
+            forfeit_address: dummy_address.assume_checked(),
+            checkpoint_tapscript: ScriptBuf::new(),
+            network: bitcoin::Network::Testnet,
+            session_duration: 0,
+            unilateral_exit_delay: bitcoin::Sequence::ZERO,
+            boarding_exit_delay: bitcoin::Sequence::ZERO,
+            utxo_min_amount: None,
+            utxo_max_amount: None,
+            vtxo_min_amount: None,
+            vtxo_max_amount: None,
+            dust: Amount::ZERO,
+            fees: None,
+            scheduled_session: None,
+            deprecated_signers: deprecated
+                .into_iter()
+                .map(|(key, cutoff)| DeprecatedSigner {
+                    pk: pk(key),
+                    cutoff_date: cutoff,
+                })
+                .collect(),
+            service_status: HashMap::new(),
+            digest: String::new(),
+            max_tx_weight: 0,
+            max_op_return_outputs: 0,
+        }
+    }
+
+    // ── all_server_keys ──────────────────────────────────────────────────────
+
+    #[test]
+    fn all_server_keys_no_deprecated() {
+        let info = make_info(PK_A, vec![]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys, vec![xonly(PK_A)]);
+    }
+
+    #[test]
+    fn all_server_keys_includes_deprecated_in_order() {
+        let info = make_info(PK_A, vec![(PK_B, 1000), (PK_C, 2000)]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys, vec![xonly(PK_A), xonly(PK_B), xonly(PK_C)]);
+    }
+
+    #[test]
+    fn all_server_keys_current_is_always_first() {
+        let info = make_info(PK_C, vec![(PK_A, 500), (PK_B, 600)]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys[0], xonly(PK_C));
+    }
+
+    // ── is_signer_past_cutoff_at ─────────────────────────────────────────────
+
+    #[test]
+    fn current_signer_key_is_never_past_cutoff() {
+        let info = make_info(PK_A, vec![]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_A), i64::MAX));
+    }
+
+    #[test]
+    fn unknown_key_is_not_past_cutoff() {
+        let info = make_info(PK_A, vec![(PK_B, 100)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_UNRELATED), 200));
+    }
+
+    #[test]
+    fn cutoff_zero_means_rotate_immediately_not_past_cutoff() {
+        // cutoff_date == 0 means "rotate now" but the operator still co-signs.
+        // is_signer_past_cutoff_at must return false so the key is not excluded from batches.
+        let info = make_info(PK_A, vec![(PK_B, 0)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), 9_999_999));
+    }
+
+    #[test]
+    fn future_cutoff_is_not_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now + 1)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn exact_cutoff_boundary_is_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now)]);
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn past_cutoff_is_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now - 1)]);
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn multiple_deprecated_only_past_key_is_flagged() {
+        let now = 1_000_000i64;
+        // PK_B: future (not past), PK_C: past
+        let info = make_info(PK_A, vec![(PK_B, now + 100), (PK_C, now - 100)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_C), now));
+    }
+}

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -487,8 +487,11 @@ pub struct DeprecatedSigner {
 impl Info {
     /// Returns all known server signing keys: the current signer followed by all deprecated ones.
     pub fn all_server_keys(&self) -> impl Iterator<Item = XOnlyPublicKey> + '_ {
-        std::iter::once(self.signer_pk.x_only_public_key().0)
-            .chain(self.deprecated_signers.iter().map(|ds| ds.pk.x_only_public_key().0))
+        std::iter::once(self.signer_pk.x_only_public_key().0).chain(
+            self.deprecated_signers
+                .iter()
+                .map(|ds| ds.pk.x_only_public_key().0),
+        )
     }
 
     /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -492,8 +492,9 @@ impl Info {
     }
 
     /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has
-    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "no cutoff" and is never
-    /// treated as past.
+    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "rotate immediately" —
+    /// the operator still co-signs but clients should migrate without delay. It is therefore
+    /// NOT treated as past-cutoff here; use `migrate_deprecated_signer_vtxos` to handle it.
     pub fn is_signer_past_cutoff_at(&self, server_pk: XOnlyPublicKey, now_unix_secs: i64) -> bool {
         self.deprecated_signers.iter().any(|ds| {
             ds.cutoff_date != 0

--- a/ark-rest/src/conversions.rs
+++ b/ark-rest/src/conversions.rs
@@ -117,11 +117,12 @@ impl TryFrom<crate::models::DeprecatedSigner> for ark_core::server::DeprecatedSi
             .parse::<PublicKey>()
             .map_err(|e| ConversionError(format!("Invalid pubkey '{pubkey_str}': {e}")))?;
 
-        let cutoff_date_str = value.cutoff_date.ok_or_else(|| {
-            ConversionError("Missing cutoff_date in deprecated signer".to_string())
-        })?;
-        let cutoff_date = i64::from_str(&cutoff_date_str)
-            .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))?;
+        // A missing cutoffDate means "rotate immediately" (same as 0).
+        let cutoff_date = match value.cutoff_date {
+            Some(s) => i64::from_str(&s)
+                .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))?,
+            None => 0,
+        };
 
         Ok(ark_core::server::DeprecatedSigner { pk, cutoff_date })
     }

--- a/ark-rest/src/conversions.rs
+++ b/ark-rest/src/conversions.rs
@@ -595,3 +595,61 @@ impl TryFrom<GetSubscriptionResponse> for ark_core::server::SubscriptionResponse
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::models::DeprecatedSigner as ModelDeprecatedSigner;
+
+    fn model(pubkey: Option<&str>, cutoff_date: Option<&str>) -> ModelDeprecatedSigner {
+        ModelDeprecatedSigner {
+            pubkey: pubkey.map(str::to_string),
+            cutoff_date: cutoff_date.map(str::to_string),
+        }
+    }
+
+    const PK_A: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    // ── DeprecatedSigner conversion ──────────────────────────────────────────
+
+    #[test]
+    fn deprecated_signer_parses_cutoff_date() {
+        let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), Some("12345")));
+        let ds = result.expect("should succeed");
+        assert_eq!(ds.cutoff_date, 12345);
+        assert_eq!(ds.pk.to_string(), PK_A);
+    }
+
+    #[test]
+    fn deprecated_signer_missing_cutoff_defaults_to_zero() {
+        // A missing cutoffDate means "rotate immediately" (cutoff_date == 0).
+        let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), None));
+        let ds = result.expect("should succeed");
+        assert_eq!(ds.cutoff_date, 0);
+    }
+
+    #[test]
+    fn deprecated_signer_missing_pubkey_returns_error() {
+        let result = ark_core::server::DeprecatedSigner::try_from(model(None, Some("100")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Missing pubkey"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn deprecated_signer_invalid_pubkey_returns_error() {
+        let result =
+            ark_core::server::DeprecatedSigner::try_from(model(Some("notahex"), Some("100")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Invalid pubkey"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn deprecated_signer_invalid_cutoff_date_returns_error() {
+        let result =
+            ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), Some("not-a-number")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("cutoff_date"), "unexpected: {msg}");
+    }
+}

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -330,6 +330,14 @@ impl Regtest {
         *guard = outpoint_block_height_offset;
     }
 
+    /// Rotate the arkd signing key. `cutoff` is passed verbatim to `--cutoff`:
+    /// use `"+86400"` for a future cutoff (regime 1, still cooperative) or
+    /// `"-60"` for a past cutoff (regime 2, operator won't co-sign).
+    #[allow(unused)]
+    pub fn rotate_signer(&self, cutoff: &str) {
+        self.run_regtest(&["rotate-signer", "--cutoff", cutoff]);
+    }
+
     // `mine` stays async (callers `.await` it) even though shelling out to the
     // regtest CLI is synchronous.
     #[allow(unused, clippy::unused_async)]
@@ -676,6 +684,9 @@ macro_rules! wait_until_balance {
     };
     (@check $balance:ident, recoverable, $target:expr) => {
         $balance.recoverable() == $target
+    };
+    (@check $balance:ident, pending_recovery, $target:expr) => {
+        $balance.pending_recovery() == $target
     };
 }
 

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -94,6 +94,103 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     tracing::info!("Sweep-migration test passed: all VTXOs settled under new signer");
 }
 
+/// Verify that `migrate_deprecated_signer_vtxos` only moves VTXOs that sit under a
+/// deprecated signer, leaving VTXOs already under the current signer untouched.
+///
+/// Setup: two VTXOs, one per signer generation.
+///   1. Settle fund_a under signer-A (current).
+///   2. Rotate → signer-A becomes deprecated (future cutoff), signer-B becomes current.
+///   3. Settle fund_b under signer-B (current).
+///   4. Call migrate → only fund_a moves; fund_b outpoint must stay identical.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_only_deprecated_vtxos_migrated() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_a = Amount::from_btc(1.0).unwrap();
+    let fund_b = Amount::from_btc(0.5).unwrap();
+
+    // -- Step 1: settle fund_a under the current (soon-to-be-deprecated) signer --
+    let (client_a, _wallet_a) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding = client_a.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding, fund_a).await;
+    client_a.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&client_a, confirmed: fund_a);
+    drop(client_a);
+
+    // -- Step 2: rotate signer --
+    regtest.rotate_signer("+86400");
+
+    // -- Step 3: reconnect and settle fund_b under the new current signer --
+    let (client_b, _wallet_b) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client_b.server_info.deprecated_signers.is_empty(),
+        "signer-A must appear as deprecated after rotation"
+    );
+
+    let boarding2 = client_b.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding2, fund_b).await;
+    client_b.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&client_b, confirmed: fund_a + fund_b);
+
+    // Record outpoints of all VTXOs currently under the new (current) signer.
+    let new_signer_pk = client_b.server_info.signer_pk.x_only_public_key().0;
+    let (vtxo_list, script_map) = client_b.list_vtxos().await.unwrap();
+    let current_signer_outpoints: std::collections::HashSet<_> = vtxo_list
+        .all_unspent()
+        .filter(|v| {
+            script_map
+                .get(&v.script)
+                .map(|vtxo| vtxo.server_pk() == new_signer_pk)
+                .unwrap_or(false)
+        })
+        .map(|v| v.outpoint)
+        .collect();
+    assert!(
+        !current_signer_outpoints.is_empty(),
+        "there must be at least one VTXO under the new signer before migration"
+    );
+
+    // -- Step 4: migrate --
+    let txid = client_b
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        txid.is_some(),
+        "migrate must submit a settlement for the deprecated-signer VTXO"
+    );
+
+    wait_until_balance!(&client_b, confirmed: fund_a + fund_b);
+
+    // Outpoints that were under the current signer MUST still be present — they were not
+    // re-settled into a new batch.
+    let (vtxo_list_after, _) = client_b.list_vtxos().await.unwrap();
+    let outpoints_after: std::collections::HashSet<_> =
+        vtxo_list_after.all_unspent().map(|v| v.outpoint).collect();
+
+    for op in &current_signer_outpoints {
+        assert!(
+            outpoints_after.contains(op),
+            "current-signer VTXO {op} was re-settled during migration — it should not have been"
+        );
+    }
+
+    tracing::info!(
+        "Selective-migration test passed: current-signer VTXOs untouched, \
+         deprecated-signer VTXO migrated"
+    );
+}
+
 /// Regime 2: VTXO created under current signer → rotate with past cutoff (operator will NOT
 /// co-sign the old key) → VTXO is stuck in `pending_recovery`, NOT in confirmed/pre_confirmed.
 ///

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::unwrap_used)]
+
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client_with_seed;
+use common::wait_until_balance;
+use common::Regtest;
+use rand::thread_rng;
+use rand::Rng;
+use std::sync::Arc;
+
+mod common;
+
+/// Regime 1: VTXO created under current signer → rotate with future cutoff (still cooperative)
+/// → `migrate_deprecated_signer_vtxos` settles all pre-cutoff VTXOs to the new signer.
+///
+/// Mirrors dotnet-sdk `SweepMigrationRotationTests` and ts-sdk rotation/migration scenario.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_sweep_migration() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+
+    client.settle(&mut rng).await.unwrap();
+
+    wait_until_balance!(&client, confirmed: fund_amount);
+    tracing::info!("VTXO confirmed under current signer");
+
+    drop(client);
+
+    // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1).
+    regtest.rotate_signer("+86400");
+    tracing::info!("Signer rotated with future cutoff (+86400)");
+
+    // Reconnect to pick up updated server info (deprecated_signers now populated).
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client2.server_info.deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after rotation"
+    );
+
+    let balance_before = client2.offchain_balance().await.unwrap();
+    tracing::info!(
+        ?balance_before,
+        "Balance seen by new client before migration"
+    );
+    assert_eq!(
+        balance_before.total(),
+        fund_amount,
+        "Total balance must be preserved after rotation"
+    );
+
+    let txid = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        txid.is_some(),
+        "migrate_deprecated_signer_vtxos must submit a settlement (returned None)"
+    );
+    tracing::info!(
+        ?txid,
+        "migrate_deprecated_signer_vtxos submitted settlement"
+    );
+
+    // Wait for the new batch to confirm.
+    wait_until_balance!(&client2, confirmed: fund_amount);
+
+    // If migration actually moved VTXOs to the new signer, there is nothing left
+    // to migrate — a second call must return None.
+    let second = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        second.is_none(),
+        "second migrate call should find nothing to migrate (VTXOs are already under new signer)"
+    );
+    tracing::info!("Sweep-migration test passed: all VTXOs settled under new signer");
+}
+
+/// Regime 2: VTXO created under current signer → rotate with past cutoff (operator will NOT
+/// co-sign the old key) → VTXO is stuck in `pending_recovery`, NOT in confirmed/pre_confirmed.
+///
+/// Mirrors dotnet-sdk `PastCutoffHeldBackRotationTests`.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_past_cutoff_held_back() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+
+    client.settle(&mut rng).await.unwrap();
+
+    wait_until_balance!(&client, confirmed: fund_amount);
+    tracing::info!("VTXO confirmed under current signer");
+
+    drop(client);
+
+    // Rotate: past cutoff (-60 seconds) means the operator will NOT co-sign the old key.
+    regtest.rotate_signer("-60");
+    tracing::info!("Signer rotated with past cutoff (-60)");
+
+    // Reconnect to pick up updated server info.
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client2.server_info.deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after rotation"
+    );
+
+    // The VTXO is under a past-cutoff deprecated signer: not spendable offchain,
+    // not yet expired → must appear in pending_recovery, not in confirmed.
+    wait_until_balance!(
+        &client2,
+        confirmed: Amount::ZERO,
+        pre_confirmed: Amount::ZERO,
+        pending_recovery: fund_amount,
+    );
+
+    tracing::info!("Past-cutoff held-back test passed: VTXO is in pending_recovery, not spendable");
+}


### PR DESCRIPTION
## Summary

⚠️ Stacks on #237
This PR is rebased on top of migrate-regtest-denigiri — please merge #237 first, or review/merge both together. The base branch will be updated to master automatically once #237 lands.

Client-side support for arkd signer-key rotation, mirroring what was done in ts-sdk #554 and dotnet-sdk #132. When the operator rotates its signing key, existing VTXOs and boarding outputs remain under the old key. This PR lets the SDK discover, classify, and cooperatively migrate those funds to the active signer, and recover Boltz swaps that straddle a rotation.

> **Depends on #242** (X-Digest header / `refresh_server_info()` / `ServerInfoChanged`). That PR populates `server_info.deprecated_signers` at runtime — without it the fields added here are always empty and the whole feature is a no-op. The code in this PR compiles and is safe to merge independently; the feature activates once #242 lands.

## Three regimes

| Regime | Condition | Behaviour |
|---|---|---|
| **Migratable** | deprecated signer, before cutoff (or `cutoffDate == 0`) | cooperative settle to current signer via `migrate_deprecated_signer_vtxos()` |
| **Pending recovery** | deprecated signer, past cutoff, not yet expired | excluded from offchain spend and batch; counted in new `OffChainBalance::pending_recovery` bucket; unilateral exit still available |
| **Recoverable** | expired | `settle()` picks up automatically — no forfeit needed |

## Changes

**`ark-core`**
- `Info::all_server_keys()` — iterates current + all deprecated signers
- `Info::is_signer_past_cutoff_at()` — returns true when a signer's cutoff has passed; `cutoff_date == 0` means "rotate immediately" and is treated as not-yet-past-cutoff (operator still co-signs; migration is triggered separately)
- `BoardingOutput::server_pk()` — exposes the server key embedded in the boarding output script

**`ark-client`**
- `get_offchain_addresses()` and `get_boarding_addresses()` fan out over `current ∪ deprecated` signers so all funds remain visible
- `OffChainBalance` gains `pending_recovery` bucket; past-cutoff VTXOs are excluded from     `confirmed`/`pre_confirmed`
- `migrate_deprecated_signer_vtxos()` — sweeps VTXOs **and boarding outputs** under pre-cutoff deprecated signers to the current signer by joining the next batch
- `fetch_commitment_transaction_inputs()` excludes past-cutoff VTXOs and boarding outputs (operator won't co-sign the old key's forfeit path — including them would brick the batch)
- `auto_select_send_inputs()` excludes past-cutoff VTXOs from offchain sends
- `discover_keys()` generates addresses for all known server keys so user keys active before a rotation are found on seed re
- Boltz: all VHTLC reconstruction sites replaced with `reconstruct_vhtlc_for_address()`, which tries current + deprecated server keys to match the stored lockup address — swap recovery works across a rotation

**`ark-rest`**
- `DeprecatedSigner` conversion: missing `cutoffDate` in JSON now maps to `0` ("rotate immediately") instead of returning a `ConversionError` and crashing `get_info`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-based cutoffs for server signer key rotation.
  * Introduced `pending_recovery` in offchain balance totals for assets held under deprecated keys past cutoff.
  * Expanded offchain address discovery to include current and deprecated server keys.
  * Improved migration of deprecated-signer VTXOs with cutoff-aware behavior.

* **Bug Fixes**
  * Excludes cutoff-past boarding and deprecated-signer VTXOs from batch input selection and auto-selection.
  * Updates VHTLC reconstruction to match the swap’s expected address during signer rotation.

* **Tests**
  * Added end-to-end coverage for signer rotation and deprecated-signer migration (including past/future cutoff cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->