### PR TITLE
Signer rotation + X-Digest headers (stacks #242 + #243, fills review gaps)

### DIFF
--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -769,7 +769,7 @@ async fn run_command<K: KeyProvider + 'static>(
             unreachable!("pending future never resolves");
         }
         Commands::SendOnchain { address, amount } => {
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -798,7 +798,7 @@ async fn run_command<K: KeyProvider + 'static>(
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -1201,7 +1201,7 @@ async fn run_command<K: KeyProvider + 'static>(
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         Commands::EstimateFees { address, amount } => {
-            let network = client.server_info.network;
+            let network = client.server_info()?.network;
             let mut rng = thread_rng();
 
             // Try parsing as ArkAddress first, then as Bitcoin address
@@ -1293,7 +1293,7 @@ async fn run_command<K: KeyProvider + 'static>(
             let selected = ark_core::coin_select::select_vtxos(
                 spendable,
                 amount,
-                client.server_info.dust,
+                client.server_info()?.dust,
                 true,
             )
             .map_err(|e| anyhow!(e))?;
@@ -1426,7 +1426,7 @@ async fn run_command<K: KeyProvider + 'static>(
 
             let receiver = SendReceiver {
                 address: address.0,
-                amount: client.dust(),
+                amount: client.dust()?,
                 assets: vec![ark_core::server::Asset {
                     asset_id,
                     amount: *amount,

--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -760,8 +760,12 @@ async fn run_command<K: KeyProvider + 'static>(
                 );
             }
 
-            let _watcher = client.start_vtxo_watcher(delegator);
+            // Default config enables the background deprecated-signer migration arm
+            // (`migrate_deprecated_signers: true`) alongside delegation and self-renewal.
+            let watcher_config = ark_client::vtxo_watcher::VtxoWatcherConfig::default();
+            let _watcher = client.start_vtxo_watcher(delegator, watcher_config);
             tracing::info!(
+                migrate_deprecated_signers = watcher_config.migrate_deprecated_signers,
                 "Watcher running. Keep this process open and run other commands in parallel."
             );
 

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -49,6 +49,7 @@ backon = { version = "1", features = ["gloo-timers-sleep"] }
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 getrandom = { version = "0.2", features = ["wasm-bindgen", "js"] }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
+js-sys = { version = "0.3" }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tonic-prost = "0.14"
 tonic-web-wasm-client = { version = "0.6", default-features = false }

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -58,8 +58,11 @@ wasm-bindgen-futures = { version = "0.4" }
 tonic-build = { version = "0.14" }
 
 [dev-dependencies]
+ark-grpc = { path = "../ark-grpc", version = "0.9.2", default-features = false, features = ["test-utils"] }
 tempfile = "3.8"
-tokio = { version = "1.41.0", features = ["macros", "rt"] }
+tokio = { version = "1.41.0", features = ["macros", "net", "rt-multi-thread", "sync"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic-prost = "0.14"
 
 [features]
 default = ["tls-native-roots"]

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -59,6 +59,7 @@ tonic-build = { version = "0.14" }
 
 [dev-dependencies]
 ark-grpc = { path = "../ark-grpc", version = "0.9.2", default-features = false, features = ["test-utils"] }
+rustls = { version = "0.23", features = ["ring"] }
 tempfile = "3.8"
 tokio = { version = "1.41.0", features = ["macros", "net", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/ark-client/src/asset.rs
+++ b/ark-client/src/asset.rs
@@ -56,8 +56,8 @@ where
 
         let selected_coins = select_vtxos(
             spendable,
-            self.server_info.dust,
-            self.server_info.dust,
+            self.server_info()?.dust,
+            self.server_info()?.dust,
             true,
         )
         .map_err(Error::from)
@@ -74,7 +74,7 @@ where
             &own_address,
             &change_address,
             &issuance_inputs,
-            &self.server_info,
+            &self.server_info()?,
             amount,
             control_asset_config,
             metadata,
@@ -131,7 +131,7 @@ where
         let mut selected = control_coins;
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
         let btc_shortfall = self
-            .server_info
+            .server_info()?
             .dust
             .checked_sub(btc_provided)
             .unwrap_or(Amount::ZERO);
@@ -143,7 +143,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for reissuance")?;
 
@@ -165,7 +165,7 @@ where
             &self_address,
             &change_address,
             &reissuance_inputs,
-            &self.server_info,
+            &self.server_info()?,
             asset_id,
             control_asset_id,
             amount,
@@ -211,9 +211,9 @@ where
         }
 
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
-        let mut btc_needed = self.server_info.dust;
+        let mut btc_needed = self.server_info()?.dust;
         if carries_asset_change {
-            btc_needed += self.server_info.dust;
+            btc_needed += self.server_info()?.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -224,7 +224,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset burn")?;
 
@@ -243,7 +243,7 @@ where
             &own_address,
             &change_address,
             &burn_inputs,
-            &self.server_info,
+            &self.server_info()?,
             asset_id,
             amount,
         )

--- a/ark-client/src/asset.rs
+++ b/ark-client/src/asset.rs
@@ -51,17 +51,13 @@ where
             return Err(Error::ad_hoc("asset amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let (own_address, _) = self.get_offchain_address()?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
-        let selected_coins = select_vtxos(
-            spendable,
-            self.server_info()?.dust,
-            self.server_info()?.dust,
-            true,
-        )
-        .map_err(Error::from)
-        .context("failed to select coins for asset issuance")?;
+        let selected_coins = select_vtxos(spendable, server_info.dust, server_info.dust, true)
+            .map_err(Error::from)
+            .context("failed to select coins for asset issuance")?;
 
         let issuance_inputs = self.build_vtxo_inputs(selected_coins, &script_pubkey_to_vtxo_map)?;
         let (change_address, change_address_vtxo) = self.get_offchain_address()?;
@@ -74,7 +70,7 @@ where
             &own_address,
             &change_address,
             &issuance_inputs,
-            &self.server_info()?,
+            &server_info,
             amount,
             control_asset_config,
             metadata,
@@ -107,6 +103,7 @@ where
             return Err(Error::ad_hoc("reissue amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let asset_info = self
             .get_asset(asset_id)
             .await
@@ -130,8 +127,7 @@ where
             control_coins.iter().map(|coin| coin.outpoint).collect();
         let mut selected = control_coins;
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
-        let btc_shortfall = self
-            .server_info()?
+        let btc_shortfall = server_info
             .dust
             .checked_sub(btc_provided)
             .unwrap_or(Amount::ZERO);
@@ -143,7 +139,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for reissuance")?;
 
@@ -165,7 +161,7 @@ where
             &self_address,
             &change_address,
             &reissuance_inputs,
-            &self.server_info()?,
+            &server_info,
             asset_id,
             control_asset_id,
             amount,
@@ -192,6 +188,7 @@ where
             return Err(Error::ad_hoc("burn amount must be > 0"));
         }
 
+        let server_info = self.server_info()?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
         let (asset_coins, asset_change) = select_vtxos_for_asset(&spendable, amount, asset_id)
@@ -211,9 +208,9 @@ where
         }
 
         let btc_provided: Amount = selected.iter().map(|coin| coin.amount).sum();
-        let mut btc_needed = self.server_info()?.dust;
+        let mut btc_needed = server_info.dust;
         if carries_asset_change {
-            btc_needed += self.server_info()?.dust;
+            btc_needed += server_info.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -224,7 +221,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset burn")?;
 
@@ -243,7 +240,7 @@ where
             &own_address,
             &change_address,
             &burn_inputs,
-            &self.server_info()?,
+            &server_info,
             asset_id,
             amount,
         )

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -45,7 +45,6 @@ use bitcoin::TxOut;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use futures::StreamExt;
-use jiff::Timestamp;
 use rand::CryptoRng;
 use rand::Rng;
 use std::collections::HashMap;
@@ -1011,7 +1010,7 @@ where
         // To track unique outpoints and prevent duplicates
         let mut seen_outpoints = std::collections::HashSet::new();
 
-        let now = Timestamp::now();
+        let now_secs = super::unix_now();
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {
@@ -1039,7 +1038,6 @@ where
                     // Skip boarding outputs whose server key is past its cooperative-sign
                     // cutoff — the operator won't co-sign the old key's forfeit path.
                     // These must be recovered via unilateral exit (send_on_chain).
-                    let now_secs = now.as_second();
                     if self
                         .server_info
                         .is_signer_past_cutoff_at(boarding_output.server_pk(), now_secs)
@@ -1049,7 +1047,7 @@ where
 
                     // Only include confirmed boarding outputs with an _inactive_ exit path.
                     if !boarding_output.can_be_claimed_unilaterally_by_owner(
-                        now.as_duration().try_into().map_err(Error::ad_hoc)?,
+                        std::time::Duration::from_secs(now_secs as u64),
                         std::time::Duration::from_secs(*confirmation_blocktime),
                         *confirmations,
                     ) {
@@ -1068,7 +1066,7 @@ where
         }
 
         let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
-        let now = Timestamp::now().as_second();
+        let now = super::unix_now();
         let dust = self.server_info.dust;
 
         // Exclude VTXOs under a past-cutoff deprecated signer that still require a forfeit.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1057,13 +1057,33 @@ where
         }
 
         let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
+        let now = Timestamp::now().as_second();
+        let dust = self.server_info.dust;
+
+        // Exclude VTXOs under a past-cutoff deprecated signer that still require a forfeit.
+        // The operator won't co-sign the forfeit for the old key, which would brick the whole
+        // batch intent. They wait until expiry (is_recoverable) before joining a batch.
+        let is_excluded = |v: &&ark_core::server::VirtualTxOutPoint| -> bool {
+            if v.is_recoverable(dust) {
+                return false; // recoverable = no forfeit needed, always safe to include
+            }
+            script_pubkey_to_vtxo_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    self.server_info
+                        .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                })
+                .unwrap_or(false)
+        };
 
         total_amount += vtxo_list
             .all_unspent()
+            .filter(|v| !is_excluded(v))
             .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.amount);
 
         let vtxo_inputs = vtxo_list
             .all_unspent()
+            .filter(|v| !is_excluded(v))
             .map(|virtual_tx_outpoint| {
                 let vtxo = script_pubkey_to_vtxo_map
                     .get(&virtual_tx_outpoint.script)

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1036,6 +1036,17 @@ where
                         continue;
                     }
 
+                    // Skip boarding outputs whose server key is past its cooperative-sign
+                    // cutoff — the operator won't co-sign the old key's forfeit path.
+                    // These must be recovered via unilateral exit (send_on_chain).
+                    let now_secs = now.as_second();
+                    if self
+                        .server_info
+                        .is_signer_past_cutoff_at(boarding_output.server_pk(), now_secs)
+                    {
+                        continue;
+                    }
+
                     // Only include confirmed boarding outputs with an _inactive_ exit path.
                     if !boarding_output.can_be_claimed_unilaterally_by_owner(
                         now.as_duration().try_into().map_err(Error::ad_hoc)?,

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1016,7 +1016,8 @@ where
         let mut seen_outpoints = std::collections::HashSet::new();
 
         let now_secs = now;
-        // Snapshot once; reused for the boarding cutoff filter and the VTXO dust/cutoff logic below.
+        // Snapshot once; reused for the boarding cutoff filter and the VTXO dust/cutoff logic
+        // below.
         let server_info = self.server_info()?;
 
         // Find outpoints for each boarding output.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -62,11 +62,18 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
+        self.settle_at(super::unix_now(), rng).await
+    }
+
+    pub(crate) async fn settle_at<R>(&self, now: i64, rng: &mut R) -> Result<Option<Txid>, Error>
+    where
+        R: Rng + CryptoRng + Clone,
+    {
         // Get off-chain address and send all funds to this address, no change output 🦄
         let (to_address, _) = self.get_offchain_address()?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+            self.fetch_commitment_transaction_inputs(now).await?;
 
         tracing::debug!(
             offchain_adress = %to_address.encode(),
@@ -124,8 +131,9 @@ where
     {
         let (to_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, mut total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, mut total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         // Convert arknotes to intent inputs and add their value to total
         let note_inputs: Vec<intent::Input> = notes
@@ -198,8 +206,9 @@ where
         // Get off-chain address and send all funds to this address, no change output.
         let (to_address, _) = self.get_offchain_address()?;
 
-        let (all_boarding_inputs, all_vtxo_inputs, _) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (all_boarding_inputs, all_vtxo_inputs, _) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         // Filter boarding inputs to only those specified.
         let boarding_inputs: Vec<_> = all_boarding_inputs
@@ -274,8 +283,9 @@ where
     {
         let (change_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let onchain_fee = self
             .fee_estimator
@@ -470,7 +480,9 @@ where
         let (to_address, _) = self.get_offchain_address()?;
 
         // Simply collect all VTXOs that can be settled.
-        let (_, vtxo_inputs, _) = self.fetch_commitment_transaction_inputs().await?;
+        let (_, vtxo_inputs, _) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let total_amount = vtxo_inputs
             .iter()
@@ -1000,6 +1012,7 @@ where
     /// upcoming batch.
     pub(crate) async fn fetch_commitment_transaction_inputs(
         &self,
+        now: i64,
     ) -> Result<(Vec<batch::OnChainInput>, Vec<intent::Input>, Amount), Error> {
         // Get all known boarding outputs.
         let boarding_outputs = self.inner.wallet.get_boarding_outputs()?;
@@ -1010,7 +1023,7 @@ where
         // To track unique outpoints and prevent duplicates
         let mut seen_outpoints = std::collections::HashSet::new();
 
-        let now_secs = super::unix_now();
+        let now_secs = now;
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1071,7 +1071,10 @@ where
         }
 
         let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
-        let now = super::unix_now();
+        // Reuse the caller-supplied timestamp (not a fresh wall-clock) so the VTXO cutoff filter
+        // below is evaluated against the same instant as the boarding filter above, and so a
+        // test-injected `now` deterministically controls both.
+        let now = now_secs;
         let dust = server_info.dust;
 
         // Exclude VTXOs under a past-cutoff deprecated signer that still require a forfeit.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -1143,7 +1143,7 @@ where
                 to_address,
                 to_amount,
             } => {
-                if to_amount < self.server_info()?.dust {
+                if to_amount < dust {
                     return Err(Error::ad_hoc(format!(
                         "cannot settle into sub-dust VTXO: {to_amount} < {dust}"
                     )));

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -278,14 +278,10 @@ where
         let (boarding_inputs, vtxo_inputs, total_amount) =
             self.fetch_commitment_transaction_inputs().await?;
 
-        let onchain_fee = self
-            .fee_estimator
-            .eval_onchain_output(ark_fees::Output {
-                amount: to_amount.to_sat(),
-                script: to_address.script_pubkey().to_string(),
-            })
-            .map_err(Error::ad_hoc)?;
-        let onchain_fee = Amount::from_sat(onchain_fee.to_satoshis());
+        let onchain_fee = self.eval_onchain_output_fee(ark_fees::Output {
+            amount: to_amount.to_sat(),
+            script: to_address.script_pubkey().to_string(),
+        })?;
 
         // Fee comes out of change, not the send amount.
         let change_amount = total_amount
@@ -391,14 +387,10 @@ where
             .iter()
             .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.amount());
 
-        let onchain_fee = self
-            .fee_estimator
-            .eval_onchain_output(ark_fees::Output {
-                amount: to_amount.to_sat(),
-                script: to_address.script_pubkey().to_string(),
-            })
-            .map_err(Error::ad_hoc)?;
-        let onchain_fee = Amount::from_sat(onchain_fee.to_satoshis());
+        let onchain_fee = self.eval_onchain_output_fee(ark_fees::Output {
+            amount: to_amount.to_sat(),
+            script: to_address.script_pubkey().to_string(),
+        })?;
 
         // Fee comes out of change, not the send amount.
         let change_amount = total_input_amount
@@ -481,7 +473,7 @@ where
             return Err(Error::ad_hoc("no inputs to settle via delegate"));
         }
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let mut outputs = vec![intent::Output::Offchain(TxOut {
             value: total_amount,
@@ -579,7 +571,7 @@ where
         tracing::debug!(intent_id, "Registered delegated intent");
 
         let network_client = self.network_client();
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         #[derive(Debug, PartialEq, Eq)]
         enum Step {
@@ -1142,7 +1134,7 @@ where
                 .collect::<Vec<_>>()
         };
 
-        let dust = self.server_info.dust;
+        let dust = self.server_info()?.dust;
 
         let mut outputs = vec![];
 
@@ -1151,7 +1143,7 @@ where
                 to_address,
                 to_amount,
             } => {
-                if to_amount < self.server_info.dust {
+                if to_amount < self.server_info()?.dust {
                     return Err(Error::ad_hoc(format!(
                         "cannot settle into sub-dust VTXO: {to_amount} < {dust}"
                     )));
@@ -1332,7 +1324,7 @@ where
             .map(|i| i.outpoint())
             .collect::<Vec<_>>();
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let own_cosigner_kps = [cosigner_keypair];
         let own_cosigner_pks = own_cosigner_kps

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -3206,18 +3206,12 @@ where
         mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
         expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        let network = self.server_info.network;
-        for server_key in self.server_info.all_server_keys() {
-            let opts = mk_opts(server_key)?;
-            let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
-            if &vhtlc.address() == expected_address {
-                return Ok(vhtlc);
-            }
-        }
-        Err(Error::ad_hoc(format!(
-            "VHTLC script could not be reconstructed for address {expected_address}: \
-             does not match current or any deprecated server key"
-        )))
+        reconstruct_vhtlc_from_keys(
+            self.server_info.all_server_keys(),
+            self.server_info.network,
+            mk_opts,
+            expected_address,
+        )
     }
 
     /// Reconstruct a [`VhtlcScript`] from swap data fields, trying current + deprecated signers.
@@ -4234,6 +4228,30 @@ struct ChainSwapSideDetails {
     bip21: Option<String>,
 }
 
+/// Iterate `server_keys` in order, building a [`VhtlcScript`] for each one, and return the
+/// first whose address matches `expected_address`.
+///
+/// Extracted from [`Client::reconstruct_vhtlc_for_address`] so the key-iteration logic can be
+/// tested without a full [`Client`] instance.
+pub(crate) fn reconstruct_vhtlc_from_keys(
+    server_keys: impl Iterator<Item = XOnlyPublicKey>,
+    network: bitcoin::Network,
+    mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
+    expected_address: &ArkAddress,
+) -> Result<VhtlcScript, Error> {
+    for server_key in server_keys {
+        let opts = mk_opts(server_key)?;
+        let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
+        if &vhtlc.address() == expected_address {
+            return Ok(vhtlc);
+        }
+    }
+    Err(Error::ad_hoc(format!(
+        "VHTLC script could not be reconstructed for address {expected_address}: \
+         does not match current or any deprecated server key"
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4500,5 +4518,171 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("640"), "unexpected error message: {msg}");
         assert!(msg.contains("639"), "unexpected error message: {msg}");
+    }
+
+    // ── reconstruct_vhtlc_from_keys ─────────────────────────────────────────
+
+    /// Build a [`VhtlcOptions`] from the first fixture in vhtlc.json (CSV > 16).
+    /// Keys and expected address are taken verbatim from the JSON fixture so the test
+    /// is independent of any client-side logic.
+    fn fixture_opts(server: XOnlyPublicKey) -> VhtlcOptions {
+        let sender = XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+            )
+            .unwrap()
+            .inner,
+        );
+        let receiver = XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+            )
+            .unwrap()
+            .inner,
+        );
+        VhtlcOptions {
+            sender,
+            receiver,
+            server,
+            preimage_hash: ripemd160::Hash::from_str("4d487dd3753a89bc9fe98401d1196523058251fc")
+                .unwrap(),
+            refund_locktime: 265,
+            unilateral_claim_delay: bitcoin::Sequence::from_height(17),
+            unilateral_refund_delay: bitcoin::Sequence::from_height(144),
+            unilateral_refund_without_receiver_delay: bitcoin::Sequence::from_height(144),
+        }
+    }
+
+    fn fixture_server_xonly() -> XOnlyPublicKey {
+        XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+            )
+            .unwrap()
+            .inner,
+        )
+    }
+
+    // Expected Ark address from the fixture (vhtlc.json CSV > 16 case, testnet).
+    const FIXTURE_ADDRESS: &str = "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63";
+
+    // A second server key that produces a different address for the same other params.
+    fn wrong_server_xonly() -> XOnlyPublicKey {
+        XOnlyPublicKey::from(
+            PublicKey::from_str(
+                "0206988651c7fbe41747bb21b54ced0a183f4d658e007ee8fdb23fbbfccb8e0c55",
+            )
+            .unwrap()
+            .inner,
+        )
+    }
+
+    #[test]
+    fn reconstruct_matches_with_single_current_key() {
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let vhtlc = reconstruct_vhtlc_from_keys(
+            std::iter::once(server),
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .unwrap();
+
+        assert_eq!(vhtlc.address(), expected);
+    }
+
+    #[test]
+    fn reconstruct_skips_wrong_key_and_finds_deprecated() {
+        let wrong = wrong_server_xonly();
+        let correct = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        // Iterator: wrong key first, correct key second (simulates signer rotation).
+        let keys = [wrong, correct].into_iter();
+        let vhtlc = reconstruct_vhtlc_from_keys(
+            keys,
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .unwrap();
+
+        assert_eq!(vhtlc.address(), expected);
+    }
+
+    #[test]
+    fn reconstruct_errors_when_no_key_matches() {
+        let wrong = wrong_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let err = reconstruct_vhtlc_from_keys(
+            std::iter::once(wrong),
+            bitcoin::Network::Testnet,
+            |sk| Ok(fixture_opts(sk)),
+            &expected,
+        )
+        .err()
+        .expect("should have failed");
+
+        assert!(
+            err.to_string()
+                .contains("does not match current or any deprecated server key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reconstruct_propagates_mk_opts_error() {
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let err = reconstruct_vhtlc_from_keys(
+            std::iter::once(server),
+            bitcoin::Network::Testnet,
+            |_| Err(Error::ad_hoc("options error")),
+            &expected,
+        )
+        .err()
+        .expect("should have failed");
+
+        assert!(
+            err.to_string().contains("options error"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn build_vhtlc_script_sender_is_refund_receiver_is_claim() {
+        // Verify the key-role mapping: build_vhtlc_script(claim, refund, ...) must produce the
+        // same address as a manually-constructed VhtlcOptions{sender=refund, receiver=claim}.
+        let claim_pk = PublicKey::from_str(
+            "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+        )
+        .unwrap();
+        let refund_pk = PublicKey::from_str(
+            "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+        )
+        .unwrap();
+        let server = fixture_server_xonly();
+        let expected = ArkAddress::decode(FIXTURE_ADDRESS).unwrap();
+
+        let opts = VhtlcOptions {
+            sender: refund_pk.inner.x_only_public_key().0,
+            receiver: claim_pk.inner.x_only_public_key().0,
+            server,
+            preimage_hash: ripemd160::Hash::from_str("4d487dd3753a89bc9fe98401d1196523058251fc")
+                .unwrap(),
+            refund_locktime: 265,
+            unilateral_claim_delay: bitcoin::Sequence::from_height(17),
+            unilateral_refund_delay: bitcoin::Sequence::from_height(144),
+            unilateral_refund_without_receiver_delay: bitcoin::Sequence::from_height(144),
+        };
+        let manual_vhtlc =
+            VhtlcScript::new(opts, bitcoin::Network::Testnet).expect("valid options");
+
+        // The manual construction produces the expected fixture address.
+        assert_eq!(manual_vhtlc.address(), expected);
     }
 }

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -541,39 +541,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -709,39 +707,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -824,39 +820,37 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap_data.refund_public_key.into(),
-                receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap_data.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap_data.refund_public_key.into(),
+                    receiver: swap_data.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap_data.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
+            &swap_data.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap_data.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap_data.vhtlc_address
-            )));
-        }
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -1431,40 +1425,37 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
+            &swap.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap.vhtlc_address
-            )));
-        }
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
@@ -1681,40 +1672,37 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash: swap.preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash: swap.preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
             },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
+            &swap.vhtlc_address,
+        )?;
         let vhtlc_address = vhtlc.address();
-        if vhtlc_address != swap.vhtlc_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match swap address ({})",
-                swap.vhtlc_address
-            )));
-        }
 
         // TODO: Ideally we can skip this if the vout is always the same (probably 0).
         let vhtlc_outpoint = {
@@ -2102,42 +2090,40 @@ where
             ))
         })?;
 
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.server_refund_public_key.into(),
-                receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)
-        .context("failed to build VHTLC script")?;
-
-        let vhtlc_address = vhtlc.address();
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
-        if vhtlc_address != expected_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match server lockup address ({expected_address})"
-            )));
-        }
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.server_refund_public_key.into(),
+                    receiver: swap.claim_public_key.into(),
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
+            },
+            &expected_address,
+        )?;
+        let vhtlc_address = vhtlc.address();
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -2463,41 +2449,40 @@ where
         let preimage_hash = ripemd160::Hash::hash(swap.preimage_hash.as_byte_array());
 
         // User's lockup VHTLC: sender=user(refund), receiver=server(claim)
-        let vhtlc = VhtlcScript::new(
-            VhtlcOptions {
-                sender: swap.refund_public_key.into(),
-                receiver: swap.server_claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
-        )
-        .map_err(Error::ad_hoc)?;
-
-        let vhtlc_address = vhtlc.address();
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
-        if vhtlc_address != expected_address {
-            return Err(Error::ad_hoc(format!(
-                "VHTLC address ({vhtlc_address}) does not match user lockup address ({expected_address})"
-            )));
-        }
+        let vhtlc = self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: swap.refund_public_key.into(),
+                    receiver: swap.server_claim_public_key.into(),
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_claim as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
+                    })?,
+                    unilateral_refund_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
+                    })?,
+                    unilateral_refund_without_receiver_delay: parse_sequence_number(
+                        timeout_block_heights.unilateral_refund_without_receiver as i64,
+                    )
+                    .map_err(|e| {
+                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                    })?,
+                })
+            },
+            &expected_address,
+        )?;
+        let vhtlc_address = vhtlc.address();
 
         let vhtlc_outpoint = {
             let virtual_tx_outpoints = self
@@ -3382,39 +3367,67 @@ where
 
     // Private helpers for pending VHTLC recovery.
 
-    /// Reconstruct a [`VhtlcScript`] from swap data fields.
+    /// Try to reconstruct a [`VhtlcScript`] that matches `expected_address` by trying the current
+    /// server signer and all deprecated signers in order. Returns the first match.
+    ///
+    /// This handles the case where the server rotated its signing key after a swap was created:
+    /// the VHTLC was built with the old key, so we must try deprecated keys to find the right one.
+    fn reconstruct_vhtlc_for_address(
+        &self,
+        mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
+        expected_address: &ArkAddress,
+    ) -> Result<VhtlcScript, Error> {
+        let network = self.server_info.network;
+        for server_key in self.server_info.all_server_keys() {
+            let opts = mk_opts(server_key)?;
+            let vhtlc = VhtlcScript::new(opts, network).map_err(Error::ad_hoc)?;
+            if &vhtlc.address() == expected_address {
+                return Ok(vhtlc);
+            }
+        }
+        Err(Error::ad_hoc(format!(
+            "VHTLC script could not be reconstructed for address {expected_address}: \
+             does not match current or any deprecated server key"
+        )))
+    }
+
+    /// Reconstruct a [`VhtlcScript`] from swap data fields, trying current + deprecated signers.
     fn build_vhtlc_script(
         &self,
         claim_public_key: PublicKey,
         refund_public_key: PublicKey,
         preimage_hash: ripemd160::Hash,
         timeout_block_heights: &TimeoutBlockHeights,
+        expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        VhtlcScript::new(
-            VhtlcOptions {
-                sender: refund_public_key.inner.x_only_public_key().0,
-                receiver: claim_public_key.inner.x_only_public_key().0,
-                server: self.server_info.signer_pk.into(),
-                preimage_hash,
-                refund_locktime: timeout_block_heights.refund,
-                unilateral_claim_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_claim as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                unilateral_refund_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund as i64,
-                )
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
-                unilateral_refund_without_receiver_delay: parse_sequence_number(
-                    timeout_block_heights.unilateral_refund_without_receiver as i64,
-                )
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?,
-            },
-            self.server_info.network,
+        let unilateral_claim_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_claim as i64,
         )
-        .map_err(Error::ad_hoc)
+        .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_refund as i64,
+        )
+        .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay = parse_sequence_number(
+            timeout_block_heights.unilateral_refund_without_receiver as i64,
+        )
+        .map_err(|e| Error::ad_hoc(format!("invalid refund without receiver timeout: {e}")))?;
+
+        self.reconstruct_vhtlc_for_address(
+            |server| {
+                Ok(VhtlcOptions {
+                    sender: refund_public_key.inner.x_only_public_key().0,
+                    receiver: claim_public_key.inner.x_only_public_key().0,
+                    server,
+                    preimage_hash,
+                    refund_locktime: timeout_block_heights.refund,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
+                })
+            },
+            expected_address,
+        )
     }
 
     /// Collect info about all active (non-terminal) VHTLCs from swap storage.
@@ -3499,15 +3512,8 @@ where
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
+                &swap.vhtlc_address,
             )?;
-
-            if vhtlc.address() != swap.vhtlc_address {
-                tracing::warn!(
-                    swap_id = swap.id,
-                    "VHTLC address mismatch for submarine swap, skipping"
-                );
-                continue;
-            }
 
             // For submarine swaps, the user is the sender (refund key).
             // Use refund_without_receiver_script as the intent proof — it only requires
@@ -3549,15 +3555,8 @@ where
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
+                &swap.vhtlc_address,
             )?;
-
-            if vhtlc.address() != swap.vhtlc_address {
-                tracing::warn!(
-                    swap_id = swap.id,
-                    "VHTLC address mismatch for reverse swap, skipping"
-                );
-                continue;
-            }
 
             // For reverse swaps, the user is the receiver (claim key).
             // Use claim_script as the intent proof — we need to sign with the receiver key.

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -552,9 +552,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -718,9 +716,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -831,9 +827,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -1436,9 +1430,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -1683,9 +1675,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -2104,9 +2094,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -2463,9 +2451,7 @@ where
                     unilateral_claim_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_claim as i64,
                     )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral claim timeout: {e}"))
-                    })?,
+                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
                     unilateral_refund_delay: parse_sequence_number(
                         timeout_block_heights.unilateral_refund as i64,
                     )
@@ -3400,18 +3386,17 @@ where
         timeout_block_heights: &TimeoutBlockHeights,
         expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        let unilateral_claim_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_claim as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_refund as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay = parse_sequence_number(
-            timeout_block_heights.unilateral_refund_without_receiver as i64,
-        )
-        .map_err(|e| Error::ad_hoc(format!("invalid refund without receiver timeout: {e}")))?;
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
 
         self.reconstruct_vhtlc_for_address(
             |server| {
@@ -3507,13 +3492,23 @@ where
                 continue;
             }
 
-            let vhtlc = self.build_vhtlc_script(
+            let vhtlc = match self.build_vhtlc_script(
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
                 &swap.vhtlc_address,
-            )?;
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        swap_id = swap.id,
+                        error = %e,
+                        "VHTLC reconstruction failed for submarine swap, skipping"
+                    );
+                    continue;
+                }
+            };
 
             // For submarine swaps, the user is the sender (refund key).
             // Use refund_without_receiver_script as the intent proof — it only requires
@@ -3550,13 +3545,23 @@ where
                 continue;
             }
 
-            let vhtlc = self.build_vhtlc_script(
+            let vhtlc = match self.build_vhtlc_script(
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,
                 &swap.timeout_block_heights,
                 &swap.vhtlc_address,
-            )?;
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        swap_id = swap.id,
+                        error = %e,
+                        "VHTLC reconstruction failed for reverse swap, skipping"
+                    );
+                    continue;
+                }
+            };
 
             // For reverse swaps, the user is the receiver (claim key).
             // Use claim_script as the intent proof — we need to sign with the receiver key.

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -540,12 +540,13 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -563,7 +564,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -580,7 +581,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -634,7 +635,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -708,12 +709,13 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -731,7 +733,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -748,7 +750,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut recoverable = vtxo_list.recoverable();
@@ -823,12 +825,13 @@ where
             .ok_or(Error::ad_hoc("submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -846,7 +849,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -863,7 +866,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -916,7 +919,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )?;
 
         // Sign the ark transaction with the sender's (user's) key.
@@ -1058,7 +1061,8 @@ where
             return Ok(());
         };
 
-        let server_signer: XOnlyPublicKey = self.server_info()?.signer_pk.into();
+        let server_info = self.server_info()?;
+        let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
         if recipient_address.server() != server_signer {
             return Err(Error::consumer(format!(
                 "recipient Arkade address belongs to a different server: expected {server_signer}, got {}",
@@ -1430,12 +1434,13 @@ where
         tracing::debug!(swap_id, "Claiming VHTLC with verified preimage");
 
         let timeout_block_heights = swap.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1453,7 +1458,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1472,7 +1477,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1522,7 +1527,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -1680,12 +1685,13 @@ where
         tracing::debug!("Ark transaction for swap found");
 
         let timeout_block_heights = swap.timeout_block_heights;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1703,7 +1709,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1722,7 +1728,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1772,7 +1778,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2101,12 +2107,13 @@ where
                  (this swap's server lockup is on-chain BTC, not an Ark VHTLC)"
             ))
         })?;
+        let server_info = self.server_info()?;
 
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.server_refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2124,7 +2131,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -2144,7 +2151,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             let vhtlc_outpoint = unspent.next().ok_or_else(|| {
@@ -2191,7 +2198,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2461,13 +2468,14 @@ where
         })?;
 
         let preimage_hash = ripemd160::Hash::hash(swap.preimage_hash.as_byte_array());
+        let server_info = self.server_info()?;
 
         // User's lockup VHTLC: sender=user(refund), receiver=server(claim)
         let vhtlc = VhtlcScript::new(
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.server_claim_public_key.into(),
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2485,7 +2493,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -2504,7 +2512,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             unspent
@@ -2553,7 +2561,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info()?,
+            &server_info,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -3390,11 +3398,12 @@ where
         preimage_hash: ripemd160::Hash,
         timeout_block_heights: &TimeoutBlockHeights,
     ) -> Result<VhtlcScript, Error> {
+        let server_info = self.server_info()?;
         VhtlcScript::new(
             VhtlcOptions {
                 sender: refund_public_key.inner.x_only_public_key().0,
                 receiver: claim_public_key.inner.x_only_public_key().0,
-                server: self.server_info()?.signer_pk.into(),
+                server: server_info.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -3412,7 +3421,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info()?.network,
+            server_info.network,
         )
         .map_err(Error::ad_hoc)
     }

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -541,6 +541,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -549,22 +561,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -705,6 +704,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -713,22 +724,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -816,6 +814,18 @@ where
 
         let timeout_block_heights = swap_data.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -824,22 +834,9 @@ where
                     server,
                     preimage_hash: swap_data.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap_data.vhtlc_address,
@@ -1419,6 +1416,18 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -1427,22 +1436,9 @@ where
                     server,
                     preimage_hash: swap.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap.vhtlc_address,
@@ -1664,6 +1660,18 @@ where
 
         let timeout_block_heights = swap.timeout_block_heights;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -1672,22 +1680,9 @@ where
                     server,
                     preimage_hash: swap.preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &swap.vhtlc_address,
@@ -2083,6 +2078,18 @@ where
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -2091,22 +2098,9 @@ where
                     server,
                     preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &expected_address,
@@ -2440,6 +2434,18 @@ where
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
+        let unilateral_claim_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
+        let unilateral_refund_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
+        let unilateral_refund_without_receiver_delay =
+            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
+                .map_err(|e| {
+                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
+                })?;
+
         let vhtlc = self.reconstruct_vhtlc_for_address(
             |server| {
                 Ok(VhtlcOptions {
@@ -2448,22 +2454,9 @@ where
                     server,
                     preimage_hash,
                     refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_claim as i64,
-                    )
-                    .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?,
-                    unilateral_refund_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid unilateral refund timeout: {e}"))
-                    })?,
-                    unilateral_refund_without_receiver_delay: parse_sequence_number(
-                        timeout_block_heights.unilateral_refund_without_receiver as i64,
-                    )
-                    .map_err(|e| {
-                        Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                    })?,
+                    unilateral_claim_delay,
+                    unilateral_refund_delay,
+                    unilateral_refund_without_receiver_delay,
                 })
             },
             &expected_address,

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -545,7 +545,7 @@ where
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -563,7 +563,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -580,7 +580,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -634,7 +634,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -713,7 +713,7 @@ where
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -731,7 +731,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -748,7 +748,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut recoverable = vtxo_list.recoverable();
@@ -828,7 +828,7 @@ where
             VhtlcOptions {
                 sender: swap_data.refund_public_key.into(),
                 receiver: swap_data.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash: swap_data.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -846,7 +846,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -863,7 +863,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -916,7 +916,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )?;
 
         // Sign the ark transaction with the sender's (user's) key.
@@ -1058,7 +1058,7 @@ where
             return Ok(());
         };
 
-        let server_signer: XOnlyPublicKey = self.server_info.signer_pk.into();
+        let server_signer: XOnlyPublicKey = self.server_info()?.signer_pk.into();
         if recipient_address.server() != server_signer {
             return Err(Error::consumer(format!(
                 "recipient Arkade address belongs to a different server: expected {server_signer}, got {}",
@@ -1435,7 +1435,7 @@ where
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1453,7 +1453,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1472,7 +1472,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1522,7 +1522,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -1685,7 +1685,7 @@ where
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash: swap.preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -1703,7 +1703,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -1722,7 +1722,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             // We expect a single outpoint.
             let mut unspent = vtxo_list.all_unspent();
@@ -1772,7 +1772,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2106,7 +2106,7 @@ where
             VhtlcOptions {
                 sender: swap.server_refund_public_key.into(),
                 receiver: swap.claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2124,7 +2124,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)
         .context("failed to build VHTLC script")?;
@@ -2144,7 +2144,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             let vhtlc_outpoint = unspent.next().ok_or_else(|| {
@@ -2191,7 +2191,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )
         .map_err(Error::from)
         .context("failed to build offchain TXs")?;
@@ -2467,7 +2467,7 @@ where
             VhtlcOptions {
                 sender: swap.refund_public_key.into(),
                 receiver: swap.server_claim_public_key.into(),
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -2485,7 +2485,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)?;
 
@@ -2504,7 +2504,7 @@ where
                 .get_virtual_tx_outpoints(std::iter::once(vhtlc_address))
                 .await?;
 
-            let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+            let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
             let mut unspent = vtxo_list.all_unspent();
             unspent
@@ -2553,7 +2553,7 @@ where
             &outputs,
             change_address,
             std::slice::from_ref(&vhtlc_input),
-            &self.server_info,
+            &self.server_info()?,
         )?;
 
         let kp = self.keypair_by_pk(&refunder_pk)?;
@@ -3394,7 +3394,7 @@ where
             VhtlcOptions {
                 sender: refund_public_key.inner.x_only_public_key().0,
                 receiver: claim_public_key.inner.x_only_public_key().0,
-                server: self.server_info.signer_pk.into(),
+                server: self.server_info()?.signer_pk.into(),
                 preimage_hash,
                 refund_locktime: timeout_block_heights.refund,
                 unilateral_claim_delay: parse_sequence_number(
@@ -3412,7 +3412,7 @@ where
                     Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
                 })?,
             },
-            self.server_info.network,
+            self.server_info()?.network,
         )
         .map_err(Error::ad_hoc)
     }

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -539,33 +539,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -702,33 +680,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -766,10 +722,10 @@ where
 
         let vhtlc_input = intent::Input::new(
             vhtlc_outpoint.outpoint,
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
+            parse_sequence_number(swap_data.timeout_block_heights.unilateral_refund as i64)
                 .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?,
             Some(absolute::LockTime::from_consensus(
-                timeout_block_heights.refund,
+                swap_data.timeout_block_heights.refund,
             )),
             TxOut {
                 value: refund_amount,
@@ -812,33 +768,11 @@ where
             .await?
             .ok_or(Error::ad_hoc("submarine swap not found"))?;
 
-        let timeout_block_heights = swap_data.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap_data.refund_public_key.into(),
-                    receiver: swap_data.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap_data.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap_data.claim_public_key,
+            swap_data.refund_public_key,
+            swap_data.preimage_hash,
+            &swap_data.timeout_block_heights,
             &swap_data.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -1414,33 +1348,11 @@ where
 
         tracing::debug!(swap_id, "Claiming VHTLC with verified preimage");
 
-        let timeout_block_heights = swap.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.refund_public_key,
+            swap.preimage_hash,
+            &swap.timeout_block_heights,
             &swap.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -1658,33 +1570,11 @@ where
 
         tracing::debug!("Ark transaction for swap found");
 
-        let timeout_block_heights = swap.timeout_block_heights;
-
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash: swap.preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.refund_public_key,
+            swap.preimage_hash,
+            &swap.timeout_block_heights,
             &swap.vhtlc_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -2078,31 +1968,11 @@ where
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.server_refund_public_key.into(),
-                    receiver: swap.claim_public_key.into(),
-                    server,
-                    preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.claim_public_key,
+            swap.server_refund_public_key,
+            preimage_hash,
+            &timeout_block_heights,
             &expected_address,
         )?;
         let vhtlc_address = vhtlc.address();
@@ -2434,31 +2304,11 @@ where
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
-        let unilateral_claim_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_claim as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral claim timeout: {e}")))?;
-        let unilateral_refund_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund as i64)
-                .map_err(|e| Error::ad_hoc(format!("invalid unilateral refund timeout: {e}")))?;
-        let unilateral_refund_without_receiver_delay =
-            parse_sequence_number(timeout_block_heights.unilateral_refund_without_receiver as i64)
-                .map_err(|e| {
-                    Error::ad_hoc(format!("invalid refund without receiver timeout: {e}"))
-                })?;
-
-        let vhtlc = self.reconstruct_vhtlc_for_address(
-            |server| {
-                Ok(VhtlcOptions {
-                    sender: swap.refund_public_key.into(),
-                    receiver: swap.server_claim_public_key.into(),
-                    server,
-                    preimage_hash,
-                    refund_locktime: timeout_block_heights.refund,
-                    unilateral_claim_delay,
-                    unilateral_refund_delay,
-                    unilateral_refund_without_receiver_delay,
-                })
-            },
+        let vhtlc = self.build_vhtlc_script(
+            swap.server_claim_public_key,
+            swap.refund_public_key,
+            preimage_hash,
+            &timeout_block_heights,
             &expected_address,
         )?;
         let vhtlc_address = vhtlc.address();

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -26,6 +26,8 @@ enum Kind {
     CoinSelect(CoinSelectError),
     /// An error related to actions within the wallet.
     Wallet(WalletError),
+    /// Ark server info changed while processing a request.
+    ServerInfoChanged(ServerInfoChangedError),
     /// An error thrown by a user of this library
     Consumer(ConsumerError),
 }
@@ -54,6 +56,9 @@ struct CoinSelectError {
 struct WalletError {
     source: Source,
 }
+
+#[derive(Debug)]
+struct ServerInfoChangedError;
 
 #[derive(Debug)]
 struct ConsumerError {
@@ -95,6 +100,25 @@ impl Error {
         Error::new(Kind::Consumer(ConsumerError {
             source: source.into(),
         }))
+    }
+
+    pub(crate) fn server_info_changed(source: impl Into<Error>) -> Self {
+        source
+            .into()
+            .context(Error::new(Kind::ServerInfoChanged(ServerInfoChangedError)))
+    }
+
+    pub fn is_server_info_changed(&self) -> bool {
+        let mut err = self;
+        loop {
+            if matches!(err.inner.kind, Kind::ServerInfoChanged(_)) {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
     }
 
     /// Returns `true` if this error chain contains an arkd digest mismatch.
@@ -177,6 +201,7 @@ impl fmt::Display for Kind {
             Kind::Core(ref err) => err.fmt(f),
             Kind::CoinSelect(ref err) => err.fmt(f),
             Kind::Wallet(ref err) => err.fmt(f),
+            Kind::ServerInfoChanged(ref err) => err.fmt(f),
             Kind::Consumer(ref err) => err.fmt(f),
         }
     }
@@ -209,6 +234,12 @@ impl fmt::Display for CoinSelectError {
 impl fmt::Display for WalletError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.source.fmt(f)
+    }
+}
+
+impl fmt::Display for ServerInfoChangedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe")
     }
 }
 

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -96,6 +96,62 @@ impl Error {
             source: source.into(),
         }))
     }
+
+    /// Returns `true` if this error chain contains an arkd digest mismatch.
+    pub fn is_digest_mismatch(&self) -> bool {
+        let mut err = self;
+        loop {
+            if err.inner.kind.is_digest_mismatch() {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
+    }
+
+    /// Returns `true` if this error chain contains an arkd build-version mismatch.
+    pub fn is_version_mismatch(&self) -> bool {
+        let mut err = self;
+        loop {
+            if err.inner.kind.is_version_mismatch() {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
+    }
+}
+
+impl Kind {
+    fn is_digest_mismatch(&self) -> bool {
+        match self {
+            Kind::ArkServer(err) => {
+                err.source.is::<ark_grpc::Error>()
+                    && err
+                        .source
+                        .downcast_ref::<ark_grpc::Error>()
+                        .is_some_and(ark_grpc::Error::is_digest_mismatch)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_version_mismatch(&self) -> bool {
+        match self {
+            Kind::ArkServer(err) => {
+                err.source.is::<ark_grpc::Error>()
+                    && err
+                        .source
+                        .downcast_ref::<ark_grpc::Error>()
+                        .is_some_and(ark_grpc::Error::is_version_mismatch)
+            }
+            _ => false,
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -160,7 +160,12 @@ impl Kind {
                         .downcast_ref::<ark_grpc::Error>()
                         .is_some_and(ark_grpc::Error::is_digest_mismatch)
             }
-            _ => false,
+            Kind::AdHoc(_)
+            | Kind::Core(_)
+            | Kind::CoinSelect(_)
+            | Kind::Wallet(_)
+            | Kind::ServerInfoChanged(_)
+            | Kind::Consumer(_) => false,
         }
     }
 
@@ -173,7 +178,12 @@ impl Kind {
                         .downcast_ref::<ark_grpc::Error>()
                         .is_some_and(ark_grpc::Error::is_version_mismatch)
             }
-            _ => false,
+            Kind::AdHoc(_)
+            | Kind::Core(_)
+            | Kind::CoinSelect(_)
+            | Kind::Wallet(_)
+            | Kind::ServerInfoChanged(_)
+            | Kind::Consumer(_) => false,
         }
     }
 }

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -361,7 +361,11 @@ where
 
 impl From<ark_grpc::Error> for Error {
     fn from(value: ark_grpc::Error) -> Self {
-        Self::ark_server(value)
+        if value.is_server_info_changed() {
+            Self::server_info_changed(Self::ark_server(value))
+        } else {
+            Self::ark_server(value)
+        }
     }
 }
 

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -58,8 +58,9 @@ where
     {
         let (change_address, _) = self.get_offchain_address()?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         let change_amount = total_amount.checked_sub(to_amount).ok_or_else(|| {
             Error::coin_select(format!(
@@ -126,8 +127,9 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs().await?;
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(super::unix_now())
+            .await?;
 
         tracing::info!(
             %to_address,

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -40,6 +40,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 
 pub mod error;
@@ -312,7 +313,11 @@ pub struct OfflineClient<B, W, S, K> {
 /// See [`OfflineClient`] docs for details.
 pub struct Client<B, W, S, K> {
     inner: OfflineClient<B, W, S, K>,
-    pub server_info: server::Info,
+    state: Arc<RwLock<ServerState>>,
+}
+
+struct ServerState {
+    server_info: server::Info,
     fee_estimator: ark_fees::Estimator,
 }
 
@@ -639,8 +644,10 @@ where
 
         let client = Client {
             inner: self,
-            server_info,
-            fee_estimator,
+            state: Arc::new(RwLock::new(ServerState {
+                server_info,
+                fee_estimator,
+            })),
         };
 
         if let Err(error) = client.discover_keys(DEFAULT_GAP_LIMIT).await {
@@ -666,6 +673,215 @@ fn build_fee_estimator(server_info: &server::Info) -> Result<ark_fees::Estimator
     ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)
 }
 
+#[derive(Clone)]
+pub struct GuardedNetworkClient {
+    inner: ark_grpc::Client,
+    state: Arc<RwLock<ServerState>>,
+}
+
+impl GuardedNetworkClient {
+    fn set_server_info(&self, server_info: server::Info) -> Result<(), Error> {
+        let fee_estimator = build_fee_estimator(&server_info)?;
+        let mut state = self
+            .state
+            .write()
+            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))?;
+        state.server_info = server_info;
+        state.fee_estimator = fee_estimator;
+        Ok(())
+    }
+
+    async fn guarded<T>(
+        &self,
+        op: impl Future<Output = Result<T, ark_grpc::Error>>,
+    ) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let original = Error::ark_server(err);
+                if let Err(refresh_err) = self.get_info_unguarded().await {
+                    return Err(refresh_err.context(Error::server_info_changed(original)));
+                }
+                Err(Error::server_info_changed(original))
+            }
+            Err(err) => Err(Error::ark_server(err)),
+        }
+    }
+
+    /// Bootstrap request that intentionally bypasses digest-mismatch guarding.
+    pub async fn get_info_unguarded(&self) -> Result<server::Info, Error> {
+        let mut inner = self.inner.clone();
+        let server_info = inner.get_info().await.map_err(Error::ark_server)?;
+        self.set_server_info(server_info.clone())?;
+        Ok(server_info)
+    }
+
+    pub async fn get_info(&self) -> Result<server::Info, Error> {
+        self.get_info_unguarded().await
+    }
+
+    pub async fn list_vtxos(
+        &self,
+        request: GetVtxosRequest,
+    ) -> Result<ark_grpc::ListVtxosResponse, Error> {
+        self.guarded(self.inner.list_vtxos(request)).await
+    }
+
+    pub async fn register_intent(&self, intent: ark_core::intent::Intent) -> Result<String, Error> {
+        self.guarded(self.inner.register_intent(intent)).await
+    }
+
+    pub async fn submit_offchain_transaction_request(
+        &self,
+        ark_tx: bitcoin::Psbt,
+        checkpoint_txs: Vec<bitcoin::Psbt>,
+    ) -> Result<server::SubmitOffchainTxResponse, Error> {
+        self.guarded(
+            self.inner
+                .submit_offchain_transaction_request(ark_tx, checkpoint_txs),
+        )
+        .await
+    }
+
+    pub async fn finalize_offchain_transaction(
+        &self,
+        txid: Txid,
+        checkpoint_txs: Vec<bitcoin::Psbt>,
+    ) -> Result<server::FinalizeOffchainTxResponse, Error> {
+        self.guarded(
+            self.inner
+                .finalize_offchain_transaction(txid, checkpoint_txs),
+        )
+        .await
+    }
+
+    pub async fn get_pending_tx(
+        &self,
+        intent: ark_core::intent::Intent,
+    ) -> Result<Vec<server::PendingTx>, Error> {
+        self.guarded(self.inner.get_pending_tx(intent)).await
+    }
+
+    pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
+        self.guarded(self.inner.confirm_registration(intent_id))
+            .await
+    }
+
+    pub async fn submit_tree_nonces(
+        &self,
+        batch_id: &str,
+        cosigner_pubkey: bitcoin::secp256k1::PublicKey,
+        pub_nonce_tree: server::NoncePks,
+    ) -> Result<(), Error> {
+        self.guarded(
+            self.inner
+                .submit_tree_nonces(batch_id, cosigner_pubkey, pub_nonce_tree),
+        )
+        .await
+    }
+
+    pub async fn submit_tree_signatures(
+        &self,
+        batch_id: &str,
+        cosigner_pk: bitcoin::secp256k1::PublicKey,
+        partial_sig_tree: server::PartialSigTree,
+    ) -> Result<(), Error> {
+        self.guarded(
+            self.inner
+                .submit_tree_signatures(batch_id, cosigner_pk, partial_sig_tree),
+        )
+        .await
+    }
+
+    pub async fn submit_signed_forfeit_txs(
+        &self,
+        signed_forfeit_txs: Vec<bitcoin::Psbt>,
+        signed_commitment_tx: Option<bitcoin::Psbt>,
+    ) -> Result<(), Error> {
+        self.guarded(
+            self.inner
+                .submit_signed_forfeit_txs(signed_forfeit_txs, signed_commitment_tx),
+        )
+        .await
+    }
+
+    pub async fn get_event_stream(
+        &self,
+        topics: Vec<String>,
+    ) -> Result<impl Stream<Item = Result<server::StreamEvent, ark_grpc::Error>> + Unpin, Error>
+    {
+        self.guarded(self.inner.get_event_stream(topics)).await
+    }
+
+    pub async fn get_tx_stream(
+        &self,
+    ) -> Result<
+        impl Stream<Item = Result<server::StreamTransactionData, ark_grpc::Error>> + Unpin,
+        Error,
+    > {
+        self.guarded(self.inner.get_tx_stream()).await
+    }
+
+    pub async fn get_vtxo_chain(
+        &self,
+        outpoint: Option<OutPoint>,
+        size_and_index: Option<(i32, i32)>,
+    ) -> Result<VtxoChainResponse, Error> {
+        self.guarded(self.inner.get_vtxo_chain(outpoint, size_and_index))
+            .await
+    }
+
+    pub async fn get_virtual_txs(
+        &self,
+        txids: Vec<String>,
+        size_and_index: Option<(i32, i32)>,
+    ) -> Result<server::VirtualTxsResponse, Error> {
+        self.guarded(self.inner.get_virtual_txs(txids, size_and_index))
+            .await
+    }
+
+    pub async fn subscribe_to_scripts(
+        &self,
+        scripts: Vec<ArkAddress>,
+        subscription_id: Option<String>,
+    ) -> Result<String, Error> {
+        self.guarded(self.inner.subscribe_to_scripts(scripts, subscription_id))
+            .await
+    }
+
+    pub async fn unsubscribe_from_scripts(
+        &self,
+        scripts: Vec<ArkAddress>,
+        subscription_id: String,
+    ) -> Result<(), Error> {
+        self.guarded(
+            self.inner
+                .unsubscribe_from_scripts(scripts, subscription_id),
+        )
+        .await
+    }
+
+    pub async fn get_subscription(
+        &self,
+        subscription_id: String,
+    ) -> Result<impl Stream<Item = Result<SubscriptionResponse, ark_grpc::Error>> + Unpin, Error>
+    {
+        self.guarded(self.inner.get_subscription(subscription_id))
+            .await
+    }
+
+    pub async fn estimate_fees(
+        &self,
+        intent: ark_core::intent::Intent,
+    ) -> Result<bitcoin::SignedAmount, Error> {
+        self.guarded(self.inner.estimate_fees(intent)).await
+    }
+
+    pub async fn get_asset(&self, asset_id: AssetId) -> Result<server::AssetInfo, Error> {
+        self.guarded(self.inner.get_asset(asset_id)).await
+    }
+}
+
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
@@ -673,18 +889,39 @@ where
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
+    /// Returns the latest cached Ark server info.
+    pub fn server_info(&self) -> Result<server::Info, Error> {
+        self.state
+            .read()
+            .map(|state| state.server_info.clone())
+            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
+    }
+
+    fn with_server_state<T>(&self, f: impl FnOnce(&ServerState) -> T) -> Result<T, Error> {
+        self.state
+            .read()
+            .map(|state| f(&state))
+            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
+    }
+
+    fn eval_onchain_output_fee(&self, output: ark_fees::Output) -> Result<Amount, Error> {
+        self.with_server_state(|state| state.fee_estimator.eval_onchain_output(output))?
+            .map(|fee| Amount::from_sat(fee.to_satoshis()))
+            .map_err(Error::ad_hoc)
+    }
+
     /// Refresh cached `/info` data after the server reports a digest mismatch.
     ///
-    /// This updates [`Client::server_info`], the gRPC digest header, and the fee estimator. The
-    /// SDK intentionally does not retry the failed operation automatically; rebuild the request
-    /// using the refreshed server info and retry only when it is safe for your call site.
-    pub async fn refresh_server_info(&mut self) -> Result<(), Error> {
-        let server_info = timeout_op(self.inner.timeout, self.network_client().get_info())
-            .await
-            .context("Failed to refresh Ark server info")??;
-
-        self.fee_estimator = build_fee_estimator(&server_info)?;
-        self.server_info = server_info;
+    /// This updates server info, the gRPC digest header, and the fee estimator. The SDK
+    /// intentionally does not retry the failed operation automatically; rebuild the request using
+    /// the refreshed server info and retry only when it is safe for your call site.
+    pub async fn refresh_server_info(&self) -> Result<(), Error> {
+        timeout_op(
+            self.inner.timeout,
+            self.network_client().get_info_unguarded(),
+        )
+        .await
+        .context("Failed to refresh Ark server info")??;
 
         Ok(())
     }
@@ -694,7 +931,7 @@ where
     /// Returns `true` when a refresh happened. The original operation is not retried; callers must
     /// rebuild any request state that depended on the old [`Client::server_info`] before retrying.
     pub async fn refresh_server_info_if_digest_mismatch(
-        &mut self,
+        &self,
         error: &Error,
     ) -> Result<bool, Error> {
         if !error.is_digest_mismatch() {
@@ -723,7 +960,7 @@ where
     /// For HD wallets, this will derive a new address each time it's called.
     /// For static key providers, this will always return the same address.
     pub fn get_offchain_address(&self) -> Result<(ArkAddress, Vtxo), Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let server_signer = server_info.signer_pk.into();
         let owner = self
@@ -745,7 +982,7 @@ where
     /// historical delegator keys are set via `historical_delegator_pks` passed to
     /// [`OfflineClient::new`], addresses for those are included too.
     pub fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         let server_signer = server_info.signer_pk.into();
 
         let pks = self.inner.key_provider.get_cached_pks()?;
@@ -791,7 +1028,7 @@ where
         server_signer: XOnlyPublicKey,
         owner: XOnlyPublicKey,
     ) -> Result<Vtxo, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         match self.inner.delegator_pk {
             Some(delegator) => Vtxo::new_with_delegator(
                 self.secp(),
@@ -829,7 +1066,7 @@ where
             return Ok(0);
         }
 
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
         let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
 
         let mut start_index = 0u32;
@@ -929,7 +1166,7 @@ where
 
     // At the moment we are always generating the same address.
     pub fn get_boarding_address(&self) -> Result<Address, Error> {
-        let server_info = &self.server_info;
+        let server_info = &self.server_info()?;
 
         let boarding_output = self.inner.wallet.new_boarding_output(
             server_info.signer_pk.into(),
@@ -982,7 +1219,7 @@ where
             .await
             .context("failed to get VTXOs for addresses")?;
 
-        let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
         Ok(vtxo_list)
     }
@@ -1014,7 +1251,7 @@ where
             })
             .collect();
 
-        let vtxo_list = VtxoList::new(self.server_info.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
 
         Ok((vtxo_list, script_pubkey_to_vtxo_map))
     }
@@ -1201,12 +1438,15 @@ where
     }
 
     /// The server's dust threshold amount.
-    pub fn dust(&self) -> Amount {
-        self.server_info.dust
+    pub fn dust(&self) -> Result<Amount, Error> {
+        Ok(self.server_info()?.dust)
     }
 
-    pub fn network_client(&self) -> ark_grpc::Client {
-        self.inner.network_client.clone()
+    pub fn network_client(&self) -> GuardedNetworkClient {
+        GuardedNetworkClient {
+            inner: self.inner.network_client.clone(),
+            state: self.state.clone(),
+        }
     }
 
     /// Fetch all VTXOs for a request, handling pagination internally.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1105,12 +1105,18 @@ where
     /// [`Self::migrate_deprecated_signer_vtxos`]. Detection (here) and migration (the watcher) are
     /// decoupled through the cached `server_info`, so no direct call between them is needed.
     pub async fn refresh_server_info(&self) -> Result<(), Error> {
-        timeout_op(
+        let server_info = timeout_op(
             self.inner.timeout,
             self.network_client().get_info_unguarded(),
         )
         .await
         .context("Failed to refresh Ark server info")??;
+
+        // `get_info_unguarded` already refreshed the gRPC digest header; mirror the freshly
+        // fetched snapshot into the cached server state so `server_info()` (and the fee estimator)
+        // reflect the new info — otherwise this method would update the digest but leave callers
+        // reading the stale `deprecated_signers`/fee data from connect time.
+        update_server_state(&self.state, server_info)?;
 
         Ok(())
     }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -92,6 +92,121 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// provide one. Identifies traffic originating from this SDK.
 pub const DEFAULT_BOLTZ_REFERRAL_ID: &str = "arkade-rs-SDK";
 
+/// Maximum number of inputs a single deprecated-signer migration leg will settle in one batch.
+///
+/// A client-side safeguard mirroring ts-sdk's `MAX_VTXOS_PER_SETTLEMENT`: it bounds the input
+/// count of one [`Client::migrate_deprecated_signer_vtxos`] leg so a wallet holding many small
+/// VTXOs does not build a batch intent that exceeds the server's transaction-weight limit. Any
+/// overflow is deferred to a later migration cycle (see [`MigrationLegReport::deferred`]).
+pub const MAX_VTXOS_PER_SETTLEMENT: usize = 50;
+
+/// A single VTXO or boarding output referenced in a [`DeprecatedSignerMigrationReport`].
+#[derive(Debug, Clone)]
+pub struct MigrationVtxoRef {
+    /// The input's outpoint.
+    pub outpoint: OutPoint,
+    /// The input's amount.
+    pub amount: Amount,
+    /// The deprecated signer the input was minted under.
+    pub signer_pk: XOnlyPublicKey,
+    /// The signer's advertised cooperative-sign cutoff (Unix seconds); `0` means "rotate now".
+    pub cutoff_date: i64,
+}
+
+/// Why a single migration leg ([`DeprecatedSignerMigrationReport::vtxo`] or
+/// [`DeprecatedSignerMigrationReport::boarding`]) settled nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationSkipReason {
+    /// The selected aggregate fell below the server's dust floor.
+    BelowDust,
+    /// Every migratable input in the leg individually exceeds the per-output ceiling
+    /// (`vtxo_max_amount`); none can migrate cooperatively, so the leg has only `oversized`
+    /// inputs and submitted nothing.
+    OversizedOnly,
+    /// The leg had no migratable inputs at all.
+    NothingMigratable,
+}
+
+/// Outcome of one [`Client::migrate_deprecated_signer_vtxos`] leg.
+///
+/// Each leg owns its full sizing pipeline and reports independently — a failure or skip in one leg
+/// never suppresses the other. The pipeline (mirroring ts-sdk's `runMigrationLeg`) is:
+///
+/// 1. inputs whose individual amount exceeds the server's per-output ceiling (`vtxo_max_amount`)
+///    are split out as [`Self::oversized`] — they can never form a `<= ceiling` output and must
+///    exit unilaterally;
+/// 2. the remainder is selected highest-value-first, bounded by both [`MAX_VTXOS_PER_SETTLEMENT`]
+///    and a running aggregate within the ceiling — the overflow lands in [`Self::deferred`] for a
+///    later cycle;
+/// 3. if the selected aggregate is below the dust floor, the leg is [`Self::skipped`] and nothing
+///    is submitted.
+#[derive(Debug, Clone)]
+pub struct MigrationLegReport {
+    /// The settlement TXID, when this leg submitted a batch. `None` on skip.
+    pub settle_txid: Option<Txid>,
+    /// Inputs submitted in this leg's settlement; empty on skip.
+    pub migrated: Vec<MigrationVtxoRef>,
+    /// Migratable inputs deferred to a later cycle by this leg's count or amount caps.
+    pub deferred: Vec<MigrationVtxoRef>,
+    /// Inputs whose value alone exceeds the per-output ceiling; they require a unilateral exit and
+    /// never migrate cooperatively.
+    pub oversized: Vec<MigrationVtxoRef>,
+    /// Why this leg submitted nothing; `None` when a settlement was attempted.
+    pub skipped: Option<MigrationSkipReason>,
+    /// The settlement error, if this leg's `settle_vtxos` call failed. Set independently of the
+    /// other leg — a failure here does not prevent the other leg from running.
+    pub error: Option<String>,
+}
+
+impl MigrationLegReport {
+    /// A leg that submitted nothing for the given reason.
+    fn skipped(reason: MigrationSkipReason) -> Self {
+        Self {
+            settle_txid: None,
+            migrated: Vec::new(),
+            deferred: Vec::new(),
+            oversized: Vec::new(),
+            skipped: Some(reason),
+            error: None,
+        }
+    }
+}
+
+/// Result of a [`Client::migrate_deprecated_signer_vtxos`] pass, split into two symmetric legs:
+/// a VTXO leg and a boarding leg. They are never combined into a single intent.
+#[derive(Debug, Clone)]
+pub struct DeprecatedSignerMigrationReport {
+    /// The VTXO migration leg.
+    pub vtxo: MigrationLegReport,
+    /// The boarding-output migration leg.
+    pub boarding: MigrationLegReport,
+}
+
+impl DeprecatedSignerMigrationReport {
+    /// A report where both legs found nothing to migrate (e.g. the server advertises no
+    /// deprecated signers, or the wallet holds no pre-cutoff deprecated-signer outputs).
+    fn nothing_migratable() -> Self {
+        Self {
+            vtxo: MigrationLegReport::skipped(MigrationSkipReason::NothingMigratable),
+            boarding: MigrationLegReport::skipped(MigrationSkipReason::NothingMigratable),
+        }
+    }
+
+    /// Whether the wallet was rotated off a deprecated signer this pass — i.e. at least one leg
+    /// submitted a settlement.
+    pub fn rotated(&self) -> bool {
+        self.vtxo.settle_txid.is_some() || self.boarding.settle_txid.is_some()
+    }
+
+    /// The settlement TXIDs produced this pass (at most one per leg).
+    pub fn settle_txids(&self) -> Vec<Txid> {
+        [self.vtxo.settle_txid, self.boarding.settle_txid]
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+}
+
 /// A client to interact with Ark Server
 ///
 /// ## Example
@@ -1190,71 +1305,241 @@ where
         })
     }
 
-    /// Sweep VTXOs and boarding outputs under deprecated server signers (before their cutoff)
-    /// to the current signer.
+    /// Sweep VTXOs and boarding outputs minted under a *pre-cutoff* deprecated server signer to
+    /// the current signer, then report what moved.
     ///
-    /// Internally this calls [`Self::settle`], which settles **all** unspent VTXOs and boarding
-    /// outputs in a single batch — not just the deprecated-signer ones. Current-signer VTXOs are
-    /// included too, which consolidates the wallet but does incur settlement fees on outputs that
-    /// would otherwise not need to move. Past-cutoff VTXOs and boarding outputs are excluded
-    /// automatically (the operator won't co-sign the old key) and become recoverable after expiry.
+    /// Only deprecated-signer, pre-cutoff inputs are touched — current-signer outputs are left
+    /// untouched (no consolidation, no incidental settlement fee), and past-cutoff outputs are
+    /// skipped automatically by [`Self::fetch_commitment_transaction_inputs`] (the operator won't
+    /// co-sign the old key, so they become recoverable after expiry and exit via the recovery
+    /// path).
     ///
-    /// Returns `None` when there are no migratable VTXOs or boarding outputs (nothing to do).
+    /// Migration runs as two **independent** legs — a VTXO leg and a boarding leg — each routed
+    /// through [`Self::settle_vtxos`] with its own scoped outpoint set. A failure in one leg does
+    /// not suppress the other. Before settling, each leg is sized against the server's per-output
+    /// ceiling (`vtxo_max_amount`) and dust floor (see [`MigrationLegReport`] for the exact
+    /// pipeline): inputs that individually exceed the ceiling are reported as `oversized` (they can
+    /// never form a `<= ceiling` output and must exit unilaterally — they are NOT silently
+    /// dropped); the remainder is selected highest-value-first up to [`MAX_VTXOS_PER_SETTLEMENT`]
+    /// and a running aggregate within the ceiling, deferring the rest to a later cycle; a leg whose
+    /// selected aggregate is below dust is skipped.
+    ///
+    /// When the server advertises no deprecated signers, returns an empty
+    /// [`MigrationSkipReason::NothingMigratable`] report without touching the wallet.
     pub async fn migrate_deprecated_signer_vtxos<R>(
         &self,
         rng: &mut R,
-    ) -> Result<Option<Txid>, Error>
+    ) -> Result<DeprecatedSignerMigrationReport, Error>
     where
         R: rand::Rng + rand::CryptoRng + Clone,
     {
-        // Snapshot the server info once so the empty-check, the per-output
-        // classification closure, and `settle_at` all see the same
-        // `deprecated_signers` set even if a concurrent digest-driven
-        // `refresh_server_info` swaps it mid-call.
+        // Snapshot the server info once (TOCTOU): the empty-check, the per-input
+        // classification closure, and the leg sizing must all see the same
+        // `deprecated_signers`/`vtxo_max_amount`/`dust` even if a concurrent digest-driven
+        // `refresh_server_info` swaps the snapshot mid-call.
         let server_info = self.server_info()?;
         if server_info.deprecated_signers.is_empty() {
-            return Ok(None);
+            return Ok(DeprecatedSignerMigrationReport::nothing_migratable());
         }
 
         let now = unix_now();
-        let (vtxo_list, script_map) = self.list_vtxos().await?;
 
-        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| {
-            server_info.deprecated_signers.iter().any(|ds| {
-                ds.pk.x_only_public_key().0 == server_pk
-                    && (ds.cutoff_date == 0 || ds.cutoff_date > now)
-            })
+        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| -> Option<i64> {
+            server_info
+                .deprecated_signers
+                .iter()
+                .find(|ds| {
+                    ds.pk.x_only_public_key().0 == server_pk
+                        && (ds.cutoff_date == 0 || ds.cutoff_date > now)
+                })
+                .map(|ds| ds.cutoff_date)
         };
 
-        let migratable_vtxos = vtxo_list.spendable_offchain().any(|v| {
-            script_map
-                .get(&v.script)
-                .map(|vtxo| is_pre_cutoff_deprecated(vtxo.server_pk()))
-                .unwrap_or(false)
-        });
+        // `fetch_commitment_transaction_inputs` already drops PAST-cutoff deprecated inputs (the
+        // operator won't co-sign the old key). We narrow further to the PRE-cutoff deprecated
+        // inputs, which is exactly the cooperatively-migratable set.
+        let (boarding_inputs, vtxo_inputs, _) =
+            self.fetch_commitment_transaction_inputs(now).await?;
 
-        let migratable_boarding = self
-            .inner
-            .wallet
-            .get_boarding_outputs()?
-            .into_iter()
-            .any(|bo| is_pre_cutoff_deprecated(bo.server_pk()));
+        // The VTXO inputs only expose their script pubkey, so resolve each one's signer via the
+        // script -> VTXO map (the same mapping `offchain_balance`/`settle_at` rely on).
+        let (_, script_map) = self.list_vtxos().await?;
 
-        if !migratable_vtxos && !migratable_boarding {
+        // Build the candidate (outpoint, amount, signer, cutoff) list for the VTXO leg.
+        let mut vtxo_candidates: Vec<MigrationVtxoRef> = Vec::new();
+        for input in &vtxo_inputs {
+            let Some(vtxo) = script_map.get(input.script_pubkey()) else {
+                tracing::debug!(
+                    outpoint = %input.outpoint(),
+                    "Skipping VTXO with no spend info during migration"
+                );
+                continue;
+            };
+            if let Some(cutoff_date) = is_pre_cutoff_deprecated(vtxo.server_pk()) {
+                vtxo_candidates.push(MigrationVtxoRef {
+                    outpoint: input.outpoint(),
+                    amount: input.amount(),
+                    signer_pk: vtxo.server_pk(),
+                    cutoff_date,
+                });
+            }
+        }
+
+        // Build the candidate list for the boarding leg.
+        let mut boarding_candidates: Vec<MigrationVtxoRef> = Vec::new();
+        for input in &boarding_inputs {
+            let signer_pk = input.boarding_output().server_pk();
+            if let Some(cutoff_date) = is_pre_cutoff_deprecated(signer_pk) {
+                boarding_candidates.push(MigrationVtxoRef {
+                    outpoint: input.outpoint(),
+                    amount: input.amount(),
+                    signer_pk,
+                    cutoff_date,
+                });
+            }
+        }
+
+        if vtxo_candidates.is_empty() && boarding_candidates.is_empty() {
             tracing::debug!("No migratable deprecated-signer VTXOs or boarding outputs found");
-            return Ok(None);
+            return Ok(DeprecatedSignerMigrationReport::nothing_migratable());
         }
 
         tracing::info!(
-            migratable_vtxos,
-            migratable_boarding,
-            "Found pre-cutoff deprecated-signer outputs; settling to current signer"
+            num_vtxos = vtxo_candidates.len(),
+            num_boarding = boarding_candidates.len(),
+            "Found pre-cutoff deprecated-signer outputs; migrating to current signer"
         );
 
-        // settle_at(now) uses the same timestamp as the pre-check above, so a VTXO that
-        // passes the migration gate cannot be silently excluded by a clock tick between
-        // the two evaluations.
-        self.settle_at(now, rng).await
+        let vtxo_max_amount = server_info.vtxo_max_amount;
+        let dust = server_info.dust;
+
+        // Run each leg independently so a failure in one does not suppress the other.
+        let vtxo_leg = self
+            .run_migration_leg(rng, vtxo_candidates, vtxo_max_amount, dust, true)
+            .await?;
+        let boarding_leg = self
+            .run_migration_leg(rng, boarding_candidates, vtxo_max_amount, dust, false)
+            .await?;
+
+        Ok(DeprecatedSignerMigrationReport {
+            vtxo: vtxo_leg,
+            boarding: boarding_leg,
+        })
+    }
+
+    /// Size a single migration leg against the server limits and settle the selected inputs.
+    ///
+    /// Mirrors ts-sdk's `runMigrationLeg`/`capSettlementBatch`. `is_vtxo_leg` selects which
+    /// argument of [`Self::settle_vtxos`] the chosen outpoints are passed in (VTXO vs boarding);
+    /// the other argument is empty so each leg is a distinct intent.
+    async fn run_migration_leg<R>(
+        &self,
+        rng: &mut R,
+        candidates: Vec<MigrationVtxoRef>,
+        vtxo_max_amount: Option<Amount>,
+        dust: Amount,
+        is_vtxo_leg: bool,
+    ) -> Result<MigrationLegReport, Error>
+    where
+        R: rand::Rng + rand::CryptoRng + Clone,
+    {
+        if candidates.is_empty() {
+            return Ok(MigrationLegReport::skipped(
+                MigrationSkipReason::NothingMigratable,
+            ));
+        }
+
+        // (1) Split out inputs whose INDIVIDUAL amount exceeds the per-output ceiling. They can
+        // never form a `<= ceiling` output, so they cannot migrate cooperatively and must exit
+        // unilaterally. Report them rather than dropping them. `None` ceiling => no limit.
+        let (oversized, mut sized): (Vec<_>, Vec<_>) = candidates
+            .into_iter()
+            .partition(|c| vtxo_max_amount.is_some_and(|max| c.amount > max));
+
+        if !oversized.is_empty() {
+            tracing::warn!(
+                count = oversized.len(),
+                ?vtxo_max_amount,
+                "Deprecated-signer migration: inputs exceed the per-output limit and cannot be \
+                 migrated cooperatively; they require a unilateral exit"
+            );
+        }
+
+        // (2) Select highest-value-first, bounded by both the count cap and a running aggregate
+        // within the ceiling. Skipped (not stopped) on an aggregate breach so a smaller input
+        // behind an oversized-but-sized one still gets in; the count cap is a hard stop. The rest
+        // is deferred to a later cycle.
+        sized.sort_by_key(|c| std::cmp::Reverse(c.amount));
+
+        let mut selected: Vec<MigrationVtxoRef> = Vec::new();
+        let mut deferred: Vec<MigrationVtxoRef> = Vec::new();
+        let mut aggregate = Amount::ZERO;
+        for candidate in sized {
+            if selected.len() >= MAX_VTXOS_PER_SETTLEMENT {
+                deferred.push(candidate);
+                continue;
+            }
+            let next = aggregate + candidate.amount;
+            if vtxo_max_amount.is_some_and(|max| next > max) {
+                deferred.push(candidate);
+                continue;
+            }
+            aggregate = next;
+            selected.push(candidate);
+        }
+
+        // (3) A migration output equals the gross sum of its inputs (migration is fee-exempt), so a
+        // selected aggregate below dust would be rejected — skip the leg.
+        if selected.is_empty() || aggregate < dust {
+            // Nothing got selected and the only candidates were oversized => OversizedOnly;
+            // otherwise the (sized) selection summed below dust.
+            let reason = if selected.is_empty() && !oversized.is_empty() {
+                MigrationSkipReason::OversizedOnly
+            } else {
+                MigrationSkipReason::BelowDust
+            };
+            return Ok(MigrationLegReport {
+                settle_txid: None,
+                migrated: Vec::new(),
+                deferred,
+                oversized,
+                skipped: Some(reason),
+                error: None,
+            });
+        }
+
+        let selected_outpoints: Vec<OutPoint> = selected.iter().map(|c| c.outpoint).collect();
+        let settle_result = if is_vtxo_leg {
+            self.settle_vtxos(rng, &selected_outpoints, &[]).await
+        } else {
+            self.settle_vtxos(rng, &[], &selected_outpoints).await
+        };
+
+        // Capture (rather than propagate) the settle error so the caller can still run the other
+        // leg — a failure in one leg must not suppress the other.
+        Ok(match settle_result {
+            Ok(settle_txid) => MigrationLegReport {
+                settle_txid,
+                migrated: selected,
+                deferred,
+                oversized,
+                skipped: None,
+                error: None,
+            },
+            Err(e) => {
+                tracing::warn!(error = %e, "Deprecated-signer migration leg failed to settle");
+                MigrationLegReport {
+                    settle_txid: None,
+                    migrated: Vec::new(),
+                    // The selected inputs did not move; surface them as deferred so a retry
+                    // re-attempts them.
+                    deferred: selected.into_iter().chain(deferred).collect(),
+                    oversized,
+                    skipped: None,
+                    error: Some(e.to_string()),
+                }
+            }
+        })
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1087,7 +1087,10 @@ where
 
         // Aggregate asset balances from spendable (non-past-cutoff) VTXOs only.
         let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
-        for vtxo in vtxo_list.spendable_offchain().filter(|v| !is_past_cutoff(v)) {
+        for vtxo in vtxo_list
+            .spendable_offchain()
+            .filter(|v| !is_past_cutoff(v))
+        {
             for asset in &vtxo.assets {
                 let total = asset_balances
                     .get(&asset.asset_id)

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1167,9 +1167,10 @@ where
             "Found pre-cutoff deprecated-signer outputs; settling to current signer"
         );
 
-        // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)
-        // and fetch_commitment_transaction_inputs() filters out past-cutoff ones automatically.
-        self.settle(rng).await
+        // settle_at(now) uses the same timestamp as the pre-check above, so a VTXO that
+        // passes the migration gate cannot be silently excluded by a clock tick between
+        // the two evaluations.
+        self.settle_at(now, rng).await
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -331,6 +331,21 @@ fn size_migration_leg(
     }
 }
 
+/// Whether the wallet holds any funds under a (deprecated) signer — spendable VTXOs, recoverable
+/// VTXOs, or boarding outputs — deciding whether the signer is surfaced by
+/// [`Client::deprecated_signer_status`].
+///
+/// Recoverable VTXOs must count: an expired signer whose VTXOs have all become recoverable
+/// (`spendable_count == 0`) still holds funds the user needs surfaced. Counting only spendable
+/// VTXOs would drop such a signer from the report and hide those funds.
+fn signer_holds_funds(
+    spendable_count: usize,
+    recoverable_count: usize,
+    boarding_count: usize,
+) -> bool {
+    spendable_count + recoverable_count + boarding_count > 0
+}
+
 /// Classify a deprecated signer from its advertised cutoff and the current time, returning the
 /// [`DeprecatedSignerStatus`] and `seconds_until_cutoff` hint.
 ///
@@ -1870,13 +1885,9 @@ where
             let vtxo_count = vtxo_agg.map(|a| a.spendable_count).unwrap_or(0);
             let vtxo_value = vtxo_agg.map(|a| a.spendable_value).unwrap_or(Amount::ZERO);
 
-            // Skip signers under which the wallet holds no funds at all. Count recoverable VTXOs
-            // too: an expired signer whose VTXOs are all recoverable (spendable_count == 0) still
-            // holds funds the user needs to see — dropping it would hide them from the report.
-            let has_any_vtxos = vtxo_agg
-                .map(|a| a.spendable_count + a.recoverable_count > 0)
-                .unwrap_or(false);
-            if !has_any_vtxos && boarding_count == 0 {
+            // Skip signers under which the wallet holds no funds at all.
+            let recoverable_vtxo_count = vtxo_agg.map(|a| a.recoverable_count).unwrap_or(0);
+            if !signer_holds_funds(vtxo_count, recoverable_vtxo_count, boarding_count) {
                 continue;
             }
 
@@ -2687,6 +2698,30 @@ mod migration_tests {
         let (status, secs) = classify_deprecated_signer(now - 1, now);
         assert_eq!(status, DeprecatedSignerStatus::Expired);
         assert_eq!(secs, None);
+    }
+
+    // ── deprecated_signer_status emptiness skip ──────────────────────────────
+
+    #[test]
+    fn signer_with_only_recoverable_vtxos_is_kept() {
+        // Regression for the report skip dropping an expired signer whose VTXOs are all
+        // recoverable (spendable_count == 0): those funds must still be surfaced.
+        assert!(signer_holds_funds(0, 3, 0));
+    }
+
+    #[test]
+    fn signer_with_only_spendable_vtxos_is_kept() {
+        assert!(signer_holds_funds(5, 0, 0));
+    }
+
+    #[test]
+    fn signer_with_only_boarding_is_kept() {
+        assert!(signer_holds_funds(0, 0, 2));
+    }
+
+    #[test]
+    fn signer_with_no_funds_is_dropped() {
+        assert!(!signer_holds_funds(0, 0, 0));
     }
 
     // ── empty-deprecated-signers short-circuit report ────────────────────────

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -223,6 +223,72 @@ impl DeprecatedSignerMigrationReport {
     }
 }
 
+/// Machine-readable status of a single deprecated server signer the wallet holds funds under.
+///
+/// Derived at read time by [`Client::deprecated_signer_status`] from the advertised
+/// `cutoff_date` and the current time; never persisted. Mirrors ts-sdk's `SignerStatus`
+/// (the non-`CURRENT`/`UNKNOWN_SIGNER` variants) and stays consistent with
+/// [`server::Info::is_signer_past_cutoff_at`]: a `cutoff_date` of `0` is "rotate immediately"
+/// (still co-signable now) and is therefore NOT treated as past-cutoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeprecatedSignerStatus {
+    /// The signer is deprecated with a future cutoff (`cutoff_date > now`). The operator still
+    /// co-signs, so these outputs are cooperatively migratable (see
+    /// [`Client::migrate_deprecated_signer_vtxos`]).
+    Migratable,
+    /// The signer is deprecated with no cutoff advertised (`cutoff_date == 0`): rotate
+    /// immediately. The operator still co-signs now, so these outputs are still cooperatively
+    /// migratable, but clients should migrate without delay.
+    DueNow,
+    /// The signer's cutoff has passed (`cutoff_date != 0 && cutoff_date <= now`). The operator
+    /// will no longer co-sign the old key — these funds cannot migrate cooperatively and instead
+    /// drain to the active signer via the recover-on-sweep path once they expire.
+    Expired,
+}
+
+/// Read-only, per-signer status of the deprecated server signers the wallet currently holds funds
+/// under. Produced by [`Client::deprecated_signer_status`]; mirrors ts-sdk's
+/// `DeprecatedSignerReport`.
+///
+/// This is observability only — building it never moves funds and never settles or migrates. The
+/// `recoverable_*` vs `awaiting_sweep_*` split and `next_sweep_eta` are only populated for
+/// [`DeprecatedSignerStatus::Expired`] signers (the post-cutoff recover-on-sweep lifecycle applies
+/// to VTXOs only).
+#[derive(Debug, Clone)]
+pub struct DeprecatedSignerReport {
+    /// The deprecated signer's x-only key.
+    pub signer_pk: XOnlyPublicKey,
+    /// The signer's status, derived from its cutoff and the current time.
+    pub status: DeprecatedSignerStatus,
+    /// The advertised cooperative-sign cutoff (Unix seconds); `0` means "rotate immediately".
+    pub cutoff_date: i64,
+    /// Seconds until the cutoff (`cutoff_date - now`); `None` when no future cutoff is advertised
+    /// (i.e. `cutoff_date == 0` or already passed).
+    pub seconds_until_cutoff: Option<i64>,
+    /// Number of spendable (non-recoverable) VTXOs the wallet holds under this signer.
+    pub vtxo_count: usize,
+    /// Total value of those spendable VTXOs.
+    pub vtxo_value: Amount,
+    /// Number of confirmed boarding UTXOs the wallet holds under this signer (includes those whose
+    /// own CSV exit window has elapsed — they leave via the unilateral sweep).
+    pub boarding_count: usize,
+    /// Total value of those boarding UTXOs.
+    pub boarding_value: Amount,
+    /// Expired-signer VTXOs already swept/expired and queued for recovery to the active signer.
+    /// Non-zero only on [`DeprecatedSignerStatus::Expired`] rows.
+    pub recoverable_count: usize,
+    /// Total value of the recoverable VTXOs.
+    pub recoverable_value: Amount,
+    /// Expired-signer VTXOs not yet swept; awaiting the server batch sweep before they become
+    /// recoverable. Non-zero only on [`DeprecatedSignerStatus::Expired`] rows.
+    pub awaiting_sweep_count: usize,
+    /// Total value of the awaiting-sweep VTXOs.
+    pub awaiting_sweep_value: Amount,
+    /// Soonest VTXO expiry (Unix seconds) among the awaiting-sweep set, as a recovery ETA hint.
+    /// `None` when there are no awaiting-sweep VTXOs under this signer.
+    pub next_sweep_eta: Option<i64>,
+}
+
 /// A client to interact with Ark Server
 ///
 /// ## Example
@@ -1532,6 +1598,175 @@ where
             vtxo: vtxo_leg,
             boarding: boarding_leg,
         })
+    }
+
+    /// Report the per-signer status of every deprecated server signer the wallet currently holds
+    /// funds under, without migrating anything.
+    ///
+    /// This is observability only — it never moves funds and never calls settle or migrate. It is
+    /// the read-only sibling of [`Self::migrate_deprecated_signer_vtxos`] and mirrors ts-sdk's
+    /// `getDeprecatedSignerStatus`. For each deprecated signer it merges the wallet's VTXO holdings
+    /// (resolved via the script -> VTXO map, like [`Self::offchain_balance`]) and its on-chain
+    /// boarding holdings (grouped by [`BoardingOutput::server_pk`]) into one
+    /// [`DeprecatedSignerReport`].
+    ///
+    /// Signers under which the wallet holds neither VTXOs nor boarding outputs are omitted (a row
+    /// per deprecated signer the wallet holds funds under, matching ts-sdk). When the server
+    /// advertises no deprecated signers, returns an empty vector without touching the chain.
+    ///
+    /// For [`DeprecatedSignerStatus::Expired`] signers the VTXOs are additionally split into the
+    /// already-swept/expired `recoverable_*` set and the not-yet-swept `awaiting_sweep_*` set, and
+    /// `next_sweep_eta` is the soonest VTXO expiry (`expires_at`) among the awaiting set.
+    pub async fn deprecated_signer_status(&self) -> Result<Vec<DeprecatedSignerReport>, Error> {
+        // Snapshot once (TOCTOU): the empty-check and every per-signer classification must see the
+        // same `deprecated_signers`/`dust` even if a concurrent refresh swaps the snapshot.
+        let server_info = self.server_info()?;
+        if server_info.deprecated_signers.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let now = unix_now();
+        let dust = server_info.dust;
+
+        // Aggregate VTXO holdings per signer in a single pass over all unspent VTXOs, resolving the
+        // signer via the script -> VTXO map (the same mapping `offchain_balance` relies on).
+        #[derive(Default)]
+        struct VtxoAgg {
+            // Spendable (non-recoverable) VTXOs.
+            spendable_count: usize,
+            spendable_value: Amount,
+            // Already-swept/expired VTXOs (only surfaced for past-cutoff signers).
+            recoverable_count: usize,
+            recoverable_value: Amount,
+            // Soonest expiry among the spendable (awaiting-sweep) VTXOs.
+            next_sweep_eta: Option<i64>,
+        }
+
+        let (vtxo_list, script_map) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let mut vtxo_aggs: HashMap<XOnlyPublicKey, VtxoAgg> = HashMap::new();
+        for v in vtxo_list.all_unspent() {
+            let Some(vtxo) = script_map.get(&v.script) else {
+                continue;
+            };
+            let agg = vtxo_aggs.entry(vtxo.server_pk()).or_default();
+            if v.is_recoverable(dust) {
+                agg.recoverable_count += 1;
+                agg.recoverable_value += v.amount;
+            } else {
+                agg.spendable_count += 1;
+                agg.spendable_value += v.amount;
+                agg.next_sweep_eta = Some(match agg.next_sweep_eta {
+                    Some(eta) => eta.min(v.expires_at),
+                    None => v.expires_at,
+                });
+            }
+        }
+
+        // Aggregate confirmed boarding holdings per signer. Mirrors the discovery in
+        // `fetch_commitment_transaction_inputs` (boarding outputs -> `find_outpoints`) but WITHOUT
+        // the cutoff/CSV-claimability filters: the report counts every confirmed, unspent boarding
+        // coin under a signer, including past-cutoff and CSV-expired ones (they still leave via the
+        // unilateral sweep).
+        let mut boarding_aggs: HashMap<XOnlyPublicKey, (usize, Amount)> = HashMap::new();
+        let mut seen_outpoints = HashSet::new();
+        for boarding_output in self.inner.wallet.get_boarding_outputs()? {
+            let outpoints = timeout_op(
+                self.inner.timeout,
+                self.blockchain().find_outpoints(boarding_output.address()),
+            )
+            .await
+            .context("failed to find boarding outpoints")??;
+
+            for o in outpoints.iter() {
+                if let ExplorerUtxo {
+                    outpoint,
+                    amount,
+                    confirmation_blocktime: Some(_),
+                    is_spent: false,
+                    ..
+                } = o
+                {
+                    if !seen_outpoints.insert(*outpoint) {
+                        continue;
+                    }
+                    let entry = boarding_aggs
+                        .entry(boarding_output.server_pk())
+                        .or_insert((0, Amount::ZERO));
+                    entry.0 += 1;
+                    entry.1 += *amount;
+                }
+            }
+        }
+
+        let mut reports = Vec::new();
+        for ds in &server_info.deprecated_signers {
+            let signer_pk = ds.pk.x_only_public_key().0;
+            let cutoff_date = ds.cutoff_date;
+
+            // Status + `seconds_until_cutoff`, consistent with `is_signer_past_cutoff_at` /
+            // `is_pre_cutoff_deprecated`: cutoff `0` = rotate-now (still co-signable); a future
+            // cutoff = migratable; a passed cutoff = expired.
+            let (status, seconds_until_cutoff) = if cutoff_date == 0 {
+                (DeprecatedSignerStatus::DueNow, None)
+            } else if cutoff_date > now {
+                (DeprecatedSignerStatus::Migratable, Some(cutoff_date - now))
+            } else {
+                (DeprecatedSignerStatus::Expired, None)
+            };
+
+            let vtxo_agg = vtxo_aggs.get(&signer_pk);
+            let (boarding_count, boarding_value) = boarding_aggs
+                .get(&signer_pk)
+                .copied()
+                .unwrap_or((0, Amount::ZERO));
+
+            let vtxo_count = vtxo_agg.map(|a| a.spendable_count).unwrap_or(0);
+            let vtxo_value = vtxo_agg.map(|a| a.spendable_value).unwrap_or(Amount::ZERO);
+
+            // Skip signers under which the wallet holds no funds at all.
+            if vtxo_count == 0 && boarding_count == 0 {
+                continue;
+            }
+
+            // The recover-on-sweep split applies to past-cutoff (expired) signers only; for still
+            // co-signable signers these stay zero / `None`.
+            let is_expired = status == DeprecatedSignerStatus::Expired;
+            let recoverable_count = vtxo_agg
+                .filter(|_| is_expired)
+                .map(|a| a.recoverable_count)
+                .unwrap_or(0);
+            let recoverable_value = vtxo_agg
+                .filter(|_| is_expired)
+                .map(|a| a.recoverable_value)
+                .unwrap_or(Amount::ZERO);
+            let (awaiting_sweep_count, awaiting_sweep_value, next_sweep_eta) = if is_expired {
+                (
+                    vtxo_count,
+                    vtxo_value,
+                    vtxo_agg.and_then(|a| a.next_sweep_eta),
+                )
+            } else {
+                (0, Amount::ZERO, None)
+            };
+
+            reports.push(DeprecatedSignerReport {
+                signer_pk,
+                status,
+                cutoff_date,
+                seconds_until_cutoff,
+                vtxo_count,
+                vtxo_value,
+                boarding_count,
+                boarding_value,
+                recoverable_count,
+                recoverable_value,
+                awaiting_sweep_count,
+                awaiting_sweep_value,
+                next_sweep_eta,
+            });
+        }
+
+        Ok(reports)
     }
 
     /// Size a single migration leg against the server limits and settle the selected inputs.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -966,6 +966,16 @@ where
     /// This updates server info, the gRPC digest header, and the fee estimator. The SDK
     /// intentionally does not retry the failed operation automatically; rebuild the request using
     /// the refreshed server info and retry only when it is safe for your call site.
+    ///
+    /// This is the "react" half of the digest-mismatch loop and the hinge that links detection to
+    /// background migration. A guarded mutating call (`ark_grpc::Client::guarded` /
+    /// `ark_rest::Client::guarded`) that hits a stale-digest error invokes its `info_refresh_hook`,
+    /// which drives this method; the refreshed snapshot includes the server's current
+    /// [`server::Info::deprecated_signers`]. The background watcher's migration arm (see
+    /// [`crate::vtxo_watcher::run_migration_arm`]) then observes those freshly advertised
+    /// deprecated signers on its next pass and rotates funds off them via
+    /// [`Self::migrate_deprecated_signer_vtxos`]. Detection (here) and migration (the watcher) are
+    /// decoupled through the cached `server_info`, so no direct call between them is needed.
     pub async fn refresh_server_info(&self) -> Result<(), Error> {
         timeout_op(
             self.inner.timeout,

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -2450,7 +2450,7 @@ mod digest_guard_tests {
         let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
 
         test_utils::GetInfoResponse {
-            version: "v0.9.8".to_string(),
+            version: "0.9.9".to_string(),
             signer_pubkey: public_key.to_string(),
             forfeit_pubkey: public_key.to_string(),
             forfeit_address: address.to_string(),

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -825,7 +825,9 @@ where
         }
 
         let server_info = &self.server_info;
-        let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
+        // Discover against current + all deprecated signers so that user keys used before a
+        // rotation are still found when recovering from seed.
+        let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
 
         let mut start_index = 0u32;
         let mut discovered_count = 0u32;
@@ -849,30 +851,31 @@ where
 
                 let owner_pk = kp.x_only_public_key().0;
 
-                let mut addresses =
-                    Vec::with_capacity(1 + self.inner.historical_delegator_pks.len());
+                let mut addresses = Vec::new();
 
-                // Default (2-leaf) address.
-                let default_vtxo = Vtxo::new_default(
-                    self.secp(),
-                    server_signer,
-                    owner_pk,
-                    server_info.unilateral_exit_delay,
-                    server_info.network,
-                )?;
-                addresses.push(default_vtxo.to_ark_address());
-
-                // Delegate (3-leaf) addresses for each known delegator.
-                for dpk in &self.inner.historical_delegator_pks {
-                    let delegate_vtxo = Vtxo::new_with_delegator(
+                for server_signer in &all_server_keys {
+                    // Default (2-leaf) address.
+                    let default_vtxo = Vtxo::new_default(
                         self.secp(),
-                        server_signer,
+                        *server_signer,
                         owner_pk,
-                        *dpk,
                         server_info.unilateral_exit_delay,
                         server_info.network,
                     )?;
-                    addresses.push(delegate_vtxo.to_ark_address());
+                    addresses.push(default_vtxo.to_ark_address());
+
+                    // Delegate (3-leaf) addresses for each known delegator.
+                    for dpk in &self.inner.historical_delegator_pks {
+                        let delegate_vtxo = Vtxo::new_with_delegator(
+                            self.secp(),
+                            *server_signer,
+                            owner_pk,
+                            *dpk,
+                            server_info.unilateral_exit_delay,
+                            server_info.network,
+                        )?;
+                        addresses.push(delegate_vtxo.to_ark_address());
+                    }
                 }
 
                 batch.push((index, kp, addresses));

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -223,6 +223,134 @@ impl DeprecatedSignerMigrationReport {
     }
 }
 
+/// Outcome of sizing one migration leg's candidate inputs against the server limits, before any
+/// settlement I/O. Produced by [`size_migration_leg`].
+#[derive(Debug, Clone)]
+struct MigrationLegSizing {
+    /// Inputs chosen to be settled this pass (highest-value-first within the caps).
+    selected: Vec<MigrationVtxoRef>,
+    /// Migratable inputs deferred to a later cycle by the count or aggregate caps.
+    deferred: Vec<MigrationVtxoRef>,
+    /// Inputs whose individual value exceeds the per-output ceiling; they can never form a
+    /// `<= ceiling` output and must exit unilaterally.
+    oversized: Vec<MigrationVtxoRef>,
+    /// Why nothing was selected, if so. `None` when [`Self::selected`] is non-empty and the leg
+    /// should proceed to settle.
+    skip_reason: Option<MigrationSkipReason>,
+}
+
+/// Size one migration leg's candidates against the per-output ceiling (`vtxo_max_amount`) and the
+/// dust floor, without performing any settlement.
+///
+/// This is the pure core of [`Client::run_migration_leg`], factored out so its branching (oversized
+/// split, count cap, running-aggregate ceiling, dust floor, and the skip-reason classification) is
+/// unit-testable without a `Client`/network. Mirrors ts-sdk's
+/// `runMigrationLeg`/`capSettlementBatch` selection. The pipeline is:
+///
+/// 1. inputs whose individual amount exceeds `vtxo_max_amount` are split out as `oversized` (a
+///    `None` ceiling means no limit, so nothing is oversized);
+/// 2. the remainder is selected highest-value-first, bounded by both [`MAX_VTXOS_PER_SETTLEMENT`]
+///    (a hard stop) and a running aggregate kept within the ceiling (a skip, so a smaller input
+///    behind a larger one can still get in); the overflow lands in `deferred`;
+/// 3. if nothing was selected, or the selected aggregate is below `dust`, `skip_reason` is set
+///    ([`MigrationSkipReason::OversizedOnly`] when the only candidates were oversized, else
+///    [`MigrationSkipReason::BelowDust`]); an empty candidate list yields
+///    [`MigrationSkipReason::NothingMigratable`].
+fn size_migration_leg(
+    candidates: Vec<MigrationVtxoRef>,
+    vtxo_max_amount: Option<Amount>,
+    dust: Amount,
+) -> MigrationLegSizing {
+    if candidates.is_empty() {
+        return MigrationLegSizing {
+            selected: Vec::new(),
+            deferred: Vec::new(),
+            oversized: Vec::new(),
+            skip_reason: Some(MigrationSkipReason::NothingMigratable),
+        };
+    }
+
+    // (1) Split out inputs whose INDIVIDUAL amount exceeds the per-output ceiling. They can
+    // never form a `<= ceiling` output, so they cannot migrate cooperatively and must exit
+    // unilaterally. Report them rather than dropping them. `None` ceiling => no limit.
+    let (oversized, mut sized): (Vec<_>, Vec<_>) = candidates
+        .into_iter()
+        .partition(|c| vtxo_max_amount.is_some_and(|max| c.amount > max));
+
+    if !oversized.is_empty() {
+        tracing::warn!(
+            count = oversized.len(),
+            ?vtxo_max_amount,
+            "Deprecated-signer migration: inputs exceed the per-output limit and cannot be \
+             migrated cooperatively; they require a unilateral exit"
+        );
+    }
+
+    // (2) Select highest-value-first, bounded by both the count cap and a running aggregate
+    // within the ceiling. Skipped (not stopped) on an aggregate breach so a smaller input
+    // behind an oversized-but-sized one still gets in; the count cap is a hard stop. The rest
+    // is deferred to a later cycle.
+    sized.sort_by_key(|c| std::cmp::Reverse(c.amount));
+
+    let mut selected: Vec<MigrationVtxoRef> = Vec::new();
+    let mut deferred: Vec<MigrationVtxoRef> = Vec::new();
+    let mut aggregate = Amount::ZERO;
+    for candidate in sized {
+        if selected.len() >= MAX_VTXOS_PER_SETTLEMENT {
+            deferred.push(candidate);
+            continue;
+        }
+        let next = aggregate + candidate.amount;
+        if vtxo_max_amount.is_some_and(|max| next > max) {
+            deferred.push(candidate);
+            continue;
+        }
+        aggregate = next;
+        selected.push(candidate);
+    }
+
+    // (3) A migration output equals the gross sum of its inputs (migration is fee-exempt), so a
+    // selected aggregate below dust would be rejected — skip the leg.
+    let skip_reason = if selected.is_empty() || aggregate < dust {
+        // Nothing got selected and the only candidates were oversized => OversizedOnly;
+        // otherwise the (sized) selection summed below dust.
+        if selected.is_empty() && !oversized.is_empty() {
+            Some(MigrationSkipReason::OversizedOnly)
+        } else {
+            Some(MigrationSkipReason::BelowDust)
+        }
+    } else {
+        None
+    };
+
+    MigrationLegSizing {
+        selected,
+        deferred,
+        oversized,
+        skip_reason,
+    }
+}
+
+/// Classify a deprecated signer from its advertised cutoff and the current time, returning the
+/// [`DeprecatedSignerStatus`] and `seconds_until_cutoff` hint.
+///
+/// Pure core of [`Client::deprecated_signer_status`], factored out so the classification is
+/// unit-testable without a `Client`/network. Consistent with
+/// [`server::Info::is_signer_past_cutoff_at`] and the `is_pre_cutoff_deprecated` check in
+/// [`Client::migrate_deprecated_signer_vtxos`]: a `cutoff_date` of `0` is "rotate now"
+/// ([`DeprecatedSignerStatus::DueNow`], still co-signable); a future cutoff is
+/// [`DeprecatedSignerStatus::Migratable`] (with a positive `seconds_until_cutoff`); a passed cutoff
+/// is [`DeprecatedSignerStatus::Expired`].
+fn classify_deprecated_signer(cutoff_date: i64, now: i64) -> (DeprecatedSignerStatus, Option<i64>) {
+    if cutoff_date == 0 {
+        (DeprecatedSignerStatus::DueNow, None)
+    } else if cutoff_date > now {
+        (DeprecatedSignerStatus::Migratable, Some(cutoff_date - now))
+    } else {
+        (DeprecatedSignerStatus::Expired, None)
+    }
+}
+
 /// Machine-readable status of a single deprecated server signer the wallet holds funds under.
 ///
 /// Derived at read time by [`Client::deprecated_signer_status`] from the advertised
@@ -1716,13 +1844,7 @@ where
             // Status + `seconds_until_cutoff`, consistent with `is_signer_past_cutoff_at` /
             // `is_pre_cutoff_deprecated`: cutoff `0` = rotate-now (still co-signable); a future
             // cutoff = migratable; a passed cutoff = expired.
-            let (status, seconds_until_cutoff) = if cutoff_date == 0 {
-                (DeprecatedSignerStatus::DueNow, None)
-            } else if cutoff_date > now {
-                (DeprecatedSignerStatus::Migratable, Some(cutoff_date - now))
-            } else {
-                (DeprecatedSignerStatus::Expired, None)
-            };
+            let (status, seconds_until_cutoff) = classify_deprecated_signer(cutoff_date, now);
 
             let vtxo_agg = vtxo_aggs.get(&signer_pk);
             let (boarding_count, boarding_value) = boarding_aggs
@@ -1795,61 +1917,17 @@ where
     where
         R: rand::Rng + rand::CryptoRng + Clone,
     {
-        if candidates.is_empty() {
-            return Ok(MigrationLegReport::skipped(
-                MigrationSkipReason::NothingMigratable,
-            ));
-        }
+        // Pure sizing (split oversized, cap count + aggregate, dust floor) is factored into
+        // `size_migration_leg` so it can be unit-tested without a `Client`/network. This leg only
+        // adds the I/O: settling the selected inputs and mapping the outcome onto a report.
+        let MigrationLegSizing {
+            selected,
+            deferred,
+            oversized,
+            skip_reason,
+        } = size_migration_leg(candidates, vtxo_max_amount, dust);
 
-        // (1) Split out inputs whose INDIVIDUAL amount exceeds the per-output ceiling. They can
-        // never form a `<= ceiling` output, so they cannot migrate cooperatively and must exit
-        // unilaterally. Report them rather than dropping them. `None` ceiling => no limit.
-        let (oversized, mut sized): (Vec<_>, Vec<_>) = candidates
-            .into_iter()
-            .partition(|c| vtxo_max_amount.is_some_and(|max| c.amount > max));
-
-        if !oversized.is_empty() {
-            tracing::warn!(
-                count = oversized.len(),
-                ?vtxo_max_amount,
-                "Deprecated-signer migration: inputs exceed the per-output limit and cannot be \
-                 migrated cooperatively; they require a unilateral exit"
-            );
-        }
-
-        // (2) Select highest-value-first, bounded by both the count cap and a running aggregate
-        // within the ceiling. Skipped (not stopped) on an aggregate breach so a smaller input
-        // behind an oversized-but-sized one still gets in; the count cap is a hard stop. The rest
-        // is deferred to a later cycle.
-        sized.sort_by_key(|c| std::cmp::Reverse(c.amount));
-
-        let mut selected: Vec<MigrationVtxoRef> = Vec::new();
-        let mut deferred: Vec<MigrationVtxoRef> = Vec::new();
-        let mut aggregate = Amount::ZERO;
-        for candidate in sized {
-            if selected.len() >= MAX_VTXOS_PER_SETTLEMENT {
-                deferred.push(candidate);
-                continue;
-            }
-            let next = aggregate + candidate.amount;
-            if vtxo_max_amount.is_some_and(|max| next > max) {
-                deferred.push(candidate);
-                continue;
-            }
-            aggregate = next;
-            selected.push(candidate);
-        }
-
-        // (3) A migration output equals the gross sum of its inputs (migration is fee-exempt), so a
-        // selected aggregate below dust would be rejected — skip the leg.
-        if selected.is_empty() || aggregate < dust {
-            // Nothing got selected and the only candidates were oversized => OversizedOnly;
-            // otherwise the (sized) selection summed below dust.
-            let reason = if selected.is_empty() && !oversized.is_empty() {
-                MigrationSkipReason::OversizedOnly
-            } else {
-                MigrationSkipReason::BelowDust
-            };
+        if let Some(reason) = skip_reason {
             return Ok(MigrationLegReport {
                 settle_txid: None,
                 migrated: Vec::new(),
@@ -2413,5 +2491,199 @@ mod digest_guard_tests {
             cached_state.read().unwrap().server_info.digest,
             "fresh-digest"
         );
+    }
+}
+
+/// Unit coverage for the pure deprecated-signer-migration logic: the per-leg sizing pipeline
+/// ([`size_migration_leg`]), the signer classification ([`classify_deprecated_signer`]), and the
+/// empty-`deprecated_signers` short-circuit report ([`DeprecatedSignerMigrationReport`]). These
+/// run without a `Client`/network — they exercise the same branching the regtest e2e tests cover
+/// end-to-end, mirroring ts-sdk's `runMigrationLeg`/`getDeprecatedSignerStatus` unit layer.
+#[cfg(test)]
+mod migration_tests {
+    use super::*;
+    use bitcoin::hashes::Hash;
+
+    /// A migratable candidate of the given amount. Each gets a distinct outpoint (via `vout`) so
+    /// selection order and counts are observable; the signer/cutoff are fixed placeholders the
+    /// sizing logic does not inspect.
+    fn candidate(vout: u32, amount: Amount) -> MigrationVtxoRef {
+        let secp = Secp256k1::new();
+        let sk = bitcoin::secp256k1::SecretKey::from_slice(&[7u8; 32]).unwrap();
+        let signer_pk = Keypair::from_secret_key(&secp, &sk).x_only_public_key().0;
+        MigrationVtxoRef {
+            outpoint: OutPoint::new(Txid::from_byte_array([0u8; 32]), vout),
+            amount,
+            signer_pk,
+            cutoff_date: 0,
+        }
+    }
+
+    fn sat(n: u64) -> Amount {
+        Amount::from_sat(n)
+    }
+
+    // ── size_migration_leg ───────────────────────────────────────────────────
+
+    #[test]
+    fn sizing_empty_candidates_is_nothing_migratable() {
+        let sizing = size_migration_leg(Vec::new(), Some(sat(1000)), sat(330));
+        assert!(sizing.selected.is_empty());
+        assert!(sizing.deferred.is_empty());
+        assert!(sizing.oversized.is_empty());
+        assert_eq!(
+            sizing.skip_reason,
+            Some(MigrationSkipReason::NothingMigratable)
+        );
+    }
+
+    #[test]
+    fn sizing_selects_all_when_within_limits() {
+        let candidates = vec![candidate(0, sat(500)), candidate(1, sat(400))];
+        let sizing = size_migration_leg(candidates, Some(sat(1000)), sat(330));
+        assert_eq!(sizing.selected.len(), 2);
+        assert!(sizing.deferred.is_empty());
+        assert!(sizing.oversized.is_empty());
+        assert_eq!(sizing.skip_reason, None);
+        // Highest-value-first ordering.
+        assert_eq!(sizing.selected[0].amount, sat(500));
+        assert_eq!(sizing.selected[1].amount, sat(400));
+    }
+
+    #[test]
+    fn sizing_caps_to_vtxo_max_deferring_the_rest() {
+        // Ceiling 1000: the 700 fits, the next 700 would push the aggregate to 1400 (> ceiling)
+        // so it is deferred, not stopped — a later 300 still fits under the running aggregate.
+        let candidates = vec![
+            candidate(0, sat(700)),
+            candidate(1, sat(700)),
+            candidate(2, sat(300)),
+        ];
+        let sizing = size_migration_leg(candidates, Some(sat(1000)), sat(330));
+        assert_eq!(sizing.selected.len(), 2);
+        let selected: Vec<_> = sizing.selected.iter().map(|c| c.amount).collect();
+        assert_eq!(selected, vec![sat(700), sat(300)]);
+        assert_eq!(sizing.deferred.len(), 1);
+        assert_eq!(sizing.deferred[0].amount, sat(700));
+        assert!(sizing.oversized.is_empty());
+        assert_eq!(sizing.skip_reason, None);
+    }
+
+    #[test]
+    fn sizing_splits_oversized_inputs() {
+        // 1500 alone exceeds the 1000 ceiling: it can never form a `<= ceiling` output, so it is
+        // reported as oversized (not dropped, not deferred). The 600 still migrates.
+        let candidates = vec![candidate(0, sat(1500)), candidate(1, sat(600))];
+        let sizing = size_migration_leg(candidates, Some(sat(1000)), sat(330));
+        assert_eq!(sizing.oversized.len(), 1);
+        assert_eq!(sizing.oversized[0].amount, sat(1500));
+        assert_eq!(sizing.selected.len(), 1);
+        assert_eq!(sizing.selected[0].amount, sat(600));
+        assert!(sizing.deferred.is_empty());
+        assert_eq!(sizing.skip_reason, None);
+    }
+
+    #[test]
+    fn sizing_oversized_only_when_all_exceed_ceiling() {
+        let candidates = vec![candidate(0, sat(1500)), candidate(1, sat(2000))];
+        let sizing = size_migration_leg(candidates, Some(sat(1000)), sat(330));
+        assert_eq!(sizing.oversized.len(), 2);
+        assert!(sizing.selected.is_empty());
+        assert!(sizing.deferred.is_empty());
+        assert_eq!(sizing.skip_reason, Some(MigrationSkipReason::OversizedOnly));
+    }
+
+    #[test]
+    fn sizing_skips_below_dust() {
+        // Selected aggregate (200) is below the dust floor (330): the leg is skipped as BelowDust
+        // (no oversized inputs involved). The candidate still satisfied the per-input and aggregate
+        // ceilings, so it remains in `selected`; `run_migration_leg` reads `selected` only when
+        // `skip_reason` is `None`, so a BelowDust leg settles nothing.
+        let candidates = vec![candidate(0, sat(200))];
+        let sizing = size_migration_leg(candidates, Some(sat(1000)), sat(330));
+        assert_eq!(sizing.skip_reason, Some(MigrationSkipReason::BelowDust));
+        assert!(sizing.oversized.is_empty());
+    }
+
+    #[test]
+    fn sizing_defers_beyond_count_cap() {
+        // One more candidate than the per-settlement count cap, each tiny so the aggregate ceiling
+        // never binds: exactly MAX_VTXOS_PER_SETTLEMENT are selected and the remainder is deferred.
+        let candidates: Vec<_> = (0..=MAX_VTXOS_PER_SETTLEMENT as u32)
+            .map(|i| candidate(i, sat(1)))
+            .collect();
+        // `None` ceiling => the aggregate cap does not apply; dust floor of 1 sat is met by the
+        // selected aggregate (MAX_VTXOS_PER_SETTLEMENT sats).
+        let sizing = size_migration_leg(candidates, None, sat(1));
+        assert_eq!(sizing.selected.len(), MAX_VTXOS_PER_SETTLEMENT);
+        assert_eq!(sizing.deferred.len(), 1);
+        assert!(sizing.oversized.is_empty());
+        assert_eq!(sizing.skip_reason, None);
+    }
+
+    #[test]
+    fn sizing_none_ceiling_means_no_oversized() {
+        // With no advertised ceiling, no input is ever oversized regardless of size.
+        let candidates = vec![candidate(0, sat(10_000_000)), candidate(1, sat(20_000_000))];
+        let sizing = size_migration_leg(candidates, None, sat(330));
+        assert!(sizing.oversized.is_empty());
+        assert_eq!(sizing.selected.len(), 2);
+        assert_eq!(sizing.skip_reason, None);
+    }
+
+    // ── classify_deprecated_signer ───────────────────────────────────────────
+
+    #[test]
+    fn classify_cutoff_zero_is_due_now() {
+        let (status, secs) = classify_deprecated_signer(0, 1_000_000);
+        assert_eq!(status, DeprecatedSignerStatus::DueNow);
+        assert_eq!(secs, None);
+    }
+
+    #[test]
+    fn classify_future_cutoff_is_migratable() {
+        let now = 1_000_000i64;
+        let (status, secs) = classify_deprecated_signer(now + 86_400, now);
+        assert_eq!(status, DeprecatedSignerStatus::Migratable);
+        assert_eq!(secs, Some(86_400));
+    }
+
+    #[test]
+    fn classify_exact_cutoff_boundary_is_expired() {
+        // cutoff_date <= now (and != 0) => expired. The boundary (cutoff == now) is past-cutoff,
+        // matching `server::Info::is_signer_past_cutoff_at`.
+        let now = 1_000_000i64;
+        let (status, secs) = classify_deprecated_signer(now, now);
+        assert_eq!(status, DeprecatedSignerStatus::Expired);
+        assert_eq!(secs, None);
+    }
+
+    #[test]
+    fn classify_past_cutoff_is_expired() {
+        let now = 1_000_000i64;
+        let (status, secs) = classify_deprecated_signer(now - 1, now);
+        assert_eq!(status, DeprecatedSignerStatus::Expired);
+        assert_eq!(secs, None);
+    }
+
+    // ── empty-deprecated-signers short-circuit report ────────────────────────
+
+    #[test]
+    fn nothing_migratable_report_is_not_rotated() {
+        // The report `migrate_deprecated_signer_vtxos` returns when the server advertises no
+        // deprecated signers: not rotated, no settle txids, both legs NothingMigratable.
+        let report = DeprecatedSignerMigrationReport::nothing_migratable();
+        assert!(!report.rotated());
+        assert!(report.settle_txids().is_empty());
+        assert_eq!(
+            report.vtxo.skipped,
+            Some(MigrationSkipReason::NothingMigratable)
+        );
+        assert_eq!(
+            report.boarding.skipped,
+            Some(MigrationSkipReason::NothingMigratable)
+        );
+        assert!(report.vtxo.migrated.is_empty());
+        assert!(report.boarding.migrated.is_empty());
     }
 }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1114,10 +1114,11 @@ where
     /// Sweep VTXOs and boarding outputs under deprecated server signers (before their cutoff)
     /// to the current signer.
     ///
-    /// This joins the next available batch and settles all inputs — current-signer and
-    /// pre-cutoff deprecated-signer alike — to a fresh current-signer address. Past-cutoff
-    /// VTXOs and boarding outputs are excluded from the batch automatically (the operator
-    /// won't co-sign the old key) and will become recoverable after expiry.
+    /// Internally this calls [`Self::settle`], which settles **all** unspent VTXOs and boarding
+    /// outputs in a single batch — not just the deprecated-signer ones. Current-signer VTXOs are
+    /// included too, which consolidates the wallet but does incur settlement fees on outputs that
+    /// would otherwise not need to move. Past-cutoff VTXOs and boarding outputs are excluded
+    /// automatically (the operator won't co-sign the old key) and become recoverable after expiry.
     ///
     /// Returns `None` when there are no migratable VTXOs or boarding outputs (nothing to do).
     pub async fn migrate_deprecated_signer_vtxos<R>(

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -641,14 +641,18 @@ where
         );
 
         let fee_estimator = build_fee_estimator(&server_info)?;
+        let state = Arc::new(RwLock::new(ServerState {
+            server_info,
+            fee_estimator,
+        }));
+        let hook_state = state.clone();
+        self.network_client
+            .set_info_refresh_hook(move |server_info| {
+                update_server_state(&hook_state, server_info)
+                    .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
+            });
 
-        let client = Client {
-            inner: self,
-            state: Arc::new(RwLock::new(ServerState {
-                server_info,
-                fee_estimator,
-            })),
-        };
+        let client = Client { inner: self, state };
 
         if let Err(error) = client.discover_keys(DEFAULT_GAP_LIMIT).await {
             tracing::warn!(?error, "Failed during key discovery");
@@ -673,213 +677,17 @@ fn build_fee_estimator(server_info: &server::Info) -> Result<ark_fees::Estimator
     ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)
 }
 
-#[derive(Clone)]
-pub struct GuardedNetworkClient {
-    inner: ark_grpc::Client,
-    state: Arc<RwLock<ServerState>>,
-}
-
-impl GuardedNetworkClient {
-    fn set_server_info(&self, server_info: server::Info) -> Result<(), Error> {
-        let fee_estimator = build_fee_estimator(&server_info)?;
-        let mut state = self
-            .state
-            .write()
-            .map_err(|_| Error::ad_hoc("client server state lock poisoned"))?;
-        state.server_info = server_info;
-        state.fee_estimator = fee_estimator;
-        Ok(())
-    }
-
-    async fn guarded<T>(
-        &self,
-        op: impl Future<Output = Result<T, ark_grpc::Error>>,
-    ) -> Result<T, Error> {
-        match op.await {
-            Ok(value) => Ok(value),
-            Err(err) if err.is_digest_mismatch() => {
-                let original = Error::ark_server(err);
-                if let Err(refresh_err) = self.get_info_unguarded().await {
-                    return Err(refresh_err.context(Error::server_info_changed(original)));
-                }
-                Err(Error::server_info_changed(original))
-            }
-            Err(err) => Err(Error::ark_server(err)),
-        }
-    }
-
-    /// Bootstrap request that intentionally bypasses digest-mismatch guarding.
-    pub async fn get_info_unguarded(&self) -> Result<server::Info, Error> {
-        let mut inner = self.inner.clone();
-        let server_info = inner.get_info().await.map_err(Error::ark_server)?;
-        self.set_server_info(server_info.clone())?;
-        Ok(server_info)
-    }
-
-    pub async fn get_info(&self) -> Result<server::Info, Error> {
-        self.get_info_unguarded().await
-    }
-
-    pub async fn list_vtxos(
-        &self,
-        request: GetVtxosRequest,
-    ) -> Result<ark_grpc::ListVtxosResponse, Error> {
-        self.guarded(self.inner.list_vtxos(request)).await
-    }
-
-    pub async fn register_intent(&self, intent: ark_core::intent::Intent) -> Result<String, Error> {
-        self.guarded(self.inner.register_intent(intent)).await
-    }
-
-    pub async fn submit_offchain_transaction_request(
-        &self,
-        ark_tx: bitcoin::Psbt,
-        checkpoint_txs: Vec<bitcoin::Psbt>,
-    ) -> Result<server::SubmitOffchainTxResponse, Error> {
-        self.guarded(
-            self.inner
-                .submit_offchain_transaction_request(ark_tx, checkpoint_txs),
-        )
-        .await
-    }
-
-    pub async fn finalize_offchain_transaction(
-        &self,
-        txid: Txid,
-        checkpoint_txs: Vec<bitcoin::Psbt>,
-    ) -> Result<server::FinalizeOffchainTxResponse, Error> {
-        self.guarded(
-            self.inner
-                .finalize_offchain_transaction(txid, checkpoint_txs),
-        )
-        .await
-    }
-
-    pub async fn get_pending_tx(
-        &self,
-        intent: ark_core::intent::Intent,
-    ) -> Result<Vec<server::PendingTx>, Error> {
-        self.guarded(self.inner.get_pending_tx(intent)).await
-    }
-
-    pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
-        self.guarded(self.inner.confirm_registration(intent_id))
-            .await
-    }
-
-    pub async fn submit_tree_nonces(
-        &self,
-        batch_id: &str,
-        cosigner_pubkey: bitcoin::secp256k1::PublicKey,
-        pub_nonce_tree: server::NoncePks,
-    ) -> Result<(), Error> {
-        self.guarded(
-            self.inner
-                .submit_tree_nonces(batch_id, cosigner_pubkey, pub_nonce_tree),
-        )
-        .await
-    }
-
-    pub async fn submit_tree_signatures(
-        &self,
-        batch_id: &str,
-        cosigner_pk: bitcoin::secp256k1::PublicKey,
-        partial_sig_tree: server::PartialSigTree,
-    ) -> Result<(), Error> {
-        self.guarded(
-            self.inner
-                .submit_tree_signatures(batch_id, cosigner_pk, partial_sig_tree),
-        )
-        .await
-    }
-
-    pub async fn submit_signed_forfeit_txs(
-        &self,
-        signed_forfeit_txs: Vec<bitcoin::Psbt>,
-        signed_commitment_tx: Option<bitcoin::Psbt>,
-    ) -> Result<(), Error> {
-        self.guarded(
-            self.inner
-                .submit_signed_forfeit_txs(signed_forfeit_txs, signed_commitment_tx),
-        )
-        .await
-    }
-
-    pub async fn get_event_stream(
-        &self,
-        topics: Vec<String>,
-    ) -> Result<impl Stream<Item = Result<server::StreamEvent, ark_grpc::Error>> + Unpin, Error>
-    {
-        self.guarded(self.inner.get_event_stream(topics)).await
-    }
-
-    pub async fn get_tx_stream(
-        &self,
-    ) -> Result<
-        impl Stream<Item = Result<server::StreamTransactionData, ark_grpc::Error>> + Unpin,
-        Error,
-    > {
-        self.guarded(self.inner.get_tx_stream()).await
-    }
-
-    pub async fn get_vtxo_chain(
-        &self,
-        outpoint: Option<OutPoint>,
-        size_and_index: Option<(i32, i32)>,
-    ) -> Result<VtxoChainResponse, Error> {
-        self.guarded(self.inner.get_vtxo_chain(outpoint, size_and_index))
-            .await
-    }
-
-    pub async fn get_virtual_txs(
-        &self,
-        txids: Vec<String>,
-        size_and_index: Option<(i32, i32)>,
-    ) -> Result<server::VirtualTxsResponse, Error> {
-        self.guarded(self.inner.get_virtual_txs(txids, size_and_index))
-            .await
-    }
-
-    pub async fn subscribe_to_scripts(
-        &self,
-        scripts: Vec<ArkAddress>,
-        subscription_id: Option<String>,
-    ) -> Result<String, Error> {
-        self.guarded(self.inner.subscribe_to_scripts(scripts, subscription_id))
-            .await
-    }
-
-    pub async fn unsubscribe_from_scripts(
-        &self,
-        scripts: Vec<ArkAddress>,
-        subscription_id: String,
-    ) -> Result<(), Error> {
-        self.guarded(
-            self.inner
-                .unsubscribe_from_scripts(scripts, subscription_id),
-        )
-        .await
-    }
-
-    pub async fn get_subscription(
-        &self,
-        subscription_id: String,
-    ) -> Result<impl Stream<Item = Result<SubscriptionResponse, ark_grpc::Error>> + Unpin, Error>
-    {
-        self.guarded(self.inner.get_subscription(subscription_id))
-            .await
-    }
-
-    pub async fn estimate_fees(
-        &self,
-        intent: ark_core::intent::Intent,
-    ) -> Result<bitcoin::SignedAmount, Error> {
-        self.guarded(self.inner.estimate_fees(intent)).await
-    }
-
-    pub async fn get_asset(&self, asset_id: AssetId) -> Result<server::AssetInfo, Error> {
-        self.guarded(self.inner.get_asset(asset_id)).await
-    }
+fn update_server_state(
+    state: &Arc<RwLock<ServerState>>,
+    server_info: server::Info,
+) -> Result<(), Error> {
+    let fee_estimator = build_fee_estimator(&server_info)?;
+    let mut state = state
+        .write()
+        .map_err(|_| Error::ad_hoc("client server state lock poisoned"))?;
+    state.server_info = server_info;
+    state.fee_estimator = fee_estimator;
+    Ok(())
 }
 
 impl<B, W, S, K> Client<B, W, S, K>
@@ -1442,11 +1250,8 @@ where
         Ok(self.server_info()?.dust)
     }
 
-    pub fn network_client(&self) -> GuardedNetworkClient {
-        GuardedNetworkClient {
-            inner: self.inner.network_client.clone(),
-            state: self.state.clone(),
-        }
+    pub fn network_client(&self) -> ark_grpc::Client {
+        self.inner.network_client.clone()
     }
 
     /// Fetch all VTXOs for a request, handling pagination internally.
@@ -1803,18 +1608,18 @@ mod digest_guard_tests {
         inner.connect().await.unwrap();
 
         let initial_info: server::Info = info_response("stale-digest").try_into().unwrap();
-        let guarded = GuardedNetworkClient {
-            inner,
-            state: Arc::new(RwLock::new(ServerState {
-                server_info: initial_info,
-                fee_estimator: build_fee_estimator(
-                    &info_response("stale-digest").try_into().unwrap(),
-                )
+        let cached_state = Arc::new(RwLock::new(ServerState {
+            server_info: initial_info,
+            fee_estimator: build_fee_estimator(&info_response("stale-digest").try_into().unwrap())
                 .unwrap(),
-            })),
-        };
+        }));
+        let hook_state = cached_state.clone();
+        inner.set_info_refresh_hook(move |server_info| {
+            update_server_state(&hook_state, server_info)
+                .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
+        });
 
-        let err = match guarded
+        let err = match inner
             .list_vtxos(GetVtxosRequest::new_for_outpoints(&[OutPoint::null()]))
             .await
         {
@@ -1823,10 +1628,11 @@ mod digest_guard_tests {
         };
 
         assert!(err.is_server_info_changed());
+        assert!(Error::from(err).is_server_info_changed());
         assert_eq!(state.list_vtxos_calls.load(Ordering::SeqCst), 1);
         assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
         assert_eq!(
-            guarded.state.read().unwrap().server_info.digest,
+            cached_state.read().unwrap().server_info.digest,
             "fresh-digest"
         );
     }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1609,3 +1609,225 @@ where
             .map_err(Into::into)
     }
 }
+
+#[cfg(test)]
+mod digest_guard_tests {
+    use super::*;
+    use ark_grpc::test_utils;
+    use bitcoin::key::Secp256k1;
+    use bitcoin::secp256k1::SecretKey;
+    use bitcoin::Address;
+    use std::convert::Infallible;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
+    use tokio::net::TcpListener;
+    use tonic::body::Body;
+    use tonic::codegen::http;
+    use tonic::codegen::Service;
+    use tonic::server::NamedService;
+    use tonic::server::UnaryService;
+
+    #[derive(Clone, Default)]
+    struct MockArkServer {
+        state: Arc<MockState>,
+    }
+
+    #[derive(Default)]
+    struct MockState {
+        get_info_calls: AtomicUsize,
+        list_vtxos_calls: AtomicUsize,
+    }
+
+    impl Service<http::Request<Body>> for MockArkServer {
+        type Response = http::Response<Body>;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+            match req.uri().path() {
+                "/ark.v1.ArkService/GetInfo" => {
+                    let method = GetInfoSvc {
+                        state: self.state.clone(),
+                    };
+                    Box::pin(async move {
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec);
+                        Ok(grpc.unary(method, req).await)
+                    })
+                }
+                "/ark.v1.IndexerService/GetVtxos" => {
+                    let method = ListVtxosSvc {
+                        state: self.state.clone(),
+                    };
+                    Box::pin(async move {
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec);
+                        Ok(grpc.unary(method, req).await)
+                    })
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(Body::empty())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+
+    impl NamedService for MockArkServer {
+        const NAME: &'static str = "ark.v1.ArkService";
+    }
+
+    #[derive(Clone)]
+    struct MockIndexerServer(MockArkServer);
+
+    impl Service<http::Request<Body>> for MockIndexerServer {
+        type Response = http::Response<Body>;
+        type Error = Infallible;
+        type Future = <MockArkServer as Service<http::Request<Body>>>::Future;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.0.poll_ready(cx)
+        }
+
+        fn call(&mut self, req: http::Request<Body>) -> Self::Future {
+            self.0.call(req)
+        }
+    }
+
+    impl NamedService for MockIndexerServer {
+        const NAME: &'static str = "ark.v1.IndexerService";
+    }
+
+    #[derive(Clone)]
+    struct GetInfoSvc {
+        state: Arc<MockState>,
+    }
+
+    impl UnaryService<test_utils::GetInfoRequest> for GetInfoSvc {
+        type Response = test_utils::GetInfoResponse;
+        type Future = Pin<
+            Box<dyn Future<Output = Result<tonic::Response<Self::Response>, tonic::Status>> + Send>,
+        >;
+
+        fn call(&mut self, _request: tonic::Request<test_utils::GetInfoRequest>) -> Self::Future {
+            self.state.get_info_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(tonic::Response::new(info_response("fresh-digest"))) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct ListVtxosSvc {
+        state: Arc<MockState>,
+    }
+
+    impl UnaryService<test_utils::GetVtxosRequest> for ListVtxosSvc {
+        type Response = test_utils::GetVtxosResponse;
+        type Future = Pin<
+            Box<dyn Future<Output = Result<tonic::Response<Self::Response>, tonic::Status>> + Send>,
+        >;
+
+        fn call(&mut self, _request: tonic::Request<test_utils::GetVtxosRequest>) -> Self::Future {
+            self.state.list_vtxos_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Err(tonic::Status::failed_precondition(
+                    "DIGEST_MISMATCH: invalid digest header",
+                ))
+            })
+        }
+    }
+
+    fn info_response(digest: &str) -> test_utils::GetInfoResponse {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(&[1; 32]).unwrap();
+        let keypair = Keypair::from_secret_key(&secp, &secret_key);
+        let public_key = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+        let (xonly, _) = keypair.x_only_public_key();
+        let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
+
+        test_utils::GetInfoResponse {
+            version: "v0.9.8".to_string(),
+            signer_pubkey: public_key.to_string(),
+            forfeit_pubkey: public_key.to_string(),
+            forfeit_address: address.to_string(),
+            checkpoint_tapscript: String::new(),
+            network: "regtest".to_string(),
+            session_duration: 60,
+            unilateral_exit_delay: 144,
+            boarding_exit_delay: 144,
+            utxo_min_amount: 0,
+            utxo_max_amount: 0,
+            vtxo_min_amount: 0,
+            vtxo_max_amount: 0,
+            dust: 1000,
+            fees: None,
+            scheduled_session: None,
+            deprecated_signers: Vec::new(),
+            service_status: Default::default(),
+            digest: digest.to_string(),
+            max_tx_weight: 0,
+            max_op_return_outputs: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn guarded_client_refreshes_info_and_does_not_retry_on_digest_mismatch() {
+        let mock = MockArkServer::default();
+        let state = mock.state.clone();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+
+        let indexer_mock = MockIndexerServer(mock.clone());
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(mock)
+                .add_service(indexer_mock)
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        let mut inner = ark_grpc::Client::new(format!("http://{addr}"));
+        inner.connect().await.unwrap();
+
+        let initial_info: server::Info = info_response("stale-digest").try_into().unwrap();
+        let guarded = GuardedNetworkClient {
+            inner,
+            state: Arc::new(RwLock::new(ServerState {
+                server_info: initial_info,
+                fee_estimator: build_fee_estimator(
+                    &info_response("stale-digest").try_into().unwrap(),
+                )
+                .unwrap(),
+            })),
+        };
+
+        let err = match guarded
+            .list_vtxos(GetVtxosRequest::new_for_outpoints(&[OutPoint::null()]))
+            .await
+        {
+            Ok(_) => panic!("list_vtxos unexpectedly succeeded"),
+            Err(err) => err,
+        };
+
+        assert!(err.is_server_info_changed());
+        assert_eq!(state.list_vtxos_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            guarded.state.read().unwrap().server_info.digest,
+            "fresh-digest"
+        );
+    }
+}

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -16,6 +16,7 @@ use ark_core::server::GetVtxosRequest;
 use ark_core::server::SubscriptionResponse;
 use ark_core::server::VirtualTxOutPoint;
 use ark_core::ArkAddress;
+use ark_core::BoardingOutput;
 use ark_core::ExplorerUtxo;
 use ark_core::UtxoCoinSelection;
 use ark_core::Vtxo;
@@ -99,6 +100,21 @@ pub const DEFAULT_BOLTZ_REFERRAL_ID: &str = "arkade-rs-SDK";
 /// VTXOs does not build a batch intent that exceeds the server's transaction-weight limit. Any
 /// overflow is deferred to a later migration cycle (see [`MigrationLegReport::deferred`]).
 pub const MAX_VTXOS_PER_SETTLEMENT: usize = 50;
+
+/// Mainnet's original unilateral-exit delay (~7 days, in seconds).
+///
+/// arkd only advertises the CURRENT exit delay in `/info`; it does not record the delays it used
+/// in the past. If the operator shortens the delay (with or without a key rotation), deposits
+/// minted under the OLD delay have a different `scriptPubKey` and would silently fall out of
+/// watch/discovery. To avoid that, discovery on mainnet probes this hardcoded legacy delay
+/// alongside the advertised one. We keep a single fallback rather than scanning an unbounded
+/// history because arkd does not expose deprecated delays. Matches `MAINNET_UNILATERAL_EXIT_DELAY`
+/// in arkade-os/ts-sdk and `MainnetLegacyUnilateralExit` in the dotnet SDK.
+///
+/// On testnets arkd has always advertised the network's intended delay, so this probe would only
+/// widen the candidate set without ever hitting; the candidate-delay helper therefore adds it on
+/// mainnet only (see [`Client::candidate_exit_delays`]).
+const MAINNET_LEGACY_UNILATERAL_EXIT_DELAY_SECS: u32 = 605_184;
 
 /// A single VTXO or boarding output referenced in a [`DeprecatedSignerMigrationReport`].
 #[derive(Debug, Clone)]
@@ -799,6 +815,26 @@ where
             tracing::warn!(?error, "Failed during key discovery");
         };
 
+        // Eagerly persist boarding rows for the current signer and every deprecated signer (each
+        // crossed with the candidate exit delays). Without this, deprecated-signer boarding rows
+        // exist only after an integrator calls `get_boarding_addresses()`, and the boarding leg of
+        // `migrate_deprecated_signer_vtxos` (a pure DB read) would silently see none — an ordering
+        // footgun the ts-sdk (eager boarding matrix at boot) and dotnet (BoardingUtxoSyncService)
+        // both avoid. Re-persisting is idempotent, so this is safe to run on every connect.
+        match client.server_info() {
+            Ok(server_info) => {
+                if let Err(error) = client.persist_watch_boarding_outputs(&server_info) {
+                    tracing::warn!(?error, "Failed to persist boarding outputs at connect");
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "Failed to read server info for boarding persistence"
+                );
+            }
+        }
+
         Ok(client)
     }
 }
@@ -1023,6 +1059,11 @@ where
         // Discover against current + all deprecated signers so that user keys used before a
         // rotation are still found when recovering from seed.
         let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
+        // Probe each server key under every candidate exit delay (the advertised delay plus, on
+        // mainnet, the legacy delay), so VTXOs minted before the operator shortened the delay are
+        // still discovered. Off mainnet this is just the advertised delay (no behaviour change).
+        let candidate_delays =
+            self.candidate_exit_delays(server_info.unilateral_exit_delay, server_info.network)?;
 
         let mut start_index = 0u32;
         let mut discovered_count = 0u32;
@@ -1049,27 +1090,29 @@ where
                 let mut addresses = Vec::new();
 
                 for server_signer in &all_server_keys {
-                    // Default (2-leaf) address.
-                    let default_vtxo = Vtxo::new_default(
-                        self.secp(),
-                        *server_signer,
-                        owner_pk,
-                        server_info.unilateral_exit_delay,
-                        server_info.network,
-                    )?;
-                    addresses.push(default_vtxo.to_ark_address());
-
-                    // Delegate (3-leaf) addresses for each known delegator.
-                    for dpk in &self.inner.historical_delegator_pks {
-                        let delegate_vtxo = Vtxo::new_with_delegator(
+                    for exit_delay in &candidate_delays {
+                        // Default (2-leaf) address.
+                        let default_vtxo = Vtxo::new_default(
                             self.secp(),
                             *server_signer,
                             owner_pk,
-                            *dpk,
-                            server_info.unilateral_exit_delay,
+                            *exit_delay,
                             server_info.network,
                         )?;
-                        addresses.push(delegate_vtxo.to_ark_address());
+                        addresses.push(default_vtxo.to_ark_address());
+
+                        // Delegate (3-leaf) addresses for each known delegator.
+                        for dpk in &self.inner.historical_delegator_pks {
+                            let delegate_vtxo = Vtxo::new_with_delegator(
+                                self.secp(),
+                                *server_signer,
+                                owner_pk,
+                                *dpk,
+                                *exit_delay,
+                                server_info.network,
+                            )?;
+                            addresses.push(delegate_vtxo.to_ark_address());
+                        }
                     }
                 }
 
@@ -1120,6 +1163,36 @@ where
         Ok(discovered_count)
     }
 
+    /// Candidate exit-delay set for discovery/watch, given the current delay advertised for one
+    /// axis (boarding or unilateral-exit).
+    ///
+    /// Returns the `current` delay plus — only on mainnet — the hardcoded legacy delay
+    /// [`MAINNET_LEGACY_UNILATERAL_EXIT_DELAY_SECS`], deduplicated. arkd advertises only the
+    /// CURRENT delay, so deposits minted under an older (longer) delay live at a different
+    /// `scriptPubKey`; probing the legacy delay too keeps them visible. On non-mainnet the set is
+    /// just `[current]`, so behaviour there is unchanged, and the de-dup makes the legacy entry a
+    /// no-op whenever `current` already equals it.
+    fn candidate_exit_delays(
+        &self,
+        current: bitcoin::Sequence,
+        network: bitcoin::Network,
+    ) -> Result<Vec<bitcoin::Sequence>, Error> {
+        let mut delays = vec![current];
+
+        if network == bitcoin::Network::Bitcoin {
+            let legacy =
+                bitcoin::Sequence::from_seconds_ceil(MAINNET_LEGACY_UNILATERAL_EXIT_DELAY_SECS)
+                    .map_err(Error::ad_hoc)?;
+            // De-dup: when the advertised mainnet delay already equals the legacy value, the
+            // legacy probe is a no-op.
+            if !delays.contains(&legacy) {
+                delays.push(legacy);
+            }
+        }
+
+        Ok(delays)
+    }
+
     // At the moment we are always generating the same address.
     pub fn get_boarding_address(&self) -> Result<Address, Error> {
         let server_info = &self.server_info()?;
@@ -1139,24 +1212,58 @@ where
 
     pub fn get_boarding_addresses(&self) -> Result<Vec<Address>, Error> {
         let server_info = &self.server_info()?;
-        let mut addresses = Vec::new();
 
-        // Current signer boarding address.
-        addresses.push(self.get_boarding_address()?);
-
-        // Deprecated signer boarding addresses — for watch/history only.
+        // Persist a boarding output for every (signer, exit-delay) candidate and return the
+        // de-duplicated addresses. This is the watch/history surface: it covers the current signer
+        // plus all deprecated signers (server-key rotation), each crossed with the candidate
+        // exit-delay set (the advertised delay plus, on mainnet, the legacy delay) so deposits
+        // minted under an older delay or an older key are still visible.
+        //
         // The spend path (settle) deliberately stays current-signer-only;
         // deprecated-signer boarding recovery is handled via migrate_deprecated_signer_vtxos().
-        for ds in &server_info.deprecated_signers {
-            let boarding_output = self.inner.wallet.new_boarding_output(
-                ds.pk.x_only_public_key().0,
-                server_info.boarding_exit_delay,
-                server_info.network,
-            )?;
-            addresses.push(boarding_output.address().clone());
+        let outputs = self.persist_watch_boarding_outputs(server_info)?;
+
+        let mut seen = HashSet::new();
+        let mut addresses = Vec::with_capacity(outputs.len());
+        for output in &outputs {
+            let address = output.address().clone();
+            if seen.insert(address.clone()) {
+                addresses.push(address);
+            }
         }
 
         Ok(addresses)
+    }
+
+    /// Persist (idempotently) a boarding output for each signer the wallet should watch crossed
+    /// with each candidate exit delay, returning the created [`BoardingOutput`]s.
+    ///
+    /// Covers the current signer plus every deprecated signer, each paired with
+    /// [`Client::candidate_exit_delays`] (the advertised boarding-exit delay plus, on mainnet, the
+    /// legacy delay). Calling [`BoardingWallet::new_boarding_output`] writes the row to the
+    /// wallet's store; re-persisting the same boarding output is a harmless overwrite (the store
+    /// keys rows by [`BoardingOutput`] identity), so this is safe to call repeatedly — at connect
+    /// time and again from [`Client::get_boarding_addresses`].
+    fn persist_watch_boarding_outputs(
+        &self,
+        server_info: &server::Info,
+    ) -> Result<Vec<BoardingOutput>, Error> {
+        let candidate_delays =
+            self.candidate_exit_delays(server_info.boarding_exit_delay, server_info.network)?;
+
+        let mut outputs = Vec::new();
+        for server_pk in server_info.all_server_keys() {
+            for exit_delay in &candidate_delays {
+                let boarding_output = self.inner.wallet.new_boarding_output(
+                    server_pk,
+                    *exit_delay,
+                    server_info.network,
+                )?;
+                outputs.push(boarding_output);
+            }
+        }
+
+        Ok(outputs)
     }
 
     pub async fn get_virtual_tx_outpoints(

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1588,6 +1588,8 @@ mod digest_guard_tests {
 
     #[tokio::test]
     async fn guarded_client_refreshes_info_and_does_not_retry_on_digest_mismatch() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let mock = MockArkServer::default();
         let state = mock.state.clone();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1108,14 +1108,15 @@ where
         })
     }
 
-    /// Sweep VTXOs under deprecated server signers (before their cutoff) to the current signer.
+    /// Sweep VTXOs and boarding outputs under deprecated server signers (before their cutoff)
+    /// to the current signer.
     ///
-    /// This joins the next available batch and settles all VTXOs — current-signer and
-    /// deprecated-signer alike — to a fresh current-signer address. Only before-cutoff
-    /// deprecated VTXOs are truly "migrated"; past-cutoff ones are excluded from the batch
-    /// automatically (they cannot be co-signed) and will become recoverable after expiry.
+    /// This joins the next available batch and settles all inputs — current-signer and
+    /// pre-cutoff deprecated-signer alike — to a fresh current-signer address. Past-cutoff
+    /// VTXOs and boarding outputs are excluded from the batch automatically (the operator
+    /// won't co-sign the old key) and will become recoverable after expiry.
     ///
-    /// Returns `None` when there are no migratable VTXOs (nothing to do).
+    /// Returns `None` when there are no migratable VTXOs or boarding outputs (nothing to do).
     pub async fn migrate_deprecated_signer_vtxos<R>(
         &self,
         rng: &mut R,
@@ -1130,26 +1131,36 @@ where
         let now = unix_now();
         let (vtxo_list, script_map) = self.list_vtxos().await?;
 
-        let migratable = vtxo_list.spendable_offchain().any(|v| {
+        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| {
+            self.server_info.deprecated_signers.iter().any(|ds| {
+                ds.pk.x_only_public_key().0 == server_pk
+                    && (ds.cutoff_date == 0 || ds.cutoff_date > now)
+            })
+        };
+
+        let migratable_vtxos = vtxo_list.spendable_offchain().any(|v| {
             script_map
                 .get(&v.script)
-                .map(|vtxo| {
-                    let server_pk = vtxo.server_pk();
-                    self.server_info.deprecated_signers.iter().any(|ds| {
-                        let ds_pk: XOnlyPublicKey = ds.pk.x_only_public_key().0;
-                        ds_pk == server_pk && (ds.cutoff_date == 0 || ds.cutoff_date > now)
-                    })
-                })
+                .map(|vtxo| is_pre_cutoff_deprecated(vtxo.server_pk()))
                 .unwrap_or(false)
         });
 
-        if !migratable {
-            tracing::debug!("No migratable deprecated-signer VTXOs found");
+        let migratable_boarding = self
+            .inner
+            .wallet
+            .get_boarding_outputs()?
+            .into_iter()
+            .any(|bo| is_pre_cutoff_deprecated(bo.server_pk()));
+
+        if !migratable_vtxos && !migratable_boarding {
+            tracing::debug!("No migratable deprecated-signer VTXOs or boarding outputs found");
             return Ok(None);
         }
 
         tracing::info!(
-            "Found VTXOs under pre-cutoff deprecated signers; settling to current signer"
+            migratable_vtxos,
+            migratable_boarding,
+            "Found pre-cutoff deprecated-signer outputs; settling to current signer"
         );
 
         // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -336,6 +336,10 @@ pub struct OffChainBalance {
     pre_confirmed: Amount,
     confirmed: Amount,
     recoverable: Amount,
+    /// Funds under a deprecated server signer whose cooperative-sign cutoff has passed.
+    /// These VTXOs cannot be spent offchain (operator won't co-sign the old key) and are not yet
+    /// recoverable (not expired). They will become recoverable once their VTXO expiry passes.
+    pending_recovery: Amount,
     asset_balances: HashMap<AssetId, u64>,
 }
 
@@ -353,8 +357,14 @@ impl OffChainBalance {
         self.recoverable
     }
 
+    /// Funds locked under a deprecated signer past its cutoff — cannot be spent offchain,
+    /// waiting for VTXO expiry to become recoverable. Still counted in `total()`.
+    pub fn pending_recovery(&self) -> Amount {
+        self.pending_recovery
+    }
+
     pub fn total(&self) -> Amount {
-        self.pre_confirmed + self.confirmed + self.recoverable
+        self.pre_confirmed + self.confirmed + self.recoverable + self.pending_recovery
     }
 
     /// Asset balances keyed by asset ID.
@@ -390,6 +400,22 @@ pub trait Blockchain {
         &self,
         txs: &[&Transaction],
     ) -> impl Future<Output = Result<(), Error>> + Send;
+}
+
+/// Current time as unix seconds. Uses `js_sys::Date` on wasm32, `std::time` elsewhere.
+fn unix_now() -> i64 {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("valid duration")
+            .as_secs() as i64
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        (js_sys::Date::now() / 1000.0) as i64
+    }
 }
 
 impl<B, W, S, K> OfflineClient<B, W, S, K>
@@ -711,38 +737,42 @@ where
     /// [`OfflineClient::new`], addresses for those are included too.
     pub fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
         let server_info = &self.server_info;
-        let server_signer = server_info.signer_pk.into();
-
         let pks = self.inner.key_provider.get_cached_pks()?;
+
+        // Build addresses for current signer + all deprecated signers so VTXOs under any
+        // known server key are discovered and visible in the balance.
+        let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
 
         let mut results = Vec::new();
 
         for owner_pk in &pks {
-            // Always include the default (2-leaf) address.
-            let default_vtxo = Vtxo::new_default(
-                self.secp(),
-                server_signer,
-                *owner_pk,
-                server_info.unilateral_exit_delay,
-                server_info.network,
-            )?;
-            results.push((default_vtxo.to_ark_address(), default_vtxo));
-
-            // Include delegate addresses for all known delegator keys.
-            let mut seen = HashSet::new();
-            for dpk in &self.inner.historical_delegator_pks {
-                if !seen.insert(dpk) {
-                    continue;
-                }
-                let delegate_vtxo = Vtxo::new_with_delegator(
+            for server_signer in &all_server_keys {
+                // Default (2-leaf) address.
+                let default_vtxo = Vtxo::new_default(
                     self.secp(),
-                    server_signer,
+                    *server_signer,
                     *owner_pk,
-                    *dpk,
                     server_info.unilateral_exit_delay,
                     server_info.network,
                 )?;
-                results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                results.push((default_vtxo.to_ark_address(), default_vtxo));
+
+                // Delegate addresses for all known delegator keys.
+                let mut seen = HashSet::new();
+                for dpk in &self.inner.historical_delegator_pks {
+                    if !seen.insert(dpk) {
+                        continue;
+                    }
+                    let delegate_vtxo = Vtxo::new_with_delegator(
+                        self.secp(),
+                        *server_signer,
+                        *owner_pk,
+                        *dpk,
+                        server_info.unilateral_exit_delay,
+                        server_info.network,
+                    )?;
+                    results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                }
             }
         }
 
@@ -910,9 +940,25 @@ where
     }
 
     pub fn get_boarding_addresses(&self) -> Result<Vec<Address>, Error> {
-        let address = self.get_boarding_address()?;
+        let server_info = &self.server_info;
+        let mut addresses = Vec::new();
 
-        Ok(vec![address])
+        // Current signer boarding address.
+        addresses.push(self.get_boarding_address()?);
+
+        // Deprecated signer boarding addresses — for watch/history only.
+        // The spend path (settle) deliberately stays current-signer-only;
+        // deprecated-signer boarding recovery is handled via migrate_deprecated_signer_vtxos().
+        for ds in &server_info.deprecated_signers {
+            let boarding_output = self.inner.wallet.new_boarding_output(
+                ds.pk.x_only_public_key().0,
+                server_info.boarding_exit_delay,
+                server_info.network,
+            )?;
+            addresses.push(boarding_output.address().clone());
+        }
+
+        Ok(addresses)
     }
 
     pub async fn get_virtual_tx_outpoints(
@@ -1002,23 +1048,43 @@ where
     }
 
     pub async fn offchain_balance(&self) -> Result<OffChainBalance, Error> {
-        let (vtxo_list, _) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let (vtxo_list, script_map) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let now = unix_now();
+
+        let is_past_cutoff = |v: &VirtualTxOutPoint| {
+            script_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    self.server_info
+                        .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                })
+                .unwrap_or(false)
+        };
 
         let pre_confirmed = vtxo_list
             .pre_confirmed()
+            .filter(|v| !is_past_cutoff(v))
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
         let confirmed = vtxo_list
             .confirmed()
+            .filter(|v| !is_past_cutoff(v))
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
         let recoverable = vtxo_list
             .recoverable()
             .fold(Amount::ZERO, |acc, x| acc + x.amount);
 
-        // Aggregate asset balances from all spendable VTXOs.
+        // Spendable offchain VTXOs under a past-cutoff deprecated signer: operator won't
+        // co-sign, so they're stuck until the VTXO expires and becomes recoverable.
+        let pending_recovery = vtxo_list
+            .spendable_offchain()
+            .filter(|v| is_past_cutoff(v))
+            .fold(Amount::ZERO, |acc, x| acc + x.amount);
+
+        // Aggregate asset balances from spendable (non-past-cutoff) VTXOs only.
         let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
-        for vtxo in vtxo_list.spendable_offchain() {
+        for vtxo in vtxo_list.spendable_offchain().filter(|v| !is_past_cutoff(v)) {
             for asset in &vtxo.assets {
                 let total = asset_balances
                     .get(&asset.asset_id)
@@ -1034,8 +1100,58 @@ where
             pre_confirmed,
             confirmed,
             recoverable,
+            pending_recovery,
             asset_balances,
         })
+    }
+
+    /// Sweep VTXOs under deprecated server signers (before their cutoff) to the current signer.
+    ///
+    /// This joins the next available batch and settles all VTXOs — current-signer and
+    /// deprecated-signer alike — to a fresh current-signer address. Only before-cutoff
+    /// deprecated VTXOs are truly "migrated"; past-cutoff ones are excluded from the batch
+    /// automatically (they cannot be co-signed) and will become recoverable after expiry.
+    ///
+    /// Returns `None` when there are no migratable VTXOs (nothing to do).
+    pub async fn migrate_deprecated_signer_vtxos<R>(
+        &self,
+        rng: &mut R,
+    ) -> Result<Option<Txid>, Error>
+    where
+        R: rand::Rng + rand::CryptoRng + Clone,
+    {
+        if self.server_info.deprecated_signers.is_empty() {
+            return Ok(None);
+        }
+
+        let now = unix_now();
+        let (vtxo_list, script_map) = self.list_vtxos().await?;
+
+        let migratable = vtxo_list.spendable_offchain().any(|v| {
+            script_map
+                .get(&v.script)
+                .map(|vtxo| {
+                    let server_pk = vtxo.server_pk();
+                    self.server_info.deprecated_signers.iter().any(|ds| {
+                        let ds_pk: XOnlyPublicKey = ds.pk.x_only_public_key().0;
+                        ds_pk == server_pk && (ds.cutoff_date == 0 || ds.cutoff_date > now)
+                    })
+                })
+                .unwrap_or(false)
+        });
+
+        if !migratable {
+            tracing::debug!("No migratable deprecated-signer VTXOs found");
+            return Ok(None);
+        }
+
+        tracing::info!(
+            "Found VTXOs under pre-cutoff deprecated signers; settling to current signer"
+        );
+
+        // settle() picks up all unspent VTXOs (expanded addresses include deprecated signers)
+        // and fetch_commitment_transaction_inputs() filters out past-cutoff ones automatically.
+        self.settle(rng).await
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1183,36 +1183,45 @@ where
         // Build addresses for current signer + all deprecated signers so VTXOs under any
         // known server key are discovered and visible in the balance.
         let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
+        // Enumerate under every candidate exit delay (the advertised delay plus, on mainnet, the
+        // legacy delay), mirroring `discover_keys`: a VTXO minted before the operator shortened the
+        // delay lives at a legacy-delay address, so building only the current delay would hide it
+        // from `list_vtxos`/balance/migration even though its key was discovered. Off mainnet this
+        // is just the advertised delay (no behaviour change).
+        let candidate_delays =
+            self.candidate_exit_delays(server_info.unilateral_exit_delay, server_info.network)?;
 
         let mut results = Vec::new();
 
         for owner_pk in &pks {
             for server_signer in &all_server_keys {
-                // Default (2-leaf) address.
-                let default_vtxo = Vtxo::new_default(
-                    self.secp(),
-                    *server_signer,
-                    *owner_pk,
-                    server_info.unilateral_exit_delay,
-                    server_info.network,
-                )?;
-                results.push((default_vtxo.to_ark_address(), default_vtxo));
-
-                // Delegate addresses for all known delegator keys.
-                let mut seen = HashSet::new();
-                for dpk in &self.inner.historical_delegator_pks {
-                    if !seen.insert(dpk) {
-                        continue;
-                    }
-                    let delegate_vtxo = Vtxo::new_with_delegator(
+                for exit_delay in &candidate_delays {
+                    // Default (2-leaf) address.
+                    let default_vtxo = Vtxo::new_default(
                         self.secp(),
                         *server_signer,
                         *owner_pk,
-                        *dpk,
-                        server_info.unilateral_exit_delay,
+                        *exit_delay,
                         server_info.network,
                     )?;
-                    results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                    results.push((default_vtxo.to_ark_address(), default_vtxo));
+
+                    // Delegate addresses for all known delegator keys.
+                    let mut seen = HashSet::new();
+                    for dpk in &self.inner.historical_delegator_pks {
+                        if !seen.insert(dpk) {
+                            continue;
+                        }
+                        let delegate_vtxo = Vtxo::new_with_delegator(
+                            self.secp(),
+                            *server_signer,
+                            *owner_pk,
+                            *dpk,
+                            *exit_delay,
+                            server_info.network,
+                        )?;
+                        results.push((delegate_vtxo.to_ark_address(), delegate_vtxo));
+                    }
                 }
             }
         }
@@ -1861,8 +1870,13 @@ where
             let vtxo_count = vtxo_agg.map(|a| a.spendable_count).unwrap_or(0);
             let vtxo_value = vtxo_agg.map(|a| a.spendable_value).unwrap_or(Amount::ZERO);
 
-            // Skip signers under which the wallet holds no funds at all.
-            if vtxo_count == 0 && boarding_count == 0 {
+            // Skip signers under which the wallet holds no funds at all. Count recoverable VTXOs
+            // too: an expired signer whose VTXOs are all recoverable (spendable_count == 0) still
+            // holds funds the user needs to see — dropping it would hide them from the report.
+            let has_any_vtxos = vtxo_agg
+                .map(|a| a.spendable_count + a.recoverable_count > 0)
+                .unwrap_or(false);
+            if !has_any_vtxos && boarding_count == 0 {
                 continue;
             }
 
@@ -1937,7 +1951,10 @@ where
             return Ok(MigrationLegReport {
                 settle_txid: None,
                 migrated: Vec::new(),
-                deferred,
+                // Surface any sized-but-skipped inputs (e.g. a below-dust selection) as deferred
+                // so a later cycle re-attempts them, matching the settle-error path below. For
+                // OversizedOnly/NothingMigratable `selected` is empty, so this is a no-op there.
+                deferred: selected.into_iter().chain(deferred).collect(),
                 oversized,
                 skipped: Some(reason),
                 error: None,

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -635,19 +635,7 @@ where
             "Connected to Ark server"
         );
 
-        let fee_estimator_config = server_info
-            .fees
-            .clone()
-            .map(|fees| ark_fees::Config {
-                intent_offchain_input_program: fees.intent_fee.offchain_input.unwrap_or_default(),
-                intent_onchain_input_program: fees.intent_fee.onchain_input.unwrap_or_default(),
-                intent_offchain_output_program: fees.intent_fee.offchain_output.unwrap_or_default(),
-                intent_onchain_output_program: fees.intent_fee.onchain_output.unwrap_or_default(),
-            })
-            .unwrap_or_default();
-
-        let fee_estimator =
-            ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)?;
+        let fee_estimator = build_fee_estimator(&server_info)?;
 
         let client = Client {
             inner: self,
@@ -663,6 +651,21 @@ where
     }
 }
 
+fn build_fee_estimator(server_info: &server::Info) -> Result<ark_fees::Estimator, Error> {
+    let fee_estimator_config = server_info
+        .fees
+        .clone()
+        .map(|fees| ark_fees::Config {
+            intent_offchain_input_program: fees.intent_fee.offchain_input.unwrap_or_default(),
+            intent_onchain_input_program: fees.intent_fee.onchain_input.unwrap_or_default(),
+            intent_offchain_output_program: fees.intent_fee.offchain_output.unwrap_or_default(),
+            intent_onchain_output_program: fees.intent_fee.onchain_output.unwrap_or_default(),
+        })
+        .unwrap_or_default();
+
+    ark_fees::Estimator::new(fee_estimator_config).map_err(Error::ark_server)
+}
+
 impl<B, W, S, K> Client<B, W, S, K>
 where
     B: Blockchain,
@@ -670,6 +673,38 @@ where
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
+    /// Refresh cached `/info` data after the server reports a digest mismatch.
+    ///
+    /// This updates [`Client::server_info`], the gRPC digest header, and the fee estimator. The
+    /// SDK intentionally does not retry the failed operation automatically; rebuild the request
+    /// using the refreshed server info and retry only when it is safe for your call site.
+    pub async fn refresh_server_info(&mut self) -> Result<(), Error> {
+        let server_info = timeout_op(self.inner.timeout, self.network_client().get_info())
+            .await
+            .context("Failed to refresh Ark server info")??;
+
+        self.fee_estimator = build_fee_estimator(&server_info)?;
+        self.server_info = server_info;
+
+        Ok(())
+    }
+
+    /// Refresh cached `/info` if `error` is a digest mismatch.
+    ///
+    /// Returns `true` when a refresh happened. The original operation is not retried; callers must
+    /// rebuild any request state that depended on the old [`Client::server_info`] before retrying.
+    pub async fn refresh_server_info_if_digest_mismatch(
+        &mut self,
+        error: &Error,
+    ) -> Result<bool, Error> {
+        if !error.is_digest_mismatch() {
+            return Ok(false);
+        }
+
+        self.refresh_server_info().await?;
+        Ok(true)
+    }
+
     /// Returns the currently configured delegator pubkey, if any.
     pub fn delegator_pk(&self) -> Option<XOnlyPublicKey> {
         self.inner.delegator_pk()

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -238,8 +238,19 @@ where
             .await
             .context("failed to get spendable VTXOs")?;
 
+        let now = crate::unix_now();
         let spendable = vtxo_list
             .spendable_offchain()
+            // Exclude VTXOs under a past-cutoff deprecated signer: operator won't co-sign.
+            .filter(|v| {
+                !script_pubkey_to_vtxo_map
+                    .get(&v.script)
+                    .map(|vtxo| {
+                        self.server_info
+                            .is_signer_past_cutoff_at(vtxo.server_pk(), now)
+                    })
+                    .unwrap_or(false)
+            })
             .map(|vtxo| VirtualTxOutPoint {
                 outpoint: vtxo.outpoint,
                 script_pubkey: vtxo.script.clone(),

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -262,7 +262,6 @@ where
             })
             .collect::<Vec<_>>();
 
-        let server_info = self.server_info()?;
         let mut selected_outpoints = HashSet::new();
         let mut selected = Vec::new();
         let mut asset_changes: HashMap<AssetId, u64> = HashMap::new();

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -18,6 +18,7 @@ use ark_core::send::sign_checkpoint_transaction;
 use ark_core::send::OffchainTransactions;
 use ark_core::send::SendReceiver;
 use ark_core::send::VtxoInput;
+use ark_core::server;
 use ark_core::server::PendingTx;
 use bitcoin::key::Secp256k1;
 use bitcoin::psbt;
@@ -192,12 +193,15 @@ where
         address: ark_core::ArkAddress,
         amount: Amount,
     ) -> Result<Txid, Error> {
+        let server_info = self.server_info()?;
         let receivers = vec![SendReceiver {
             address,
             amount,
             assets: Vec::new(),
         }];
-        let pending_tx = self.build_and_submit(vtxo_inputs, receivers).await?;
+        let pending_tx = self
+            .build_and_submit(vtxo_inputs, receivers, &server_info)
+            .await?;
         Ok(pending_tx.ark_txid)
     }
 
@@ -249,6 +253,7 @@ where
             })
             .collect::<Vec<_>>();
 
+        let server_info = self.server_info()?;
         let mut selected_outpoints = HashSet::new();
         let mut selected = Vec::new();
         let mut asset_changes: HashMap<AssetId, u64> = HashMap::new();
@@ -306,7 +311,7 @@ where
         }
 
         if !asset_changes.is_empty() {
-            btc_needed += self.server_info()?.dust;
+            btc_needed += server_info.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -318,7 +323,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, server_info.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset transfer")?;
 
@@ -501,13 +506,12 @@ where
         vtxo_inputs: Vec<VtxoInput>,
         receivers: Vec<SendReceiver>,
     ) -> Result<Txid, Error> {
-        Self::validate_selected_inputs_cover_receivers(
-            &vtxo_inputs,
-            &receivers,
-            self.server_info()?.dust,
-        )?;
+        let server_info = self.server_info()?;
+        Self::validate_selected_inputs_cover_receivers(&vtxo_inputs, &receivers, server_info.dust)?;
 
-        let pending_tx = self.build_and_submit(vtxo_inputs, receivers).await?;
+        let pending_tx = self
+            .build_and_submit(vtxo_inputs, receivers, &server_info)
+            .await?;
         let ark_txid = pending_tx.ark_txid;
 
         self.sign_and_finalize_pending_tx(pending_tx).await?;
@@ -557,20 +561,16 @@ where
         &self,
         inputs: Vec<VtxoInput>,
         receivers: Vec<SendReceiver>,
+        server_info: &server::Info,
     ) -> Result<PendingTx, Error> {
         let (change_address, change_address_vtxo) = self.get_offchain_address()?;
 
         let OffchainTransactions {
             ark_tx,
             checkpoint_txs,
-        } = build_asset_send_transactions(
-            &receivers,
-            &change_address,
-            &inputs,
-            &self.server_info()?,
-        )
-        .map_err(Error::from)
-        .context("failed to build offchain asset-send transactions")?;
+        } = build_asset_send_transactions(&receivers, &change_address, &inputs, server_info)
+            .map_err(Error::from)
+            .context("failed to build offchain asset-send transactions")?;
 
         self.submit_built_offchain_send(ark_tx, checkpoint_txs, change_address_vtxo.owner_pk())
             .await
@@ -694,7 +694,7 @@ where
         // finalized. This is much cheaper than fetching all VTXOs when there
         // are no pending transactions (common case).
         let addresses = ark_addresses.iter().map(|(a, _)| *a);
-        let request = ark_core::server::GetVtxosRequest::new_for_addresses(addresses)
+        let request = server::GetVtxosRequest::new_for_addresses(addresses)
             .pending_only()
             .map_err(Error::from)?;
 

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -306,7 +306,7 @@ where
         }
 
         if !asset_changes.is_empty() {
-            btc_needed += self.server_info.dust;
+            btc_needed += self.server_info()?.dust;
         }
 
         let btc_shortfall = btc_needed.checked_sub(btc_provided).unwrap_or(Amount::ZERO);
@@ -318,7 +318,7 @@ where
                 .cloned()
                 .collect();
 
-            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info.dust, true)
+            let btc_coins = select_vtxos(available, btc_shortfall, self.server_info()?.dust, true)
                 .map_err(Error::from)
                 .context("failed to select BTC coins for asset transfer")?;
 
@@ -504,7 +504,7 @@ where
         Self::validate_selected_inputs_cover_receivers(
             &vtxo_inputs,
             &receivers,
-            self.server_info.dust,
+            self.server_info()?.dust,
         )?;
 
         let pending_tx = self.build_and_submit(vtxo_inputs, receivers).await?;
@@ -563,9 +563,14 @@ where
         let OffchainTransactions {
             ark_tx,
             checkpoint_txs,
-        } = build_asset_send_transactions(&receivers, &change_address, &inputs, &self.server_info)
-            .map_err(Error::from)
-            .context("failed to build offchain asset-send transactions")?;
+        } = build_asset_send_transactions(
+            &receivers,
+            &change_address,
+            &inputs,
+            &self.server_info()?,
+        )
+        .map_err(Error::from)
+        .context("failed to build offchain asset-send transactions")?;
 
         self.submit_built_offchain_send(ark_tx, checkpoint_txs, change_address_vtxo.owner_pk())
             .await

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -245,10 +245,11 @@ where
         to_address: Address,
         to_amount: Amount,
     ) -> Result<(Transaction, Vec<TxOut>), Error> {
-        if to_amount < self.server_info()?.dust {
+        let dust = self.server_info()?.dust;
+        if to_amount < dust {
             return Err(Error::ad_hoc(format!(
                 "invalid amount {to_amount}, must be greater than dust: {}",
-                self.server_info()?.dust,
+                dust,
             )));
         }
 

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -245,10 +245,10 @@ where
         to_address: Address,
         to_amount: Amount,
     ) -> Result<(Transaction, Vec<TxOut>), Error> {
-        if to_amount < self.server_info.dust {
+        if to_amount < self.server_info()?.dust {
             return Err(Error::ad_hoc(format!(
                 "invalid amount {to_amount}, must be greater than dust: {}",
-                self.server_info.dust,
+                self.server_info()?.dust,
             )));
         }
 

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -62,6 +62,38 @@ const MAX_BACKOFF: Duration = Duration::from_secs(30);
 const KEY_DISCOVERY_INTERVAL: Duration = Duration::from_secs(10);
 const KEY_DISCOVERY_GAP_LIMIT: u32 = 20;
 
+/// How often the background migration arm fires when healthy. The frequent cadence is safe
+/// because [`Client::migrate_deprecated_signer_vtxos`] short-circuits to a no-op
+/// `NothingMigratable` report when the server advertises no deprecated signers or the wallet holds
+/// no pre-cutoff deprecated-signer outputs.
+const MIGRATION_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Exponential-backoff bounds for the migration arm after a failing pass. Mirrors ts-sdk's
+/// `MIGRATION_COOLDOWN_MS` (base 30s, doubling per consecutive failure, capped at 5 minutes); the
+/// cooldown resets to the base on a successful or no-op pass.
+const MIGRATION_BASE_COOLDOWN: Duration = Duration::from_secs(30);
+const MIGRATION_MAX_COOLDOWN: Duration = Duration::from_secs(300);
+
+/// Configuration for [`Client::start_vtxo_watcher`].
+#[derive(Debug, Clone, Copy)]
+pub struct VtxoWatcherConfig {
+    /// When `true` (the default), the watcher runs a periodic
+    /// [`Client::migrate_deprecated_signer_vtxos`] pass that rotates funds off any deprecated
+    /// server signer the wallet still holds pre-cutoff outputs under. Errors are logged and
+    /// swallowed (never killing the loop), and a persistently failing pass backs off
+    /// exponentially. Set to `false` to disable the migration arm entirely; renewal and delegation
+    /// behavior are unaffected either way.
+    pub migrate_deprecated_signers: bool,
+}
+
+impl Default for VtxoWatcherConfig {
+    fn default() -> Self {
+        Self {
+            migrate_deprecated_signers: true,
+        }
+    }
+}
+
 /// Pre-computed mapping from script pubkeys to their Vtxo metadata and ArkAddress.
 ///
 /// Built once per (re)connection from `get_offchain_addresses()`. Used both for the subscription
@@ -122,6 +154,8 @@ where
     ///
     /// 1. **Delegates** them to the configured delegator service for future auto-renewal
     /// 2. **Self-renews** VTXOs that are close to expiry (safety net)
+    /// 3. **Migrates** funds off deprecated server signers on a periodic, backed-off pass (unless
+    ///    disabled via [`VtxoWatcherConfig::migrate_deprecated_signers`])
     ///
     /// Reconnects automatically with exponential backoff (1s → 2s → … → 30s) on stream errors.
     ///
@@ -132,12 +166,13 @@ where
     pub fn start_vtxo_watcher(
         self: &Arc<Self>,
         delegator: Arc<DelegatorClient>,
+        config: VtxoWatcherConfig,
     ) -> VtxoWatcherHandle {
         let (stop_tx, stop_rx) = watch::channel(false);
 
         let client = Arc::clone(self);
         tokio::spawn(async move {
-            run_watcher_loop(client, delegator, stop_rx).await;
+            run_watcher_loop(client, delegator, config, stop_rx).await;
             tracing::debug!("VTXO watcher stopped");
         });
 
@@ -149,6 +184,7 @@ where
 async fn run_watcher_loop<B, W, S, K>(
     client: Arc<Client<B, W, S, K>>,
     delegator: Arc<DelegatorClient>,
+    config: VtxoWatcherConfig,
     mut stop_rx: watch::Receiver<bool>,
 ) where
     B: Blockchain + Send + Sync + 'static,
@@ -290,11 +326,27 @@ async fn run_watcher_loop<B, W, S, K>(
             }
         });
 
+        // Independent migration arm: rotates funds off deprecated server signers on its own
+        // self-paced cooldown loop, separate from the renewal/delegation worker and the
+        // subscription stream (it polls wallet state, like renewal). Spawned per connection and
+        // aborted on reconnect/stop so passes never overlap. Disabled entirely when the config
+        // flag is off.
+        let migration_handle = config.migrate_deprecated_signers.then(|| {
+            let client = client.clone();
+            let mut stop_rx = stop_rx.clone();
+            tokio::spawn(async move {
+                run_migration_arm(&client, &mut stop_rx).await;
+            })
+        });
+
         loop {
             tokio::select! {
                 _ = stop_rx.changed() => {
                     drop(work_tx);
                     let _ = worker_handle.await;
+                    if let Some(handle) = migration_handle {
+                        handle.abort();
+                    }
                     return;
                 }
                 _ = renew_interval.tick() => {
@@ -359,12 +411,88 @@ async fn run_watcher_loop<B, W, S, K>(
 
         drop(work_tx);
         let _ = worker_handle.await;
+        // Abort the per-connection migration arm; the next iteration spawns a fresh one. This
+        // prevents two migration loops racing across a reconnect.
+        if let Some(handle) = migration_handle {
+            handle.abort();
+        }
 
         if wait_or_stop(&mut stop_rx, backoff).await {
             return;
         }
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }
+}
+
+/// Background migration arm: periodically rotate funds off deprecated server signers.
+///
+/// On each fire it runs one [`Client::migrate_deprecated_signer_vtxos`] pass and logs the outcome.
+/// Errors are swallowed (never propagated — this must never kill the watcher). Cadence is
+/// [`MIGRATION_INTERVAL`] while healthy; a failing pass backs off exponentially between
+/// [`MIGRATION_BASE_COOLDOWN`] and [`MIGRATION_MAX_COOLDOWN`], resetting to the base interval on a
+/// successful or no-op pass. The frequent base cadence is cheap because the migration call is a
+/// no-op (`NothingMigratable`) whenever there is nothing to rotate.
+///
+/// This closes the detect→react loop with the digest-mismatch machinery: when a guarded request
+/// (gRPC `guarded()` / REST `guarded()`) detects a stale `/info` digest, its `info_refresh_hook`
+/// calls [`Client::refresh_server_info`], which swaps the cached `deprecated_signers`. This arm
+/// then picks up the freshly advertised deprecated signers on its next pass and migrates.
+async fn run_migration_arm<B, W, S, K>(
+    client: &Client<B, W, S, K>,
+    stop_rx: &mut watch::Receiver<bool>,
+) where
+    B: Blockchain + Send + Sync + 'static,
+    W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
+    S: SwapStorage + 'static,
+    K: KeyProvider + Send + Sync + 'static,
+{
+    // Consecutive-failure count drives the exponential cooldown; `0` means healthy (use the base
+    // interval). Reset to `0` on any successful or no-op pass.
+    let mut consecutive_failures: u32 = 0;
+    loop {
+        let delay = migration_delay(consecutive_failures);
+        if wait_or_stop(stop_rx, delay).await {
+            return;
+        }
+
+        let mut rng = OsRng;
+        match client.migrate_deprecated_signer_vtxos(&mut rng).await {
+            Ok(report) => {
+                if report.rotated() {
+                    tracing::info!(
+                        txids = ?report.settle_txids(),
+                        "Background migration rotated funds off deprecated signer(s)"
+                    );
+                } else {
+                    tracing::debug!("Background migration pass: nothing to migrate");
+                }
+                // Success or no-op: back to the healthy cadence.
+                consecutive_failures = 0;
+            }
+            Err(e) => {
+                // Back off so a persistently failing migration does not retry every interval.
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                let next = migration_delay(consecutive_failures);
+                tracing::warn!("Background migration pass failed: {e}; backing off {next:?}");
+            }
+        }
+    }
+}
+
+/// Cooldown before the next migration pass given the consecutive-failure count.
+///
+/// `0` failures → the healthy [`MIGRATION_INTERVAL`]. Otherwise an exponential backoff of
+/// `MIGRATION_BASE_COOLDOWN * 2^(failures - 1)`, saturating at [`MIGRATION_MAX_COOLDOWN`] (mirrors
+/// ts-sdk's `MIGRATION_COOLDOWN_MS = 30_000 * 2^failures`, capped at 5 minutes).
+fn migration_delay(consecutive_failures: u32) -> Duration {
+    if consecutive_failures == 0 {
+        return MIGRATION_INTERVAL;
+    }
+    let shift = consecutive_failures - 1;
+    let scaled = MIGRATION_BASE_COOLDOWN
+        .checked_mul(1u32.checked_shl(shift).unwrap_or(u32::MAX))
+        .unwrap_or(MIGRATION_MAX_COOLDOWN);
+    scaled.min(MIGRATION_MAX_COOLDOWN)
 }
 
 /// Wait for the given duration or until stop is signalled. Returns `true` if stopped.
@@ -923,6 +1051,24 @@ mod tests {
             ark_txid: None,
             assets: vec![],
         }
+    }
+
+    #[test]
+    fn migration_delay_uses_base_interval_when_healthy() {
+        assert_eq!(migration_delay(0), MIGRATION_INTERVAL);
+    }
+
+    #[test]
+    fn migration_delay_backs_off_exponentially_and_caps() {
+        // 30s * 2^(failures-1): 30s, 60s, 120s, 240s, then saturates at the 5min cap.
+        assert_eq!(migration_delay(1), MIGRATION_BASE_COOLDOWN);
+        assert_eq!(migration_delay(2), MIGRATION_BASE_COOLDOWN * 2);
+        assert_eq!(migration_delay(3), MIGRATION_BASE_COOLDOWN * 4);
+        assert_eq!(migration_delay(4), MIGRATION_BASE_COOLDOWN * 8);
+        assert_eq!(migration_delay(5), MIGRATION_MAX_COOLDOWN);
+        // Large failure counts must not panic (no shift overflow) and stay at the cap.
+        assert_eq!(migration_delay(100), MIGRATION_MAX_COOLDOWN);
+        assert_eq!(migration_delay(u32::MAX), MIGRATION_MAX_COOLDOWN);
     }
 
     #[test]

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -621,7 +621,15 @@ async fn delegate_vtxos<B, W, S, K>(
         .cloned()
         .collect();
 
-    let groups = group_by_expiry_day(&enriched, script_map, client.server_info.dust);
+    let server_info = match client.server_info() {
+        Ok(server_info) => server_info,
+        Err(e) => {
+            tracing::error!("Failed to read server info for delegation: {e}");
+            return;
+        }
+    };
+
+    let groups = group_by_expiry_day(&enriched, script_map, server_info.dust);
     if groups.is_empty() {
         tracing::debug!("No delegate-eligible VTXOs after enrichment/grouping; skipping");
         return;
@@ -647,7 +655,7 @@ async fn delegate_vtxos<B, W, S, K>(
     let mut handles = Vec::new();
 
     for (_day, group_vtxos) in groups {
-        let valid_at = calculate_valid_at(&group_vtxos, client.server_info.dust);
+        let valid_at = calculate_valid_at(&group_vtxos, server_info.dust);
 
         let mut vtxo_inputs = Vec::new();
         let mut total_amount = Amount::ZERO;
@@ -693,7 +701,7 @@ async fn delegate_vtxos<B, W, S, K>(
         }
         let net_amount = total_amount - fee;
 
-        if net_amount < client.server_info.dust {
+        if net_amount < server_info.dust {
             tracing::warn!(%net_amount, "Net amount after fee is below dust, skipping");
             continue;
         }
@@ -710,8 +718,8 @@ async fn delegate_vtxos<B, W, S, K>(
             script_pubkey: dest_script.clone(),
         }));
 
-        let server_info_forfeit_addr = client.server_info.forfeit_address.clone();
-        let dust = client.server_info.dust;
+        let server_info_forfeit_addr = server_info.forfeit_address.clone();
+        let dust = server_info.dust;
         let ds = Arc::clone(&delegator_state);
 
         let delegator = delegator.clone();

--- a/ark-core/src/boarding_output.rs
+++ b/ark-core/src/boarding_output.rs
@@ -81,6 +81,10 @@ impl BoardingOutput {
         self.owner
     }
 
+    pub fn server_pk(&self) -> XOnlyPublicKey {
+        self.server
+    }
+
     pub fn script_pubkey(&self) -> ScriptBuf {
         self.address.script_pubkey()
     }

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -30,6 +30,16 @@ use std::str::FromStr;
 /// baseline.
 pub const TARGET_ARKD_VERSION: &str = "v0.9.8";
 
+/// Version of this SDK, as `rust-sdk/<crate version>`.
+///
+/// Sent in the `X-SDK-Version`/`x-sdk-version` request header so the server can
+/// attribute traffic to the Rust SDK (the `rust-sdk/` prefix distinguishes it
+/// from other SDKs that may send the same header) and its release. The version
+/// is resolved from the crate version at compile time, so it tracks releases
+/// automatically — unlike [`TARGET_ARKD_VERSION`], which is the hand-maintained
+/// arkd compatibility target.
+pub const SDK_VERSION: &str = concat!("rust-sdk/", env!("CARGO_PKG_VERSION"));
+
 /// An aggregate public nonce per shared internal (non-leaf) node in the batch-tree.
 #[derive(Debug, Clone)]
 pub struct NoncePks(HashMap<Txid, musig::PublicNonce>);

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -484,6 +484,25 @@ pub struct DeprecatedSigner {
     pub cutoff_date: i64,
 }
 
+impl Info {
+    /// Returns all known server signing keys: the current signer followed by all deprecated ones.
+    pub fn all_server_keys(&self) -> impl Iterator<Item = XOnlyPublicKey> + '_ {
+        std::iter::once(self.signer_pk.x_only_public_key().0)
+            .chain(self.deprecated_signers.iter().map(|ds| ds.pk.x_only_public_key().0))
+    }
+
+    /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has
+    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "no cutoff" and is never
+    /// treated as past.
+    pub fn is_signer_past_cutoff_at(&self, server_pk: XOnlyPublicKey, now_unix_secs: i64) -> bool {
+        self.deprecated_signers.iter().any(|ds| {
+            ds.cutoff_date != 0
+                && ds.cutoff_date <= now_unix_secs
+                && ds.pk.x_only_public_key().0 == server_pk
+        })
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StreamStartedEvent {
     pub id: String,

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -799,3 +799,137 @@ pub fn parse_fee_amount(amount_str: Option<String>) -> Amount {
         .map(Amount::from_sat)
         .unwrap_or(Amount::ZERO)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::address::NetworkUnchecked;
+    use bitcoin::secp256k1::PublicKey;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    // Well-known compressed secp256k1 public keys used as test fixtures.
+    const PK_A: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const PK_B: &str = "02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+    const PK_C: &str = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+    const PK_UNRELATED: &str = "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4";
+
+    fn pk(hex: &str) -> PublicKey {
+        PublicKey::from_str(hex).unwrap()
+    }
+
+    fn xonly(hex: &str) -> XOnlyPublicKey {
+        pk(hex).x_only_public_key().0
+    }
+
+    fn make_info(current_hex: &str, deprecated: Vec<(&str, i64)>) -> Info {
+        let dummy_address: bitcoin::Address<NetworkUnchecked> =
+            "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+                .parse()
+                .unwrap();
+        Info {
+            version: "1".into(),
+            signer_pk: pk(current_hex),
+            forfeit_pk: pk(current_hex),
+            forfeit_address: dummy_address.assume_checked(),
+            checkpoint_tapscript: ScriptBuf::new(),
+            network: bitcoin::Network::Testnet,
+            session_duration: 0,
+            unilateral_exit_delay: bitcoin::Sequence::ZERO,
+            boarding_exit_delay: bitcoin::Sequence::ZERO,
+            utxo_min_amount: None,
+            utxo_max_amount: None,
+            vtxo_min_amount: None,
+            vtxo_max_amount: None,
+            dust: Amount::ZERO,
+            fees: None,
+            scheduled_session: None,
+            deprecated_signers: deprecated
+                .into_iter()
+                .map(|(key, cutoff)| DeprecatedSigner {
+                    pk: pk(key),
+                    cutoff_date: cutoff,
+                })
+                .collect(),
+            service_status: HashMap::new(),
+            digest: String::new(),
+            max_tx_weight: 0,
+            max_op_return_outputs: 0,
+        }
+    }
+
+    // ── all_server_keys ──────────────────────────────────────────────────────
+
+    #[test]
+    fn all_server_keys_no_deprecated() {
+        let info = make_info(PK_A, vec![]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys, vec![xonly(PK_A)]);
+    }
+
+    #[test]
+    fn all_server_keys_includes_deprecated_in_order() {
+        let info = make_info(PK_A, vec![(PK_B, 1000), (PK_C, 2000)]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys, vec![xonly(PK_A), xonly(PK_B), xonly(PK_C)]);
+    }
+
+    #[test]
+    fn all_server_keys_current_is_always_first() {
+        let info = make_info(PK_C, vec![(PK_A, 500), (PK_B, 600)]);
+        let keys: Vec<_> = info.all_server_keys().collect();
+        assert_eq!(keys[0], xonly(PK_C));
+    }
+
+    // ── is_signer_past_cutoff_at ─────────────────────────────────────────────
+
+    #[test]
+    fn current_signer_key_is_never_past_cutoff() {
+        let info = make_info(PK_A, vec![]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_A), i64::MAX));
+    }
+
+    #[test]
+    fn unknown_key_is_not_past_cutoff() {
+        let info = make_info(PK_A, vec![(PK_B, 100)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_UNRELATED), 200));
+    }
+
+    #[test]
+    fn cutoff_zero_means_rotate_immediately_not_past_cutoff() {
+        // cutoff_date == 0 means "rotate now" but the operator still co-signs.
+        // is_signer_past_cutoff_at must return false so the key is not excluded from batches.
+        let info = make_info(PK_A, vec![(PK_B, 0)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), 9_999_999));
+    }
+
+    #[test]
+    fn future_cutoff_is_not_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now + 1)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn exact_cutoff_boundary_is_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now)]);
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn past_cutoff_is_past() {
+        let now = 1_000_000i64;
+        let info = make_info(PK_A, vec![(PK_B, now - 1)]);
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
+    }
+
+    #[test]
+    fn multiple_deprecated_only_past_key_is_flagged() {
+        let now = 1_000_000i64;
+        // PK_B: future (not past), PK_C: past
+        let info = make_info(PK_A, vec![(PK_B, now + 100), (PK_C, now - 100)]);
+        assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
+        assert!(info.is_signer_past_cutoff_at(xonly(PK_C), now));
+    }
+}

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -487,8 +487,11 @@ pub struct DeprecatedSigner {
 impl Info {
     /// Returns all known server signing keys: the current signer followed by all deprecated ones.
     pub fn all_server_keys(&self) -> impl Iterator<Item = XOnlyPublicKey> + '_ {
-        std::iter::once(self.signer_pk.x_only_public_key().0)
-            .chain(self.deprecated_signers.iter().map(|ds| ds.pk.x_only_public_key().0))
+        std::iter::once(self.signer_pk.x_only_public_key().0).chain(
+            self.deprecated_signers
+                .iter()
+                .map(|ds| ds.pk.x_only_public_key().0),
+        )
     }
 
     /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -20,6 +20,13 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// arkd build version targeted by this SDK.
+///
+/// Sent in the `X-Build-Version`/`x-build-version` request header so arkd can
+/// reject clients that target an older incompatible server version. This is the
+/// arkd protocol target, not the Rust crate version.
+pub const TARGET_ARKD_VERSION: &str = "v0.9.8";
+
 /// An aggregate public nonce per shared internal (non-leaf) node in the batch-tree.
 #[derive(Debug, Clone)]
 pub struct NoncePks(HashMap<Txid, musig::PublicNonce>);

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -28,7 +28,7 @@ use std::str::FromStr;
 ///
 /// Update this when the SDK intentionally targets a newer arkd compatibility
 /// baseline.
-pub const TARGET_ARKD_VERSION: &str = "v0.9.8";
+pub const TARGET_ARKD_VERSION: &str = "0.9.9";
 
 /// Version of this SDK, as `rust-sdk/<crate version>`.
 ///

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -25,6 +25,9 @@ use std::str::FromStr;
 /// Sent in the `X-Build-Version`/`x-build-version` request header so arkd can
 /// reject clients that target an older incompatible server version. This is the
 /// arkd protocol target, not the Rust crate version.
+///
+/// Update this when the SDK intentionally targets a newer arkd compatibility
+/// baseline.
 pub const TARGET_ARKD_VERSION: &str = "v0.9.8";
 
 /// An aggregate public nonce per shared internal (non-leaf) node in the batch-tree.

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -492,8 +492,9 @@ impl Info {
     }
 
     /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has
-    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "no cutoff" and is never
-    /// treated as past.
+    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "rotate immediately" —
+    /// the operator still co-signs but clients should migrate without delay. It is therefore
+    /// NOT treated as past-cutoff here; use `migrate_deprecated_signer_vtxos` to handle it.
     pub fn is_signer_past_cutoff_at(&self, server_pk: XOnlyPublicKey, now_unix_secs: i64) -> bool {
         self.deprecated_signers.iter().any(|ds| {
             ds.cutoff_date != 0

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -69,10 +69,12 @@ use bitcoin::ScriptBuf;
 use bitcoin::SignedAmount;
 use bitcoin::Transaction;
 use bitcoin::Txid;
+use futures::Future;
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -119,12 +121,16 @@ impl tonic::service::Interceptor for HeaderInterceptor {
 type InterceptedChannel =
     tonic::codegen::InterceptedService<tonic::transport::Channel, HeaderInterceptor>;
 
+type InfoRefreshHook =
+    Arc<dyn Fn(Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>> + Send + Sync>;
+
 #[derive(Clone)]
 pub struct Client {
     url: String,
     ark_client: Option<ArkServiceClient<InterceptedChannel>>,
     indexer_client: Option<IndexerServiceClient<InterceptedChannel>>,
     header_state: HeaderState,
+    info_refresh_hook: Option<InfoRefreshHook>,
 }
 
 impl fmt::Debug for Client {
@@ -143,7 +149,18 @@ impl Client {
             ark_client: None,
             indexer_client: None,
             header_state: HeaderState::default(),
+            info_refresh_hook: None,
         }
+    }
+
+    pub fn set_info_refresh_hook(
+        &mut self,
+        hook: impl Fn(Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+            + Send
+            + Sync
+            + 'static,
+    ) {
+        self.info_refresh_hook = Some(Arc::new(hook));
     }
 
     pub async fn connect(&mut self) -> Result<(), Error> {
@@ -174,7 +191,23 @@ impl Client {
         Ok(())
     }
 
-    pub async fn get_info(&mut self) -> Result<Info, Error> {
+    async fn guarded<T>(&self, op: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let original = err;
+                let info = self.get_info_unguarded().await?;
+                if let Some(hook) = &self.info_refresh_hook {
+                    hook(info).map_err(Error::conversion)?;
+                }
+                Err(Error::server_info_changed(original))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Bootstrap request that intentionally bypasses digest-mismatch guarding.
+    pub async fn get_info_unguarded(&self) -> Result<Info, Error> {
         let mut client = self.ark_client()?;
 
         let response = client
@@ -185,6 +218,10 @@ impl Client {
         let info: Info = response.into_inner().try_into()?;
         self.header_state.set_digest(info.digest.clone());
         Ok(info)
+    }
+
+    pub async fn get_info(&self) -> Result<Info, Error> {
+        self.get_info_unguarded().await
     }
 
     /// List VTXOs with pagination support.
@@ -199,10 +236,14 @@ impl Client {
 
         let mut client = self.indexer_client()?;
 
-        let response = client
-            .get_vtxos(generated::ark::v1::GetVtxosRequest::from(request))
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .guarded(async {
+                client
+                    .get_vtxos(generated::ark::v1::GetVtxosRequest::from(request))
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let inner = response.into_inner();
 
@@ -229,10 +270,14 @@ impl Client {
             intent: Some(intent),
         };
 
-        let response = client
-            .register_intent(request)
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .guarded(async {
+                client
+                    .register_intent(request)
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let intent_id = response.into_inner().intent_id;
 
@@ -258,13 +303,17 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .collect();
 
-        let res = client
-            .submit_tx(generated::ark::v1::SubmitTxRequest {
-                signed_ark_tx: ark_tx,
-                checkpoint_txs,
+        let res = self
+            .guarded(async {
+                client
+                    .submit_tx(generated::ark::v1::SubmitTxRequest {
+                        signed_ark_tx: ark_tx,
+                        checkpoint_txs,
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let res = res.into_inner();
 
@@ -306,13 +355,16 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .collect();
 
-        client
-            .finalize_tx(generated::ark::v1::FinalizeTxRequest {
-                ark_txid: txid.to_string(),
-                final_checkpoint_txs: checkpoint_txs,
-            })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .finalize_tx(generated::ark::v1::FinalizeTxRequest {
+                    ark_txid: txid.to_string(),
+                    final_checkpoint_txs: checkpoint_txs,
+                })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(FinalizeOffchainTxResponse {})
     }
@@ -325,14 +377,18 @@ impl Client {
 
         let intent: Intent = intent.try_into()?;
 
-        let res = client
-            .get_pending_tx(generated::ark::v1::GetPendingTxRequest {
-                identifier: Some(
-                    generated::ark::v1::get_pending_tx_request::Identifier::Intent(intent),
-                ),
+        let res = self
+            .guarded(async {
+                client
+                    .get_pending_tx(generated::ark::v1::GetPendingTxRequest {
+                        identifier: Some(
+                            generated::ark::v1::get_pending_tx_request::Identifier::Intent(intent),
+                        ),
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let inner = res.into_inner();
         let base64 = base64::engine::GeneralPurpose::new(
@@ -370,10 +426,13 @@ impl Client {
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
         let mut client = self.ark_client()?;
 
-        client
-            .confirm_registration(ConfirmRegistrationRequest { intent_id })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .confirm_registration(ConfirmRegistrationRequest { intent_id })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -386,14 +445,17 @@ impl Client {
     ) -> Result<(), Error> {
         let mut client = self.ark_client()?;
 
-        client
-            .submit_tree_nonces(SubmitTreeNoncesRequest {
-                batch_id: batch_id.to_string(),
-                pubkey: cosigner_pubkey.to_string(),
-                tree_nonces: pub_nonce_tree.encode(),
-            })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .submit_tree_nonces(SubmitTreeNoncesRequest {
+                    batch_id: batch_id.to_string(),
+                    pubkey: cosigner_pubkey.to_string(),
+                    tree_nonces: pub_nonce_tree.encode(),
+                })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -406,14 +468,17 @@ impl Client {
     ) -> Result<(), Error> {
         let mut client = self.ark_client()?;
 
-        client
-            .submit_tree_signatures(SubmitTreeSignaturesRequest {
-                batch_id: batch_id.to_string(),
-                pubkey: cosigner_pk.to_string(),
-                tree_signatures: partial_sig_tree.encode(),
-            })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .submit_tree_signatures(SubmitTreeSignaturesRequest {
+                    batch_id: batch_id.to_string(),
+                    pubkey: cosigner_pk.to_string(),
+                    tree_signatures: partial_sig_tree.encode(),
+                })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -434,16 +499,19 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .unwrap_or_default();
 
-        client
-            .submit_signed_forfeit_txs(SubmitSignedForfeitTxsRequest {
-                signed_forfeit_txs: signed_forfeit_txs
-                    .iter()
-                    .map(|psbt| base64.encode(psbt.serialize()))
-                    .collect(),
-                signed_commitment_tx,
-            })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .submit_signed_forfeit_txs(SubmitSignedForfeitTxsRequest {
+                    signed_forfeit_txs: signed_forfeit_txs
+                        .iter()
+                        .map(|psbt| base64.encode(psbt.serialize()))
+                        .collect(),
+                    signed_commitment_tx,
+                })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -454,10 +522,14 @@ impl Client {
     ) -> Result<impl Stream<Item = Result<StreamEvent, Error>> + Unpin, Error> {
         let mut client = self.ark_client()?;
 
-        let response = client
-            .get_event_stream(GetEventStreamRequest { topics })
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .guarded(async {
+                client
+                    .get_event_stream(GetEventStreamRequest { topics })
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
         let mut stream = response.into_inner();
 
         let stream = stream! {
@@ -489,10 +561,14 @@ impl Client {
     ) -> Result<impl Stream<Item = Result<StreamTransactionData, Error>> + Unpin, Error> {
         let mut client = self.ark_client()?;
 
-        let response = client
-            .get_transactions_stream(GetTransactionsStreamRequest {})
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .guarded(async {
+                client
+                    .get_transactions_stream(GetTransactionsStreamRequest {})
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let mut stream = response.into_inner();
 
@@ -526,17 +602,22 @@ impl Client {
         size_and_index: Option<(i32, i32)>,
     ) -> Result<VtxoChainResponse, Error> {
         let mut client = self.indexer_client()?;
-        let response = client
-            .get_vtxo_chain(generated::ark::v1::GetVtxoChainRequest {
-                outpoint: outpoint.map(|o| generated::ark::v1::IndexerOutpoint {
-                    txid: o.txid.to_string(),
-                    vout: o.vout,
-                }),
-                page: size_and_index
-                    .map(|(size, index)| generated::ark::v1::IndexerPageRequest { size, index }),
+        let response = self
+            .guarded(async {
+                client
+                    .get_vtxo_chain(generated::ark::v1::GetVtxoChainRequest {
+                        outpoint: outpoint.map(|o| generated::ark::v1::IndexerOutpoint {
+                            txid: o.txid.to_string(),
+                            vout: o.vout,
+                        }),
+                        page: size_and_index.map(|(size, index)| {
+                            generated::ark::v1::IndexerPageRequest { size, index }
+                        }),
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
         let result = response.try_into()?;
         Ok(result)
@@ -548,14 +629,19 @@ impl Client {
         size_and_index: Option<(i32, i32)>,
     ) -> Result<VirtualTxsResponse, Error> {
         let mut client = self.indexer_client()?;
-        let response = client
-            .get_virtual_txs(generated::ark::v1::GetVirtualTxsRequest {
-                txids,
-                page: size_and_index
-                    .map(|(size, index)| generated::ark::v1::IndexerPageRequest { size, index }),
+        let response = self
+            .guarded(async {
+                client
+                    .get_virtual_txs(generated::ark::v1::GetVirtualTxsRequest {
+                        txids,
+                        page: size_and_index.map(|(size, index)| {
+                            generated::ark::v1::IndexerPageRequest { size, index }
+                        }),
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
         let result = response.try_into()?;
         Ok(result)
@@ -584,13 +670,17 @@ impl Client {
         // For new subscription we expect empty string ("") here
         let subscription_id = subscription_id.unwrap_or_default();
 
-        let response = client
-            .subscribe_for_scripts(SubscribeForScriptsRequest {
-                scripts,
-                subscription_id,
+        let response = self
+            .guarded(async {
+                client
+                    .subscribe_for_scripts(SubscribeForScriptsRequest {
+                        scripts,
+                        subscription_id,
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let response = response.into_inner();
 
@@ -609,13 +699,16 @@ impl Client {
             .map(|address| address.to_p2tr_script_pubkey().to_hex_string())
             .collect::<Vec<_>>();
 
-        let _ = client
-            .unsubscribe_for_scripts(UnsubscribeForScriptsRequest {
-                subscription_id,
-                scripts,
-            })
-            .await
-            .map_err(Error::request)?;
+        self.guarded(async {
+            client
+                .unsubscribe_for_scripts(UnsubscribeForScriptsRequest {
+                    subscription_id,
+                    scripts,
+                })
+                .await
+                .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -627,10 +720,14 @@ impl Client {
     ) -> Result<impl Stream<Item = Result<SubscriptionResponse, Error>> + Unpin, Error> {
         let mut client = self.indexer_client()?;
 
-        let response = client
-            .get_subscription(GetSubscriptionRequest { subscription_id })
-            .await
-            .map_err(Error::request)?;
+        let response = self
+            .guarded(async {
+                client
+                    .get_subscription(GetSubscriptionRequest { subscription_id })
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let mut stream = response.into_inner();
 
@@ -667,12 +764,16 @@ impl Client {
         let mut client = self.ark_client()?;
 
         let intent = intent.try_into()?;
-        let response = client
-            .estimate_intent_fee(EstimateIntentFeeRequest {
-                intent: Some(intent),
+        let response = self
+            .guarded(async {
+                client
+                    .estimate_intent_fee(EstimateIntentFeeRequest {
+                        intent: Some(intent),
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
         let response = response.into_inner();
 
         Ok(SignedAmount::from_sat(response.fee))
@@ -681,12 +782,16 @@ impl Client {
     pub async fn get_asset(&self, asset_id: AssetId) -> Result<AssetInfo, Error> {
         let mut client = self.indexer_client()?;
 
-        let response = client
-            .get_asset(generated::ark::v1::GetAssetRequest {
-                asset_id: asset_id.to_string(),
+        let response = self
+            .guarded(async {
+                client
+                    .get_asset(generated::ark::v1::GetAssetRequest {
+                        asset_id: asset_id.to_string(),
+                    })
+                    .await
+                    .map_err(Error::request)
             })
-            .await
-            .map_err(Error::request)?;
+            .await?;
 
         let inner = response.into_inner();
 

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -75,28 +75,56 @@ use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::RwLock;
 
-#[derive(Clone, Copy)]
-struct VersionInterceptor;
+#[derive(Clone, Default)]
+struct HeaderState {
+    digest: Arc<RwLock<Option<String>>>,
+}
 
-impl tonic::service::Interceptor for VersionInterceptor {
+impl HeaderState {
+    fn set_digest(&self, digest: String) {
+        if let Ok(mut guard) = self.digest.write() {
+            *guard = (!digest.is_empty()).then_some(digest);
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct HeaderInterceptor {
+    state: HeaderState,
+}
+
+impl tonic::service::Interceptor for HeaderInterceptor {
     fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
-        req.metadata_mut().insert(
+        let metadata = req.metadata_mut();
+        metadata.insert(
             "x-build-version",
             tonic::metadata::MetadataValue::from_static(TARGET_ARKD_VERSION),
         );
+
+        if let Ok(guard) = self.state.digest.read() {
+            if let Some(digest) = guard.as_deref() {
+                if let Ok(value) = tonic::metadata::MetadataValue::try_from(digest) {
+                    metadata.insert("x-digest", value);
+                }
+            }
+        }
+
         Ok(req)
     }
 }
 
 type InterceptedChannel =
-    tonic::codegen::InterceptedService<tonic::transport::Channel, VersionInterceptor>;
+    tonic::codegen::InterceptedService<tonic::transport::Channel, HeaderInterceptor>;
 
 #[derive(Clone)]
 pub struct Client {
     url: String,
     ark_client: Option<ArkServiceClient<InterceptedChannel>>,
     indexer_client: Option<IndexerServiceClient<InterceptedChannel>>,
+    header_state: HeaderState,
 }
 
 impl fmt::Debug for Client {
@@ -114,6 +142,7 @@ impl Client {
             url,
             ark_client: None,
             indexer_client: None,
+            header_state: HeaderState::default(),
         }
     }
 
@@ -133,9 +162,12 @@ impl Client {
 
         let channel = endpoint.connect().await.map_err(Error::connect)?;
 
+        let interceptor = HeaderInterceptor {
+            state: self.header_state.clone(),
+        };
         let ark_service_client =
-            ArkServiceClient::with_interceptor(channel.clone(), VersionInterceptor);
-        let indexer_client = IndexerServiceClient::with_interceptor(channel, VersionInterceptor);
+            ArkServiceClient::with_interceptor(channel.clone(), interceptor.clone());
+        let indexer_client = IndexerServiceClient::with_interceptor(channel, interceptor);
 
         self.ark_client = Some(ark_service_client);
         self.indexer_client = Some(indexer_client);
@@ -150,7 +182,9 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        response.into_inner().try_into()
+        let info: Info = response.into_inner().try_into()?;
+        self.header_state.set_digest(info.digest.clone());
+        Ok(info)
     }
 
     /// List VTXOs with pagination support.

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -55,6 +55,7 @@ use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
 use ark_core::server::VtxoChain;
 use ark_core::server::VtxoChains;
+use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use ark_core::TxGraphChunk;
 use async_stream::stream;
@@ -82,7 +83,7 @@ impl tonic::service::Interceptor for VersionInterceptor {
     fn call(&mut self, mut req: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
         req.metadata_mut().insert(
             "x-build-version",
-            tonic::metadata::MetadataValue::from_static(env!("CARGO_PKG_VERSION")),
+            tonic::metadata::MetadataValue::from_static(TARGET_ARKD_VERSION),
         );
         Ok(req)
     }

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -55,6 +55,7 @@ use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
 use ark_core::server::VtxoChain;
 use ark_core::server::VtxoChains;
+use ark_core::server::SDK_VERSION;
 use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use ark_core::TxGraphChunk;
@@ -119,6 +120,10 @@ impl tonic::service::Interceptor for HeaderInterceptor {
         metadata.insert(
             "x-build-version",
             tonic::metadata::MetadataValue::from_static(TARGET_ARKD_VERSION),
+        );
+        metadata.insert(
+            "x-sdk-version",
+            tonic::metadata::MetadataValue::from_static(SDK_VERSION),
         );
 
         if let Some(digest) = self.state.digest() {

--- a/ark-grpc/src/client.rs
+++ b/ark-grpc/src/client.rs
@@ -87,8 +87,23 @@ struct HeaderState {
 
 impl HeaderState {
     fn set_digest(&self, digest: String) {
-        if let Ok(mut guard) = self.digest.write() {
-            *guard = (!digest.is_empty()).then_some(digest);
+        let digest = (!digest.is_empty()).then_some(digest);
+        match self.digest.write() {
+            Ok(mut guard) => *guard = digest,
+            Err(poisoned) => {
+                log::warn!("digest header state lock poisoned while updating; recovering");
+                *poisoned.into_inner() = digest;
+            }
+        }
+    }
+
+    fn digest(&self) -> Option<String> {
+        match self.digest.read() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                log::warn!("digest header state lock poisoned while reading; recovering");
+                poisoned.into_inner().clone()
+            }
         }
     }
 }
@@ -106,11 +121,9 @@ impl tonic::service::Interceptor for HeaderInterceptor {
             tonic::metadata::MetadataValue::from_static(TARGET_ARKD_VERSION),
         );
 
-        if let Ok(guard) = self.state.digest.read() {
-            if let Some(digest) = guard.as_deref() {
-                if let Ok(value) = tonic::metadata::MetadataValue::try_from(digest) {
-                    metadata.insert("x-digest", value);
-                }
+        if let Some(digest) = self.state.digest() {
+            if let Ok(value) = tonic::metadata::MetadataValue::try_from(digest.as_str()) {
+                metadata.insert("x-digest", value);
             }
         }
 

--- a/ark-grpc/src/error.rs
+++ b/ark-grpc/src/error.rs
@@ -70,6 +70,19 @@ impl Error {
         false
     }
 
+    /// Returns `true` if the server rejected the request because the cached
+    /// `/info` digest is stale.
+    pub fn is_digest_mismatch(&self) -> bool {
+        if let Some(source) = &self.inner.source {
+            if let Some(status) = source.downcast_ref::<tonic::Status>() {
+                return status.code() == tonic::Code::FailedPrecondition
+                    && (status.message().contains("DIGEST_MISMATCH")
+                        || status.message().contains("invalid digest header"));
+            }
+        }
+        false
+    }
+
     fn description(&self) -> &str {
         match &self.inner.kind {
             Kind::Connect => "failed to connect to Ark server",
@@ -151,5 +164,26 @@ mod tests {
     fn is_version_mismatch_false_when_no_source() {
         let err = Error::not_connected();
         assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_for_matching_status() {
+        let status = tonic::Status::failed_precondition("invalid digest header");
+        let err = Error::request(status);
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_for_error_code_in_message() {
+        let status = tonic::Status::failed_precondition("DIGEST_MISMATCH");
+        let err = Error::request(status);
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_false_for_other_failed_precondition() {
+        let status = tonic::Status::failed_precondition("something else");
+        let err = Error::request(status);
+        assert!(!err.is_digest_mismatch());
     }
 }

--- a/ark-grpc/src/error.rs
+++ b/ark-grpc/src/error.rs
@@ -20,6 +20,7 @@ enum Kind {
     Conversion,
     EventStreamDisconnect,
     EventStream,
+    ServerInfoChanged,
 }
 
 impl Error {
@@ -58,6 +59,14 @@ impl Error {
         Error::new(Kind::EventStream).with(source)
     }
 
+    pub(crate) fn server_info_changed(source: impl Into<Source>) -> Self {
+        Error::new(Kind::ServerInfoChanged).with(source)
+    }
+
+    pub fn is_server_info_changed(&self) -> bool {
+        matches!(self.inner.kind, Kind::ServerInfoChanged)
+    }
+
     /// Returns `true` if the server rejected the request because the SDK
     /// version is too old.
     pub fn is_version_mismatch(&self) -> bool {
@@ -91,6 +100,7 @@ impl Error {
             Kind::Conversion => "failed to convert between types",
             Kind::EventStreamDisconnect => "got disconnected from event stream",
             Kind::EventStream => "error via event stream",
+            Kind::ServerInfoChanged => "Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe",
         }
     }
 }

--- a/ark-grpc/src/test_utils.rs
+++ b/ark-grpc/src/test_utils.rs
@@ -6,6 +6,10 @@
 pub use crate::generated::ark::v1::admin_service_client::AdminServiceClient;
 pub use crate::generated::ark::v1::CreateNoteRequest;
 pub use crate::generated::ark::v1::CreateNoteResponse;
+pub use crate::generated::ark::v1::GetInfoRequest;
+pub use crate::generated::ark::v1::GetInfoResponse;
+pub use crate::generated::ark::v1::GetVtxosRequest;
+pub use crate::generated::ark::v1::GetVtxosResponse;
 use ark_core::ArkNote;
 
 /// Default admin service URL (arkd runs admin on port 7071).

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -43,9 +43,10 @@ use bitcoin::Txid;
 use futures::stream;
 use futures::Stream;
 use futures::StreamExt;
+use std::sync::RwLock;
 
 pub struct Client {
-    configuration: apis::configuration::Configuration,
+    configuration: RwLock<apis::configuration::Configuration>,
 }
 
 pub struct ListVtxosResponse {
@@ -53,33 +54,62 @@ pub struct ListVtxosResponse {
     pub page: Option<IndexerPage>,
 }
 
+fn build_reqwest_client(digest: Option<&str>) -> Result<reqwest::Client, Error> {
+    let mut default_headers = reqwest::header::HeaderMap::new();
+    default_headers.insert(
+        "X-Build-Version",
+        reqwest::header::HeaderValue::from_static(TARGET_ARKD_VERSION),
+    );
+    if let Some(digest) = digest {
+        default_headers.insert(
+            "X-Digest",
+            reqwest::header::HeaderValue::from_str(digest).map_err(Error::request)?,
+        );
+    }
+
+    reqwest::Client::builder()
+        .default_headers(default_headers)
+        .build()
+        .map_err(Error::request)
+}
+
 impl Client {
     pub fn new(ark_server_url: String) -> Result<Self, Error> {
-        let mut default_headers = reqwest::header::HeaderMap::new();
-        default_headers.insert(
-            "X-Build-Version",
-            reqwest::header::HeaderValue::from_static(TARGET_ARKD_VERSION),
-        );
-        let client = reqwest::Client::builder()
-            .default_headers(default_headers)
-            .build()
-            .map_err(Error::request)?;
-
         let configuration = apis::configuration::Configuration {
             base_path: ark_server_url,
-            client,
+            client: build_reqwest_client(None)?,
             ..Default::default()
         };
 
-        Ok(Self { configuration })
+        Ok(Self {
+            configuration: RwLock::new(configuration),
+        })
+    }
+
+    fn configuration(&self) -> Result<apis::configuration::Configuration, Error> {
+        self.configuration
+            .read()
+            .map(|configuration| configuration.clone())
+            .map_err(|_| Error::request("REST client configuration lock poisoned"))
+    }
+
+    fn update_digest(&self, digest: &str) -> Result<(), Error> {
+        let mut configuration = self
+            .configuration
+            .write()
+            .map_err(|_| Error::request("REST client configuration lock poisoned"))?;
+        configuration.client = build_reqwest_client((!digest.is_empty()).then_some(digest))?;
+        Ok(())
     }
 
     pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
-        let info = ark_service_get_info(&self.configuration)
+        let configuration = self.configuration()?;
+        let info = ark_service_get_info(&configuration)
             .await
             .map_err(Error::request)?;
 
-        let info = info.try_into()?;
+        let info: ark_core::server::Info = info.try_into()?;
+        self.update_digest(&info.digest)?;
 
         Ok(info)
     }
@@ -102,7 +132,7 @@ impl Client {
             .collect();
 
         let res = ark_service_submit_tx(
-            &self.configuration,
+            &self.configuration()?,
             models::SubmitTxRequest {
                 signed_ark_tx: Some(ark_tx),
                 checkpoint_txs,
@@ -151,7 +181,7 @@ impl Client {
             .collect();
 
         ark_service_finalize_tx(
-            &self.configuration,
+            &self.configuration()?,
             models::FinalizeTxRequest {
                 ark_txid: Some(txid.to_string()),
                 final_checkpoint_txs: checkpoint_txs,
@@ -207,7 +237,7 @@ impl Client {
         let after = request.after().map(|b| b as i64);
 
         let response = indexer_service_get_vtxos(
-            &self.configuration,
+            &self.configuration()?,
             scripts,
             outpoints,
             spendable_only,
@@ -253,7 +283,7 @@ impl Client {
         let proof = base64.encode(&bytes);
 
         let response = ark_service_register_intent(
-            &self.configuration,
+            &self.configuration()?,
             models::RegisterIntentRequest {
                 intent: Some(Intent {
                     proof: Some(proof),
@@ -285,7 +315,7 @@ impl Client {
 
         let proof = base64.encode(&bytes);
         ark_service_delete_intent(
-            &self.configuration,
+            &self.configuration()?,
             models::DeleteIntentRequest {
                 intent: Some(Intent {
                     proof: Some(proof),
@@ -303,8 +333,10 @@ impl Client {
         &self,
         topics: Vec<String>,
     ) -> Result<impl Stream<Item = Result<StreamEvent, Error>> + Unpin, Error> {
+        let configuration = self.configuration()?;
+
         // Build the URL with query parameters
-        let mut url = format!("{}/v1/batch/events", self.configuration.base_path);
+        let mut url = format!("{}/v1/batch/events", configuration.base_path);
         if !topics.is_empty() {
             let query_params: Vec<String> = topics
                 .iter()
@@ -314,8 +346,8 @@ impl Client {
         }
 
         // Create the request for SSE
-        let client = &self.configuration.client;
-        let request = client
+        let request = configuration
+            .client
             .get(&url)
             .header("Accept", "text/event-stream")
             .send()
@@ -380,7 +412,7 @@ impl Client {
     }
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
         ark_service_confirm_registration(
-            &self.configuration,
+            &self.configuration()?,
             ConfirmRegistrationRequest {
                 intent_id: Some(intent_id),
             },
@@ -400,7 +432,7 @@ impl Client {
         let tree_nonces = pub_nonce_tree.encode();
 
         ark_service_submit_tree_nonces(
-            &self.configuration,
+            &self.configuration()?,
             SubmitTreeNoncesRequest {
                 batch_id: Some(batch_id.to_string()),
                 pubkey: Some(cosigner_pubkey.to_string()),
@@ -422,7 +454,7 @@ impl Client {
         let tree_signatures = partial_sig_tree.encode();
 
         ark_service_submit_tree_signatures(
-            &self.configuration,
+            &self.configuration()?,
             SubmitTreeSignaturesRequest {
                 batch_id: Some(batch_id.to_string()),
                 pubkey: Some(cosigner_pk.to_string()),
@@ -450,7 +482,7 @@ impl Client {
             .unwrap_or_default();
 
         ark_service_submit_signed_forfeit_txs(
-            &self.configuration,
+            &self.configuration()?,
             SubmitSignedForfeitTxsRequest {
                 signed_forfeit_txs: signed_forfeit_txs
                     .iter()
@@ -488,7 +520,7 @@ impl Client {
         let subscription_id = subscription_id.unwrap_or_default();
 
         let response = indexer_service_subscribe_for_scripts(
-            &self.configuration,
+            &self.configuration()?,
             SubscribeForScriptsRequest {
                 scripts: Some(scripts),
                 subscription_id: Some(subscription_id),
@@ -516,7 +548,7 @@ impl Client {
             .collect::<Vec<_>>();
 
         let _ = indexer_service_unsubscribe_for_scripts(
-            &self.configuration,
+            &self.configuration()?,
             UnsubscribeForScriptsRequest {
                 subscription_id: Some(subscription_id),
                 scripts: Some(scripts),
@@ -532,15 +564,17 @@ impl Client {
         &self,
         subscription_id: String,
     ) -> Result<impl Stream<Item = Result<SubscriptionResponse, Error>> + Unpin, Error> {
+        let configuration = self.configuration()?;
+
         // Build the URL with subscription_id parameter
         let url = format!(
             "{}/v1/script/subscription/{subscription_id}",
-            self.configuration.base_path,
+            configuration.base_path,
         );
 
         // Create the request for SSE
-        let client = &self.configuration.client;
-        let request = client
+        let request = configuration
+            .client
             .get(&url)
             .header("Accept", "text/event-stream")
             .send()
@@ -614,7 +648,7 @@ impl Client {
         let (size, index) = size_and_index
             .map(|(sz, indx)| (Some(sz), Some(indx)))
             .unwrap_or_default();
-        let response = indexer_service_get_virtual_txs(&self.configuration, txids, size, index)
+        let response = indexer_service_get_virtual_txs(&self.configuration()?, txids, size, index)
             .await
             .map_err(Error::request)?;
 

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -41,12 +41,22 @@ use bitcoin::secp256k1::PublicKey;
 use bitcoin::Psbt;
 use bitcoin::Txid;
 use futures::stream;
+use futures::Future;
 use futures::Stream;
 use futures::StreamExt;
+use std::error::Error as StdError;
+use std::sync::Arc;
 use std::sync::RwLock;
+
+type InfoRefreshHook = Arc<
+    dyn Fn(ark_core::server::Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+        + Send
+        + Sync,
+>;
 
 pub struct Client {
     configuration: RwLock<apis::configuration::Configuration>,
+    info_refresh_hook: Option<InfoRefreshHook>,
 }
 
 pub struct ListVtxosResponse {
@@ -83,7 +93,22 @@ impl Client {
 
         Ok(Self {
             configuration: RwLock::new(configuration),
+            info_refresh_hook: None,
         })
+    }
+
+    /// Register a callback invoked with the freshly fetched [`ark_core::server::Info`] whenever a
+    /// mutating call triggers a digest-mismatch refresh (see [`Self::guarded`]). Mirrors
+    /// `ark_grpc::Client::set_info_refresh_hook`; lets `ark-client` keep its cached server info
+    /// (including `deprecated_signers`) up to date so the background migration watcher reacts.
+    pub fn set_info_refresh_hook(
+        &mut self,
+        hook: impl Fn(ark_core::server::Info) -> Result<(), Box<dyn StdError + Send + Sync + 'static>>
+            + Send
+            + Sync
+            + 'static,
+    ) {
+        self.info_refresh_hook = Some(Arc::new(hook));
     }
 
     fn configuration(&self) -> Result<apis::configuration::Configuration, Error> {
@@ -102,7 +127,29 @@ impl Client {
         Ok(())
     }
 
-    pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
+    /// Run a mutating request and, on a digest mismatch, refresh `/info` before surfacing the
+    /// error. Mirrors `ark_grpc::Client::guarded`: the server signals `DIGEST_MISMATCH` when the
+    /// cached `/info` digest (sent as `X-Digest`) is stale; we re-fetch `/info` (which updates the
+    /// cached digest header and invokes [`Self::set_info_refresh_hook`]), then return
+    /// [`Error::server_info_changed`] WITHOUT retrying the original request — the caller must
+    /// rebuild it against the refreshed server info if a retry is safe.
+    async fn guarded<T>(&self, op: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
+        match op.await {
+            Ok(value) => Ok(value),
+            Err(err) if err.is_digest_mismatch() => {
+                let info = self.get_info_unguarded().await?;
+                if let Some(hook) = &self.info_refresh_hook {
+                    hook(info).map_err(Error::conversion)?;
+                }
+                Err(Error::server_info_changed(err))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Fetch `/info`, updating the cached `X-Digest` header. Intentionally bypasses
+    /// digest-mismatch guarding (it is the bootstrap/refresh request itself).
+    pub async fn get_info_unguarded(&self) -> Result<ark_core::server::Info, Error> {
         let configuration = self.configuration()?;
         let info = ark_service_get_info(&configuration)
             .await
@@ -112,6 +159,10 @@ impl Client {
         self.update_digest(&info.digest)?;
 
         Ok(info)
+    }
+
+    pub async fn get_info(&self) -> Result<ark_core::server::Info, Error> {
+        self.get_info_unguarded().await
     }
 
     pub async fn submit_offchain_transaction_request(
@@ -131,15 +182,20 @@ impl Client {
             .map(|tx| Some(base64.encode(tx.serialize())))
             .collect();
 
-        let res = ark_service_submit_tx(
-            &self.configuration()?,
-            models::SubmitTxRequest {
-                signed_ark_tx: Some(ark_tx),
-                checkpoint_txs,
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let res = self
+            .guarded(async {
+                ark_service_submit_tx(
+                    &configuration,
+                    models::SubmitTxRequest {
+                        signed_ark_tx: Some(ark_tx),
+                        checkpoint_txs,
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let signed_ark_tx = res.final_ark_tx;
         let signed_ark_tx = signed_ark_tx.ok_or(Error::request("Signed ark tx not received"))?;
@@ -180,15 +236,19 @@ impl Client {
             .map(|tx| Some(base64.encode(tx.serialize())))
             .collect();
 
-        ark_service_finalize_tx(
-            &self.configuration()?,
-            models::FinalizeTxRequest {
-                ark_txid: Some(txid.to_string()),
-                final_checkpoint_txs: checkpoint_txs,
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_finalize_tx(
+                &configuration,
+                models::FinalizeTxRequest {
+                    ark_txid: Some(txid.to_string()),
+                    final_checkpoint_txs: checkpoint_txs,
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(FinalizeOffchainTxResponse {})
     }
@@ -282,17 +342,22 @@ impl Client {
 
         let proof = base64.encode(&bytes);
 
-        let response = ark_service_register_intent(
-            &self.configuration()?,
-            models::RegisterIntentRequest {
-                intent: Some(Intent {
-                    proof: Some(proof),
-                    message: Some(message),
-                }),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                ark_service_register_intent(
+                    &configuration,
+                    models::RegisterIntentRequest {
+                        intent: Some(Intent {
+                            proof: Some(proof),
+                            message: Some(message),
+                        }),
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
         let intent_id = response
             .intent_id
             .ok_or(Error::request("Could not get intent id"))?;
@@ -314,17 +379,21 @@ impl Client {
         let bytes = proof.serialize();
 
         let proof = base64.encode(&bytes);
-        ark_service_delete_intent(
-            &self.configuration()?,
-            models::DeleteIntentRequest {
-                intent: Some(Intent {
-                    proof: Some(proof),
-                    message: Some(message),
-                }),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_delete_intent(
+                &configuration,
+                models::DeleteIntentRequest {
+                    intent: Some(Intent {
+                        proof: Some(proof),
+                        message: Some(message),
+                    }),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -411,14 +480,18 @@ impl Client {
         Ok(Box::pin(stream))
     }
     pub async fn confirm_registration(&self, intent_id: String) -> Result<(), Error> {
-        ark_service_confirm_registration(
-            &self.configuration()?,
-            ConfirmRegistrationRequest {
-                intent_id: Some(intent_id),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_confirm_registration(
+                &configuration,
+                ConfirmRegistrationRequest {
+                    intent_id: Some(intent_id),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -431,16 +504,20 @@ impl Client {
     ) -> Result<(), Error> {
         let tree_nonces = pub_nonce_tree.encode();
 
-        ark_service_submit_tree_nonces(
-            &self.configuration()?,
-            SubmitTreeNoncesRequest {
-                batch_id: Some(batch_id.to_string()),
-                pubkey: Some(cosigner_pubkey.to_string()),
-                tree_nonces: Some(tree_nonces),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_tree_nonces(
+                &configuration,
+                SubmitTreeNoncesRequest {
+                    batch_id: Some(batch_id.to_string()),
+                    pubkey: Some(cosigner_pubkey.to_string()),
+                    tree_nonces: Some(tree_nonces),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -453,16 +530,20 @@ impl Client {
     ) -> Result<(), Error> {
         let tree_signatures = partial_sig_tree.encode();
 
-        ark_service_submit_tree_signatures(
-            &self.configuration()?,
-            SubmitTreeSignaturesRequest {
-                batch_id: Some(batch_id.to_string()),
-                pubkey: Some(cosigner_pk.to_string()),
-                tree_signatures: Some(tree_signatures),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_tree_signatures(
+                &configuration,
+                SubmitTreeSignaturesRequest {
+                    batch_id: Some(batch_id.to_string()),
+                    pubkey: Some(cosigner_pk.to_string()),
+                    tree_signatures: Some(tree_signatures),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -481,18 +562,22 @@ impl Client {
             .map(|tx| base64.encode(tx.serialize()))
             .unwrap_or_default();
 
-        ark_service_submit_signed_forfeit_txs(
-            &self.configuration()?,
-            SubmitSignedForfeitTxsRequest {
-                signed_forfeit_txs: signed_forfeit_txs
-                    .iter()
-                    .map(|psbt| Some(base64.encode(psbt.serialize())))
-                    .collect(),
-                signed_commitment_tx: Some(signed_commitment_tx),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            ark_service_submit_signed_forfeit_txs(
+                &configuration,
+                SubmitSignedForfeitTxsRequest {
+                    signed_forfeit_txs: signed_forfeit_txs
+                        .iter()
+                        .map(|psbt| Some(base64.encode(psbt.serialize())))
+                        .collect(),
+                    signed_commitment_tx: Some(signed_commitment_tx),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -677,5 +762,60 @@ impl Client {
                 total: a.total.unwrap_or_default(),
             }),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
+
+    /// A non-digest error passes through `guarded` untouched: no refresh, no hook, no
+    /// `server_info_changed` rewrap.
+    #[tokio::test]
+    async fn guarded_passes_through_non_digest_error() {
+        let mut client = Client::new("http://127.0.0.1:1".to_string()).unwrap();
+        let hook_fired = Arc::new(AtomicBool::new(false));
+        let flag = hook_fired.clone();
+        client.set_info_refresh_hook(move |_info| {
+            flag.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let err = client
+            .guarded(async { Err::<(), _>(Error::request("connection refused")) })
+            .await
+            .expect_err("should surface the original error");
+
+        assert!(!err.is_server_info_changed());
+        assert!(!err.is_digest_mismatch());
+        assert!(!hook_fired.load(Ordering::SeqCst));
+    }
+
+    /// A digest-mismatch error routes into the refresh branch: `guarded` attempts to re-fetch
+    /// `/info`. Here `base_path` points at a closed port so the refetch fails, proving the branch
+    /// was taken (the original error is NOT returned verbatim — it is replaced by the failed
+    /// refresh attempt) without needing a live server. The hook only fires once the refetch
+    /// succeeds, so it stays unfired here.
+    #[tokio::test]
+    async fn guarded_detects_digest_mismatch_and_attempts_refresh() {
+        let mut client = Client::new("http://127.0.0.1:1".to_string()).unwrap();
+        let hook_fired = Arc::new(AtomicBool::new(false));
+        let flag = hook_fired.clone();
+        client.set_info_refresh_hook(move |_info| {
+            flag.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+
+        let err = client
+            .guarded(async { Err::<(), _>(Error::request("DIGEST_MISMATCH")) })
+            .await
+            .expect_err("digest mismatch should trigger a refresh that fails on a closed port");
+
+        // The refetch failed, so we get its request error, not the original passed straight
+        // through and not `server_info_changed` (which only happens on a successful refresh).
+        assert!(!err.is_server_info_changed());
+        assert!(!hook_fired.load(Ordering::SeqCst));
     }
 }

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -33,6 +33,7 @@ use ark_core::server::SubmitOffchainTxResponse;
 use ark_core::server::SubscriptionResponse;
 use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
+use ark_core::server::SDK_VERSION;
 use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use bitcoin::base64;
@@ -69,6 +70,10 @@ fn build_reqwest_client(digest: Option<&str>) -> Result<reqwest::Client, Error> 
     default_headers.insert(
         "X-Build-Version",
         reqwest::header::HeaderValue::from_static(TARGET_ARKD_VERSION),
+    );
+    default_headers.insert(
+        "X-Sdk-Version",
+        reqwest::header::HeaderValue::from_static(SDK_VERSION),
     );
     if let Some(digest) = digest {
         default_headers.insert(

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -144,6 +144,11 @@ impl Client {
             }
         }
 
+        // Lock-ordering invariant: when both are held, `configuration` is acquired before
+        // `digest`. This is the only place both write locks are taken; keep that order if other
+        // code paths ever need both, to avoid a deadlock. A benign race (two threads passing the
+        // unchanged-check above and both rebuilding) only costs a redundant rebuild, not
+        // correctness.
         let mut configuration = self
             .configuration
             .write()

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -167,15 +167,29 @@ impl Client {
     async fn guarded<T>(&self, op: impl Future<Output = Result<T, Error>>) -> Result<T, Error> {
         match op.await {
             Ok(value) => Ok(value),
-            Err(err) if err.is_digest_mismatch() => {
-                let info = self.get_info_unguarded().await?;
-                if let Some(hook) = &self.info_refresh_hook {
-                    hook(info).map_err(Error::conversion)?;
-                }
-                Err(Error::server_info_changed(err))
-            }
-            Err(err) => Err(err),
+            Err(err) => Err(self.refresh_on_digest_mismatch(err).await),
         }
+    }
+
+    /// If `err` is a digest mismatch, re-fetch `/info` (updating the cached `X-Digest` header and
+    /// invoking [`Self::set_info_refresh_hook`]) and rewrap as [`Error::server_info_changed`];
+    /// otherwise return `err` unchanged. Errors from the refresh or the hook are surfaced in place.
+    /// Shared by [`Self::guarded`] (unary calls) and the SSE connection paths, which detect the
+    /// mismatch from the streaming response's status + body rather than a generated error.
+    async fn refresh_on_digest_mismatch(&self, err: Error) -> Error {
+        if !err.is_digest_mismatch() {
+            return err;
+        }
+        let info = match self.get_info_unguarded().await {
+            Ok(info) => info,
+            Err(refresh_err) => return refresh_err,
+        };
+        if let Some(hook) = &self.info_refresh_hook {
+            if let Err(hook_err) = hook(info).map_err(Error::conversion) {
+                return hook_err;
+            }
+        }
+        Error::server_info_changed(err)
     }
 
     /// Fetch `/info`, updating the cached `X-Digest` header. Intentionally bypasses
@@ -459,12 +473,16 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        // Check if the request was successful
+        // Check if the request was successful. Read the body (not just the status) so a
+        // DIGEST_MISMATCH marker is visible to `refresh_on_digest_mismatch`, which refreshes
+        // `/info` and surfaces `ServerInfoChanged` — matching the unary guarded path.
         if !request.status().is_success() {
-            return Err(Error::request(format!(
-                "Event stream request failed with status: {}",
-                request.status()
-            )));
+            let status = request.status();
+            let body = request.text().await.unwrap_or_default();
+            let err = Error::request(format!(
+                "Event stream request failed with status {status}: {body}"
+            ));
+            return Err(self.refresh_on_digest_mismatch(err).await);
         }
 
         // Convert the response into a byte stream using async chunks
@@ -640,15 +658,20 @@ impl Client {
         // For new subscription we expect empty string ("") here
         let subscription_id = subscription_id.unwrap_or_default();
 
-        let response = indexer_service_subscribe_for_scripts(
-            &self.configuration()?,
-            SubscribeForScriptsRequest {
-                scripts: Some(scripts),
-                subscription_id: Some(subscription_id),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_subscribe_for_scripts(
+                    &configuration,
+                    SubscribeForScriptsRequest {
+                        scripts: Some(scripts),
+                        subscription_id: Some(subscription_id),
+                    },
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let subscription_id = response
             .subscription_id
@@ -668,15 +691,19 @@ impl Client {
             .map(|address| address.to_p2tr_script_pubkey().to_hex_string())
             .collect::<Vec<_>>();
 
-        let _ = indexer_service_unsubscribe_for_scripts(
-            &self.configuration()?,
-            UnsubscribeForScriptsRequest {
-                subscription_id: Some(subscription_id),
-                scripts: Some(scripts),
-            },
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        self.guarded(async {
+            indexer_service_unsubscribe_for_scripts(
+                &configuration,
+                UnsubscribeForScriptsRequest {
+                    subscription_id: Some(subscription_id),
+                    scripts: Some(scripts),
+                },
+            )
+            .await
+            .map_err(Error::request)
+        })
+        .await?;
 
         Ok(())
     }
@@ -702,12 +729,16 @@ impl Client {
             .await
             .map_err(Error::request)?;
 
-        // Check if the request was successful
+        // Check if the request was successful. Read the body (not just the status) so a
+        // DIGEST_MISMATCH marker is visible to `refresh_on_digest_mismatch`, which refreshes
+        // `/info` and surfaces `ServerInfoChanged` — matching the unary guarded path.
         if !request.status().is_success() {
-            return Err(Error::request(format!(
-                "Subscription stream request failed with status: {}",
-                request.status()
-            )));
+            let status = request.status();
+            let body = request.text().await.unwrap_or_default();
+            let err = Error::request(format!(
+                "Subscription stream request failed with status {status}: {body}"
+            ));
+            return Err(self.refresh_on_digest_mismatch(err).await);
         }
 
         // Convert the response into a byte stream using async chunks

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -33,6 +33,7 @@ use ark_core::server::SubmitOffchainTxResponse;
 use ark_core::server::SubscriptionResponse;
 use ark_core::server::VirtualTxOutPoint;
 use ark_core::server::VirtualTxsResponse;
+use ark_core::server::TARGET_ARKD_VERSION;
 use ark_core::ArkAddress;
 use bitcoin::base64;
 use bitcoin::base64::Engine;
@@ -57,7 +58,7 @@ impl Client {
         let mut default_headers = reqwest::header::HeaderMap::new();
         default_headers.insert(
             "X-Build-Version",
-            reqwest::header::HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
+            reqwest::header::HeaderValue::from_static(TARGET_ARKD_VERSION),
         );
         let client = reqwest::Client::builder()
             .default_headers(default_headers)

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -57,6 +57,11 @@ type InfoRefreshHook = Arc<
 
 pub struct Client {
     configuration: RwLock<apis::configuration::Configuration>,
+    // The `X-Digest` currently baked into `configuration.client`'s default headers. Tracked
+    // separately so `update_digest` can skip rebuilding the `reqwest::Client` (which would drop
+    // the connection pool and TLS sessions) when the digest is unchanged — the steady-state
+    // case, since every `/info` fetch re-applies the same digest.
+    digest: RwLock<Option<String>>,
     info_refresh_hook: Option<InfoRefreshHook>,
 }
 
@@ -98,6 +103,7 @@ impl Client {
 
         Ok(Self {
             configuration: RwLock::new(configuration),
+            digest: RwLock::new(None),
             info_refresh_hook: None,
         })
     }
@@ -124,11 +130,31 @@ impl Client {
     }
 
     fn update_digest(&self, digest: &str) -> Result<(), Error> {
+        let normalized = (!digest.is_empty()).then(|| digest.to_owned());
+
+        // Skip the rebuild (which drops the connection pool) when the digest is unchanged — the
+        // common case, since every `/info` fetch re-applies the current digest.
+        {
+            let current = self
+                .digest
+                .read()
+                .map_err(|_| Error::request("REST client digest lock poisoned"))?;
+            if *current == normalized {
+                return Ok(());
+            }
+        }
+
         let mut configuration = self
             .configuration
             .write()
             .map_err(|_| Error::request("REST client configuration lock poisoned"))?;
-        configuration.client = build_reqwest_client((!digest.is_empty()).then_some(digest))?;
+        configuration.client = build_reqwest_client(normalized.as_deref())?;
+
+        let mut current = self
+            .digest
+            .write()
+            .map_err(|_| Error::request("REST client digest lock poisoned"))?;
+        *current = normalized;
         Ok(())
     }
 

--- a/ark-rest/src/client.rs
+++ b/ark-rest/src/client.rs
@@ -327,21 +327,26 @@ impl Client {
         let before = request.before().map(|b| b as i64);
         let after = request.after().map(|b| b as i64);
 
-        let response = indexer_service_get_vtxos(
-            &self.configuration()?,
-            scripts,
-            outpoints,
-            spendable_only,
-            spent_only,
-            recoverable_only,
-            pending_only,
-            before,
-            after,
-            page_period_size,
-            page_period_index,
-        )
-        .await
-        .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_get_vtxos(
+                    &configuration,
+                    scripts,
+                    outpoints,
+                    spendable_only,
+                    spent_only,
+                    recoverable_only,
+                    pending_only,
+                    before,
+                    after,
+                    page_period_size,
+                    page_period_index,
+                )
+                .await
+                .map_err(Error::request)
+            })
+            .await?;
 
         let vtxos = response.vtxos.ok_or(Error::request("VTXOs not received"))?;
         let vtxos = vtxos
@@ -764,9 +769,14 @@ impl Client {
         let (size, index) = size_and_index
             .map(|(sz, indx)| (Some(sz), Some(indx)))
             .unwrap_or_default();
-        let response = indexer_service_get_virtual_txs(&self.configuration()?, txids, size, index)
-            .await
-            .map_err(Error::request)?;
+        let configuration = self.configuration()?;
+        let response = self
+            .guarded(async {
+                indexer_service_get_virtual_txs(&configuration, txids, size, index)
+                    .await
+                    .map_err(Error::request)
+            })
+            .await?;
 
         let base64 = &base64::engine::GeneralPurpose::new(
             &base64::alphabet::STANDARD,

--- a/ark-rest/src/conversions.rs
+++ b/ark-rest/src/conversions.rs
@@ -117,11 +117,12 @@ impl TryFrom<crate::models::DeprecatedSigner> for ark_core::server::DeprecatedSi
             .parse::<PublicKey>()
             .map_err(|e| ConversionError(format!("Invalid pubkey '{pubkey_str}': {e}")))?;
 
-        let cutoff_date_str = value.cutoff_date.ok_or_else(|| {
-            ConversionError("Missing cutoff_date in deprecated signer".to_string())
-        })?;
-        let cutoff_date = i64::from_str(&cutoff_date_str)
-            .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))?;
+        // A missing cutoffDate means "rotate immediately" (same as 0).
+        let cutoff_date = match value.cutoff_date {
+            Some(s) => i64::from_str(&s)
+                .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))?,
+            None => 0,
+        };
 
         Ok(ark_core::server::DeprecatedSigner { pk, cutoff_date })
     }

--- a/ark-rest/src/conversions.rs
+++ b/ark-rest/src/conversions.rs
@@ -595,3 +595,61 @@ impl TryFrom<GetSubscriptionResponse> for ark_core::server::SubscriptionResponse
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::models::DeprecatedSigner as ModelDeprecatedSigner;
+
+    fn model(pubkey: Option<&str>, cutoff_date: Option<&str>) -> ModelDeprecatedSigner {
+        ModelDeprecatedSigner {
+            pubkey: pubkey.map(str::to_string),
+            cutoff_date: cutoff_date.map(str::to_string),
+        }
+    }
+
+    const PK_A: &str = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    // ── DeprecatedSigner conversion ──────────────────────────────────────────
+
+    #[test]
+    fn deprecated_signer_parses_cutoff_date() {
+        let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), Some("12345")));
+        let ds = result.expect("should succeed");
+        assert_eq!(ds.cutoff_date, 12345);
+        assert_eq!(ds.pk.to_string(), PK_A);
+    }
+
+    #[test]
+    fn deprecated_signer_missing_cutoff_defaults_to_zero() {
+        // A missing cutoffDate means "rotate immediately" (cutoff_date == 0).
+        let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), None));
+        let ds = result.expect("should succeed");
+        assert_eq!(ds.cutoff_date, 0);
+    }
+
+    #[test]
+    fn deprecated_signer_missing_pubkey_returns_error() {
+        let result = ark_core::server::DeprecatedSigner::try_from(model(None, Some("100")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Missing pubkey"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn deprecated_signer_invalid_pubkey_returns_error() {
+        let result =
+            ark_core::server::DeprecatedSigner::try_from(model(Some("notahex"), Some("100")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Invalid pubkey"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn deprecated_signer_invalid_cutoff_date_returns_error() {
+        let result =
+            ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), Some("not-a-number")));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("cutoff_date"), "unexpected: {msg}");
+    }
+}

--- a/ark-rest/src/error.rs
+++ b/ark-rest/src/error.rs
@@ -48,6 +48,16 @@ impl Error {
         false
     }
 
+    /// Returns `true` if the server rejected the request because the cached
+    /// `/info` digest is stale.
+    pub fn is_digest_mismatch(&self) -> bool {
+        if let Some(source) = &self.inner.source {
+            let source = source.to_string();
+            return source.contains("DIGEST_MISMATCH") || source.contains("invalid digest header");
+        }
+        false
+    }
+
     fn description(&self) -> &str {
         match &self.inner.kind {
             Kind::Request => "request failed",
@@ -111,5 +121,17 @@ mod tests {
     fn is_version_mismatch_false_when_no_source() {
         let err = Error::new(Kind::Request);
         assert!(!err.is_version_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_true_when_source_contains_marker() {
+        let err = Error::request("DIGEST_MISMATCH: invalid digest header");
+        assert!(err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_digest_mismatch_false_for_other_errors() {
+        let err = Error::request("connection refused");
+        assert!(!err.is_digest_mismatch());
     }
 }

--- a/ark-rest/src/error.rs
+++ b/ark-rest/src/error.rs
@@ -17,6 +17,7 @@ struct ErrorImpl {
 enum Kind {
     Request,
     Conversion,
+    ServerInfoChanged,
 }
 
 impl Error {
@@ -37,6 +38,16 @@ impl Error {
 
     pub(crate) fn conversion(source: impl Into<Source>) -> Self {
         Error::new(Kind::Conversion).with(source)
+    }
+
+    pub(crate) fn server_info_changed(source: impl Into<Source>) -> Self {
+        Error::new(Kind::ServerInfoChanged).with(source)
+    }
+
+    /// Returns `true` if the failed operation triggered a digest-mismatch refresh of the cached
+    /// `/info` (the original request was not retried; rebuild and retry if safe).
+    pub fn is_server_info_changed(&self) -> bool {
+        matches!(self.inner.kind, Kind::ServerInfoChanged)
     }
 
     /// Returns `true` if the server rejected the request because the SDK
@@ -62,6 +73,7 @@ impl Error {
         match &self.inner.kind {
             Kind::Request => "request failed",
             Kind::Conversion => "failed to convert between types",
+            Kind::ServerInfoChanged => "Ark server info changed while processing the request. Server info was refreshed, but the failed operation was not retried. Rebuild the request and retry if safe",
         }
     }
 }
@@ -133,5 +145,17 @@ mod tests {
     fn is_digest_mismatch_false_for_other_errors() {
         let err = Error::request("connection refused");
         assert!(!err.is_digest_mismatch());
+    }
+
+    #[test]
+    fn is_server_info_changed_true_for_server_info_changed_kind() {
+        let err = Error::server_info_changed("DIGEST_MISMATCH");
+        assert!(err.is_server_info_changed());
+    }
+
+    #[test]
+    fn is_server_info_changed_false_for_other_errors() {
+        let err = Error::request("DIGEST_MISMATCH");
+        assert!(!err.is_server_info_changed());
     }
 }

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -120,7 +120,8 @@ pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
     let mut max_blocktime_offset = 0;
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()
         .expect("unilateral VTXO exit delay should be relative")

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -330,6 +330,14 @@ impl Regtest {
         *guard = outpoint_block_height_offset;
     }
 
+    /// Rotate the arkd signing key. `cutoff` is passed verbatim to `--cutoff`:
+    /// use `"+86400"` for a future cutoff (regime 1, still cooperative) or
+    /// `"-60"` for a past cutoff (regime 2, operator won't co-sign).
+    #[allow(unused)]
+    pub fn rotate_signer(&self, cutoff: &str) {
+        self.run_regtest(&["rotate-signer", "--cutoff", cutoff]);
+    }
+
     // `mine` stays async (callers `.await` it) even though shelling out to the
     // regtest CLI is synchronous.
     #[allow(unused, clippy::unused_async)]
@@ -676,6 +684,9 @@ macro_rules! wait_until_balance {
     };
     (@check $balance:ident, recoverable, $target:expr) => {
         $balance.recoverable() == $target
+    };
+    (@check $balance:ident, pending_recovery, $target:expr) => {
+        $balance.pending_recovery() == $target
     };
 }
 

--- a/e2e-tests/tests/e2e_assets.rs
+++ b/e2e-tests/tests/e2e_assets.rs
@@ -133,7 +133,7 @@ pub async fn e2e_assets() {
     let send_txid = alice
         .send(vec![SendReceiver {
             address: bob_address,
-            amount: alice.dust(),
+            amount: alice.dust().unwrap(),
             assets: vec![ark_core::server::Asset {
                 asset_id: issued_asset_id,
                 amount: send_amount,

--- a/e2e-tests/tests/e2e_continue_pending_tx.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx.rs
@@ -57,7 +57,13 @@ pub async fn e2e_continue_pending_tx() {
         })
         .collect::<Vec<_>>();
 
-    let selected = select_vtxos(spendable, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
 
     let vtxo_inputs: Vec<VtxoInput> = selected
         .into_iter()

--- a/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
@@ -110,8 +110,13 @@ pub async fn e2e_continue_pending_tx_multi_input() {
         })
         .collect::<Vec<_>>();
 
-    let selected =
-        select_vtxos(spendable_coins, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable_coins,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
     assert_eq!(
         selected.len(),
         2,

--- a/e2e-tests/tests/e2e_finalize_pending_tx.rs
+++ b/e2e-tests/tests/e2e_finalize_pending_tx.rs
@@ -57,7 +57,13 @@ pub async fn e2e_finalize_pending_tx() {
         })
         .collect::<Vec<_>>();
 
-    let selected = select_vtxos(spendable, send_amount, alice.server_info.dust, true).unwrap();
+    let selected = select_vtxos(
+        spendable,
+        send_amount,
+        alice.server_info().unwrap().dust,
+        true,
+    )
+    .unwrap();
 
     let vtxo_inputs: Vec<VtxoInput> = selected
         .into_iter()

--- a/e2e-tests/tests/e2e_multisig_delegate.rs
+++ b/e2e-tests/tests/e2e_multisig_delegate.rs
@@ -80,10 +80,10 @@ pub async fn e2e_multisig_delegate() {
         MsigOutputTaprootOptions {
             alice_pk: alice_msig_output_pk.into(),
             bob_pk: bob_msig_output_pk.into(),
-            server_pk: alice.server_info.signer_pk.into(),
-            unilateral_exit_delay: alice.server_info.unilateral_exit_delay,
+            server_pk: alice.server_info().unwrap().signer_pk.into(),
+            unilateral_exit_delay: alice.server_info().unwrap().unilateral_exit_delay,
         },
-        alice.server_info.network,
+        alice.server_info().unwrap().network,
     )
     .unwrap();
 
@@ -117,7 +117,7 @@ pub async fn e2e_multisig_delegate() {
         OutPoint { txid, vout: 0 },
         // TODO: This should be modelled in the output type. I think it's supposed to be the
         // highest sequence number of all leaves, but I'm not sure.
-        alice.server_info.unilateral_exit_delay,
+        alice.server_info().unwrap().unilateral_exit_delay,
         None,
         TxOut {
             value: msig_output_amount,
@@ -138,8 +138,8 @@ pub async fn e2e_multisig_delegate() {
             script_pubkey: msig_output.script_pubkey(),
         })],
         bob_delegate_cosigner_pk,
-        &alice.server_info.forfeit_address,
-        alice.server_info.dust,
+        &alice.server_info().unwrap().forfeit_address,
+        alice.server_info().unwrap().dust,
     )
     .unwrap();
 
@@ -197,7 +197,7 @@ pub async fn e2e_multisig_delegate() {
         .await
         .unwrap();
 
-    let vtxo_list = VtxoList::new(alice.server_info.dust, virtual_tx_outpoints);
+    let vtxo_list = VtxoList::new(alice.server_info().unwrap().dust, virtual_tx_outpoints);
 
     assert_eq!(vtxo_list.all_unspent().count(), 1);
     assert_eq!(vtxo_list.spent().count(), 1);
@@ -208,7 +208,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(settled_msig_outpoint.is_preconfirmed);
     assert!(!settled_msig_outpoint.is_swept);
     assert!(!settled_msig_outpoint.is_unrolled);
-    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info.dust));
+    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
     assert_eq!(settled_msig_outpoint.settled_by, Some(commitment_txid));
 
     let new_msig_outpoint = &vtxo_list.all_unspent().next().unwrap();
@@ -217,7 +217,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(!new_msig_outpoint.is_preconfirmed);
     assert!(!new_msig_outpoint.is_swept);
     assert!(!new_msig_outpoint.is_unrolled);
-    assert!(!new_msig_outpoint.is_recoverable(alice.server_info.dust));
+    assert!(!new_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
     assert!(new_msig_outpoint
         .commitment_txids
         .contains(&commitment_txid));

--- a/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
@@ -26,7 +26,8 @@ pub async fn send_onchain_boarding_output() {
     // To be able to spend a boarding output it needs to have been confirmed for at least
     // `boarding_exit_delay`.
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()
         .expect("boarding exit delay should be relative")

--- a/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
@@ -128,7 +128,8 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
     let mut max_blocktime_offset = 0;
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()
         .expect("unilateral VTXO exit delay should be relative")
@@ -142,7 +143,8 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
     };
 
     match alice
-        .server_info
+        .server_info()
+        .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()
         .expect("boarding exit delay should be relative")

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -186,13 +186,12 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     // test isolates the boarding migration *leg* itself.
     regtest.rotate_signer("+86400");
 
-    // The rotation recreates arkd-wallet and restarts arkd, so the existing connection breaks
-    // and the stack takes the better part of a minute to fully recover (arkd-wallet recreate +
-    // arkd restart + reconnect). Retry the info refresh until arkd is back and advertises the
-    // deprecated signer (the gRPC channel re-dials on retry); the reconnect-based tests get a
-    // comparable budget from connect_with_retries + the get_info timeout.
+    // `rotate_signer` already blocks until arkd has restarted and re-advertises the deprecated
+    // signer, but the restart broke our existing gRPC connection, so the first refresh may hit a
+    // stale channel and need a re-dial. Retry until the refreshed snapshot shows the deprecated
+    // signer.
     let mut rotated = false;
-    for _ in 0..60 {
+    for _ in 0..30 {
         if client.refresh_server_info().await.is_ok()
             && !client.server_info().unwrap().deprecated_signers.is_empty()
         {

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -65,16 +65,16 @@ pub async fn e2e_signer_rotation_sweep_migration() {
         "Total balance must be preserved after rotation"
     );
 
-    let txid = client2
+    let report = client2
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();
     assert!(
-        txid.is_some(),
-        "migrate_deprecated_signer_vtxos must submit a settlement (returned None)"
+        report.rotated(),
+        "migrate_deprecated_signer_vtxos must submit a settlement (no leg rotated)"
     );
     tracing::info!(
-        ?txid,
+        ?report,
         "migrate_deprecated_signer_vtxos submitted settlement"
     );
 
@@ -82,13 +82,13 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     wait_until_balance!(&client2, confirmed: fund_amount);
 
     // If migration actually moved VTXOs to the new signer, there is nothing left
-    // to migrate — a second call must return None.
+    // to migrate — a second call must rotate nothing.
     let second = client2
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();
     assert!(
-        second.is_none(),
+        !second.rotated(),
         "second migrate call should find nothing to migrate (VTXOs are already under new signer)"
     );
     tracing::info!("Sweep-migration test passed: all VTXOs settled under new signer");

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -187,10 +187,12 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     regtest.rotate_signer("+86400");
 
     // The rotation recreates arkd-wallet and restarts arkd, so the existing connection breaks
-    // briefly. Retry the info refresh until arkd is back and advertises the deprecated signer
-    // (the gRPC channel re-dials on retry).
+    // and the stack takes the better part of a minute to fully recover (arkd-wallet recreate +
+    // arkd restart + reconnect). Retry the info refresh until arkd is back and advertises the
+    // deprecated signer (the gRPC channel re-dials on retry); the reconnect-based tests get a
+    // comparable budget from connect_with_retries + the get_info timeout.
     let mut rotated = false;
-    for _ in 0..30 {
+    for _ in 0..60 {
         if client.refresh_server_info().await.is_ok()
             && !client.server_info().unwrap().deprecated_signers.is_empty()
         {

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::unwrap_used)]
+
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client_with_seed;
+use common::wait_until_balance;
+use common::Regtest;
+use rand::thread_rng;
+use rand::Rng;
+use std::sync::Arc;
+
+mod common;
+
+/// Regime 1: VTXO created under current signer → rotate with future cutoff (still cooperative)
+/// → `migrate_deprecated_signer_vtxos` settles all pre-cutoff VTXOs to the new signer.
+///
+/// Mirrors dotnet-sdk `SweepMigrationRotationTests` and ts-sdk rotation/migration scenario.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_sweep_migration() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+
+    client.settle(&mut rng).await.unwrap();
+
+    wait_until_balance!(&client, confirmed: fund_amount);
+    tracing::info!("VTXO confirmed under current signer");
+
+    drop(client);
+
+    // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1).
+    regtest.rotate_signer("+86400");
+    tracing::info!("Signer rotated with future cutoff (+86400)");
+
+    // Reconnect to pick up updated server info (deprecated_signers now populated).
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client2.server_info.deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after rotation"
+    );
+
+    let balance_before = client2.offchain_balance().await.unwrap();
+    tracing::info!(
+        ?balance_before,
+        "Balance seen by new client before migration"
+    );
+    assert_eq!(
+        balance_before.total(),
+        fund_amount,
+        "Total balance must be preserved after rotation"
+    );
+
+    let txid = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        txid.is_some(),
+        "migrate_deprecated_signer_vtxos must submit a settlement (returned None)"
+    );
+    tracing::info!(
+        ?txid,
+        "migrate_deprecated_signer_vtxos submitted settlement"
+    );
+
+    // Wait for the new batch to confirm.
+    wait_until_balance!(&client2, confirmed: fund_amount);
+
+    // If migration actually moved VTXOs to the new signer, there is nothing left
+    // to migrate — a second call must return None.
+    let second = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        second.is_none(),
+        "second migrate call should find nothing to migrate (VTXOs are already under new signer)"
+    );
+    tracing::info!("Sweep-migration test passed: all VTXOs settled under new signer");
+}
+
+/// Regime 2: VTXO created under current signer → rotate with past cutoff (operator will NOT
+/// co-sign the old key) → VTXO is stuck in `pending_recovery`, NOT in confirmed/pre_confirmed.
+///
+/// Mirrors dotnet-sdk `PastCutoffHeldBackRotationTests`.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_past_cutoff_held_back() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+
+    client.settle(&mut rng).await.unwrap();
+
+    wait_until_balance!(&client, confirmed: fund_amount);
+    tracing::info!("VTXO confirmed under current signer");
+
+    drop(client);
+
+    // Rotate: past cutoff (-60 seconds) means the operator will NOT co-sign the old key.
+    regtest.rotate_signer("-60");
+    tracing::info!("Signer rotated with past cutoff (-60)");
+
+    // Reconnect to pick up updated server info.
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client2.server_info.deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after rotation"
+    );
+
+    // The VTXO is under a past-cutoff deprecated signer: not spendable offchain,
+    // not yet expired → must appear in pending_recovery, not in confirmed.
+    wait_until_balance!(
+        &client2,
+        confirmed: Amount::ZERO,
+        pre_confirmed: Amount::ZERO,
+        pending_recovery: fund_amount,
+    );
+
+    tracing::info!("Past-cutoff held-back test passed: VTXO is in pending_recovery, not spendable");
+}

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -185,14 +185,26 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     // do not). Connect-time deprecated-boarding persistence is exercised on every connect; this
     // test isolates the boarding migration *leg* itself.
     regtest.rotate_signer("+86400");
-    client.refresh_server_info().await.unwrap();
+
+    // The rotation recreates arkd-wallet and restarts arkd, so the existing connection breaks
+    // briefly. Retry the info refresh until arkd is back and advertises the deprecated signer
+    // (the gRPC channel re-dials on retry).
+    let mut rotated = false;
+    for _ in 0..30 {
+        if client.refresh_server_info().await.is_ok()
+            && !client.server_info().unwrap().deprecated_signers.is_empty()
+        {
+            rotated = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    assert!(
+        rotated,
+        "server_info should list the old signer as deprecated after rotation"
+    );
     tracing::info!(
         "Signer rotated with future cutoff (+86400); boarding UTXO now under deprecated signer"
-    );
-
-    assert!(
-        !client.server_info().unwrap().deprecated_signers.is_empty(),
-        "server_info should list the old signer as deprecated after rotation"
     );
 
     let report = client

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -177,38 +177,37 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     let boarding_address = client.get_boarding_address().unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
 
-    drop(client);
-
-    // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1), so
-    // the boarding input is cooperatively migratable.
+    // Rotate with a future cutoff: the old signer is deprecated but still co-signs (regime 1), so
+    // the boarding input is cooperatively migratable. We keep the SAME client and just refresh its
+    // cached server info to pick up the rotation — boarding outputs are owned by the wallet
+    // keypair, which this seed-only test harness does not re-derive across a reconnect (only the
+    // client's offchain keys are seed-derived, so VTXOs survive a reconnect but boarding outputs
+    // do not). Connect-time deprecated-boarding persistence is exercised on every connect; this
+    // test isolates the boarding migration *leg* itself.
     regtest.rotate_signer("+86400");
+    client.refresh_server_info().await.unwrap();
     tracing::info!(
         "Signer rotated with future cutoff (+86400); boarding UTXO now under deprecated signer"
     );
 
-    // Reconnect with the same seed to pick up updated server info. Connect-time persistence watches
-    // the deprecated signer's boarding outputs, so we never call `get_boarding_addresses()` here.
-    let (client2, _wallet2) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
-
     assert!(
-        !client2.server_info().unwrap().deprecated_signers.is_empty(),
+        !client.server_info().unwrap().deprecated_signers.is_empty(),
         "server_info should list the old signer as deprecated after rotation"
     );
 
-    let report = client2
+    let report = client
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();
 
     assert!(
         report.rotated(),
-        "boarding-only migration must submit a settlement"
+        "boarding-only migration must submit a settlement: {report:?}"
     );
     assert!(
         report.boarding.settle_txid.is_some(),
-        "the deprecated boarding input must migrate through the boarding leg \
-         (connect-time persistence handles discovery, no get_boarding_addresses() call)"
+        "the deprecated boarding input must migrate through the boarding leg: {:?}",
+        report.boarding
     );
     assert!(
         report.boarding.error.is_none(),
@@ -221,8 +220,8 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     );
 
     // After migration the funds live under the new signer; a second pass finds nothing to migrate.
-    wait_until_balance!(&client2, confirmed: fund_amount);
-    let second = client2
+    wait_until_balance!(&client, confirmed: fund_amount);
+    let second = client
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
+use ark_client::DeprecatedSignerStatus;
 use bitcoin::key::Secp256k1;
 use bitcoin::Amount;
 use common::init_tracing;
@@ -146,4 +147,217 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
     );
 
     tracing::info!("Past-cutoff held-back test passed: VTXO is in pending_recovery, not spendable");
+}
+
+/// Boarding-only migration: fund a boarding address but DO NOT settle it to a VTXO, then rotate
+/// with a future cutoff. After reconnecting with the same seed, the deprecated BOARDING input must
+/// migrate cooperatively through the report's boarding leg — WITHOUT any explicit
+/// `get_boarding_addresses()` call, because connect-time boarding persistence already watches the
+/// deprecated signer's boarding outputs.
+///
+/// Mirrors ts-sdk `deprecatedSignerMigration.test.ts` "migrates a real boarding UTXO with no cutoff
+/// (DUE_NOW)" — the boarding-only leg isolated from the VTXO path.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_boarding_only_migration() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    // Fund a boarding output under the current signer but deliberately do NOT settle it: this
+    // isolates the boarding-input migration path from the VTXO one.
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+
+    drop(client);
+
+    // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1), so
+    // the boarding input is cooperatively migratable.
+    regtest.rotate_signer("+86400");
+    tracing::info!(
+        "Signer rotated with future cutoff (+86400); boarding UTXO now under deprecated signer"
+    );
+
+    // Reconnect with the same seed to pick up updated server info. Connect-time persistence watches
+    // the deprecated signer's boarding outputs, so we never call `get_boarding_addresses()` here.
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    assert!(
+        !client2.server_info().unwrap().deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after rotation"
+    );
+
+    let report = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+
+    assert!(
+        report.rotated(),
+        "boarding-only migration must submit a settlement"
+    );
+    assert!(
+        report.boarding.settle_txid.is_some(),
+        "the deprecated boarding input must migrate through the boarding leg \
+         (connect-time persistence handles discovery, no get_boarding_addresses() call)"
+    );
+    assert!(
+        report.boarding.error.is_none(),
+        "boarding leg must not error: {:?}",
+        report.boarding.error
+    );
+    tracing::info!(
+        ?report,
+        "Boarding-only migration submitted boarding-leg settlement"
+    );
+
+    // After migration the funds live under the new signer; a second pass finds nothing to migrate.
+    wait_until_balance!(&client2, confirmed: fund_amount);
+    let second = client2
+        .migrate_deprecated_signer_vtxos(&mut rng)
+        .await
+        .unwrap();
+    assert!(
+        !second.rotated(),
+        "second migrate call should find nothing to migrate"
+    );
+    tracing::info!("Boarding-only migration test passed");
+}
+
+/// Classification: a future cutoff (`+86400`) makes the deprecated signer `Migratable` with a
+/// positive `seconds_until_cutoff`, exposed via the read-only `deprecated_signer_status()`.
+///
+/// Mirrors ts-sdk `deprecatedSignerMigration.test.ts` MIGRATABLE group
+/// (`status: "MIGRATABLE"`, `secondsUntilCutoff > 0`). `rotate_signer("+86400")` resolves the
+/// cutoff to `now + 86400` (an absolute future Unix timestamp), so we assert `cutoff_date` is in
+/// the future and `seconds_until_cutoff > 0` rather than an exact offset.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_status_migratable() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+    client.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&client, confirmed: fund_amount);
+
+    drop(client);
+
+    // Capture a lower bound on "now" before rotating so we can assert the cutoff is in the future.
+    let before_rotate = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    regtest.rotate_signer("+86400");
+    tracing::info!("Signer rotated with future cutoff (+86400)");
+
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let status = client2.deprecated_signer_status().await.unwrap();
+    assert_eq!(
+        status.len(),
+        1,
+        "exactly one deprecated signer the wallet holds funds under"
+    );
+    let row = &status[0];
+    assert_eq!(
+        row.status,
+        DeprecatedSignerStatus::Migratable,
+        "a future cutoff classifies as Migratable"
+    );
+    assert!(
+        row.cutoff_date > before_rotate,
+        "cutoff_date ({}) should be a future timestamp (> {before_rotate})",
+        row.cutoff_date
+    );
+    assert!(
+        row.seconds_until_cutoff.is_some_and(|s| s > 0),
+        "Migratable signer should have a positive seconds_until_cutoff, got {:?}",
+        row.seconds_until_cutoff
+    );
+    assert!(
+        row.vtxo_count >= 1,
+        "the funded VTXO should be counted under the deprecated signer"
+    );
+    tracing::info!(?row, "Migratable classification test passed");
+}
+
+/// Classification: a zero cutoff (`"0"`) makes the deprecated signer `DueNow` with
+/// `cutoff_date == 0` and no `seconds_until_cutoff`, exposed via `deprecated_signer_status()`.
+///
+/// Mirrors ts-sdk `deprecatedSignerMigration.test.ts` DUE_NOW group (`status: "DUE_NOW"`,
+/// `cutoffDate` undefined). `rotate_signer("0")` advertises cutoff `0` ("rotate immediately",
+/// still co-signable).
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_status_due_now() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+    client.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&client, confirmed: fund_amount);
+
+    drop(client);
+
+    // Cutoff "0" => "rotate immediately" (DUE_NOW): deprecated, no cutoff advertised, still
+    // co-signable.
+    regtest.rotate_signer("0");
+    tracing::info!("Signer rotated with zero cutoff (DueNow)");
+
+    let (client2, _wallet2) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let status = client2.deprecated_signer_status().await.unwrap();
+    assert_eq!(
+        status.len(),
+        1,
+        "exactly one deprecated signer the wallet holds funds under"
+    );
+    let row = &status[0];
+    assert_eq!(
+        row.status,
+        DeprecatedSignerStatus::DueNow,
+        "a zero cutoff classifies as DueNow"
+    );
+    assert_eq!(
+        row.cutoff_date, 0,
+        "DueNow signer advertises cutoff_date == 0"
+    );
+    assert_eq!(
+        row.seconds_until_cutoff, None,
+        "DueNow signer has no seconds_until_cutoff"
+    );
+    tracing::info!(?row, "DueNow classification test passed");
 }

--- a/e2e-tests/tests/fulmine_delegator_smoke.rs
+++ b/e2e-tests/tests/fulmine_delegator_smoke.rs
@@ -42,7 +42,10 @@ async fn fulmine_delegator_smoke() {
     assert_eq!(next_vtxo.delegator_pk(), Some(delegator_pk));
 
     // Start watcher and keep handle alive for the test duration.
-    let _watcher = client.start_vtxo_watcher(delegator);
+    let _watcher = client.start_vtxo_watcher(
+        delegator,
+        ark_client::vtxo_watcher::VtxoWatcherConfig::default(),
+    );
 
     let boarding_address = client.get_boarding_address().unwrap();
     let fund_amount = Amount::from_sat(100_000);


### PR DESCRIPTION
## Summary

Stacks **#242 (X-Digest headers)** and **#243 (deprecated signer-key rotation)** onto one branch and finishes every gap an in-depth review found against the reference implementations (ts-sdk #554, dotnet, fulmine `handle-signer-key-migration`).

**Supersedes #242 and #243** — this branch contains both of their commits plus the integration and the gap fixes. Merging this closes both.

Closes #242
Closes #243

## Why a stacked branch

#242 moved `server_info` behind `Arc<RwLock<ServerState>>` with a fallible `server_info()` accessor; #243 kept the public `server_info` field and read it infallibly throughout the regime-classification code — so the two **do not compile together**. They also had real functional gaps relative to the reference SDKs. This branch reconciles the API and fills the gaps.

## Gaps filled (11 confirmed by the review)

| Commit | Gaps | What |
|---|---|---|
| G01 | structural | Port all of #243's regime code onto #242's lock API (`let server_info = self.server_info()?` once per fn); snapshot once in `migrate`/`offchain_balance` to avoid a TOCTOU when a concurrent `refresh_server_info` swaps `deprecated_signers` |
| G02/G03/G04 | migration core | `migrate_deprecated_signer_vtxos` now moves **only** pre-cutoff deprecated funds (was sweeping ALL VTXOs+boarding), via two **independent** scoped `settle_vtxos` legs (a settle failure in one leg is captured, not propagated); per-leg sizing (per-input `vtxo_max_amount` ceiling → oversized split for unilateral exit, `MAX_VTXOS_PER_SETTLEMENT=50`, running-aggregate cap with defer, dust floor); returns a structured `DeprecatedSignerMigrationReport` instead of `Option<Txid>` |
| G06/G12 | discovery | Discovery/watch addresses derive over a candidate exit-delay set `{current ∪ legacy 605184s}` (mainnet-only, de-duped) so funds minted before the operator shortened the delay are still found; `finish_connect` eagerly persists deprecated-signer **boarding** rows so migrate's boarding leg isn't gated on calling `get_boarding_addresses()` first |
| G05/G11 | observability | New read-only `deprecated_signer_status() -> Vec<DeprecatedSignerReport>` (per-signer status/cutoff/counts/values, recoverable-vs-awaiting-sweep split, `next_sweep_eta`) |
| G08/G09 | automation/transport | Watcher gains an opt-out (default-on) background migration pass with exponential backoff (log-not-throw); ark-rest gains gRPC-parity digest-mismatch detection (a `guarded()` wrapper over its mutating calls) closing the detect→react loop. Both transports also send an `X-SDK-Version: rust-sdk/<crate version>` request header (sibling to `X-Build-Version`) so the server can attribute traffic to this SDK and release. Active-signer auto-rotate intentionally **not** added (ts-sdk-only) |
| G13 | tests | 13 unit tests (sizing + status classification) + 3 e2e tests (boarding-only migration, DueNow-vs-Migratable) |

Three review claims were corrected during implementation (all verified in code): `settle_vtxos` already provided the scoped settle primitive; `discover_keys` already auto-runs at connect for VTXOs (only the boarding axis needed G12); and a first-cut leg implementation `?`-propagated a leg error — fixed so a failure in one leg can't suppress the other.

During e2e validation a latent bug in `refresh_server_info` surfaced: it fetched a fresh `/info` (refreshing the gRPC digest header) but discarded the result, leaving the cached `server_info()` (and fee estimator) stale — so callers reacting to a digest mismatch never saw the newly advertised `deprecated_signers`. Fixed to write the refreshed snapshot into the cached server state.

## Review round (post-CI-green)

Addressed an automated review; each finding was verified against the code first.

**Fixed (all confirmed real):**
- `fetch_commitment_transaction_inputs` shadowed its `now` param with a fresh `unix_now()`, so the boarding and VTXO cutoff filters ran against different timestamps (and a test-injected `now` reached only the boarding filter) -- now reuses the passed `now` for both.
- `deprecated_signer_status` counted only spendable VTXOs in its emptiness skip, dropping an expired signer holding only recoverable VTXOs (hiding those funds); now counts recoverable + boarding too. Locked by a `signer_holds_funds` unit test.
- `get_offchain_addresses` enumerated only the current exit delay while `discover_keys` fans out over `candidate_exit_delays`; a legacy-delay VTXO was discovered as a key but never enumerated as an address, leaving it invisible to balance/migration on mainnet. Now fans out over `candidate_exit_delays` (no off-mainnet change).
- `run_migration_leg` dropped `selected` inputs from the report on a sizing skip; now surfaces them as `deferred` like the settle-error path.
- `send_vtxo` took two `server_info` snapshots; collapsed to one.

**Also addressed in the review round:** REST `guarded()` digest-mismatch parity with gRPC is now complete across unary indexer reads AND the SSE streams (via a shared `refresh_on_digest_mismatch` helper), and `update_digest` no longer rebuilds the `reqwest::Client` when the digest is unchanged (preserving the connection pool). REST-consumer parity only -- `ark-client` uses the gRPC client, so the migration path is unaffected.

**Only deferred item:** a regression test for the `fetch_commitment_transaction_inputs` timestamp fix -- locking it needs network-mock infrastructure (the network client is a concrete type with no trait seam), a change disproportionate to the fix; left out by maintainer decision. The #227 (smart-settle) interaction was checked: migration calls `settle_vtxos` directly, which #227 does not touch, so there is no silent-settle-nothing bug -- only a mechanical rebase on whichever merges second.

## Verification

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- nightly rustfmt / dprint — clean
- `ark-client` lib unit tests: 41 pass; `ark-rest`: 14 pass (incl. new guarded-detection + cooldown-backoff tests)
- The signer-rotation e2e suite runs under regtest in CI against a live arkd: 5/5 passing (sweep + boarding-only migration, past-cutoff hold-back, DueNow-vs-Migratable status).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable background VTXO migration for deprecated signers via `VtxoWatcherConfig` (with periodic backoff and optional disable).
  * Off-chain balance now exposes `pending_recovery` for clearer migration visibility.
  * gRPC and REST now include build/digest compatibility headers and automatically refresh server info on digest mismatches.

* **Improvements**
  * More resilient VHTLC reconstruction and better handling when server info changes mid-request.
  * Dust/fee estimation and settlement/asset send flows now consistently use the latest server parameters.

* **Tests**
  * Added regtest and end-to-end coverage for signer rotation/migration and compatibility refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


