### PR TITLE
fix: preserve cutoff_date as Option<i64> instead of collapsing None to 0

### DIFF
--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -125,8 +125,8 @@ pub struct MigrationVtxoRef {
     pub amount: Amount,
     /// The deprecated signer the input was minted under.
     pub signer_pk: XOnlyPublicKey,
-    /// The signer's advertised cooperative-sign cutoff (Unix seconds); `0` means "rotate now".
-    pub cutoff_date: i64,
+    /// The signer's advertised cooperative-sign cutoff (Unix seconds); `None` means "rotate now".
+    pub cutoff_date: Option<i64>,
 }
 
 /// Why a single migration leg ([`DeprecatedSignerMigrationReport::vtxo`] or
@@ -352,17 +352,18 @@ fn signer_holds_funds(
 /// Pure core of [`Client::deprecated_signer_status`], factored out so the classification is
 /// unit-testable without a `Client`/network. Consistent with
 /// [`server::Info::is_signer_past_cutoff_at`] and the `is_pre_cutoff_deprecated` check in
-/// [`Client::migrate_deprecated_signer_vtxos`]: a `cutoff_date` of `0` is "rotate now"
+/// [`Client::migrate_deprecated_signer_vtxos`]: `None` is "rotate now"
 /// ([`DeprecatedSignerStatus::DueNow`], still co-signable); a future cutoff is
 /// [`DeprecatedSignerStatus::Migratable`] (with a positive `seconds_until_cutoff`); a passed cutoff
 /// is [`DeprecatedSignerStatus::Expired`].
-fn classify_deprecated_signer(cutoff_date: i64, now: i64) -> (DeprecatedSignerStatus, Option<i64>) {
-    if cutoff_date == 0 {
-        (DeprecatedSignerStatus::DueNow, None)
-    } else if cutoff_date > now {
-        (DeprecatedSignerStatus::Migratable, Some(cutoff_date - now))
-    } else {
-        (DeprecatedSignerStatus::Expired, None)
+fn classify_deprecated_signer(
+    cutoff_date: Option<i64>,
+    now: i64,
+) -> (DeprecatedSignerStatus, Option<i64>) {
+    match cutoff_date {
+        None => (DeprecatedSignerStatus::DueNow, None),
+        Some(d) if d > now => (DeprecatedSignerStatus::Migratable, Some(d - now)),
+        Some(_) => (DeprecatedSignerStatus::Expired, None),
     }
 }
 
@@ -371,19 +372,19 @@ fn classify_deprecated_signer(cutoff_date: i64, now: i64) -> (DeprecatedSignerSt
 /// Derived at read time by [`Client::deprecated_signer_status`] from the advertised
 /// `cutoff_date` and the current time; never persisted. Mirrors ts-sdk's `SignerStatus`
 /// (the non-`CURRENT`/`UNKNOWN_SIGNER` variants) and stays consistent with
-/// [`server::Info::is_signer_past_cutoff_at`]: a `cutoff_date` of `0` is "rotate immediately"
+/// [`server::Info::is_signer_past_cutoff_at`]: `cutoff_date == None` is "rotate immediately"
 /// (still co-signable now) and is therefore NOT treated as past-cutoff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeprecatedSignerStatus {
-    /// The signer is deprecated with a future cutoff (`cutoff_date > now`). The operator still
-    /// co-signs, so these outputs are cooperatively migratable (see
+    /// The signer is deprecated with a future cutoff (`cutoff_date == Some(d)` where `d > now`).
+    /// The operator still co-signs, so these outputs are cooperatively migratable (see
     /// [`Client::migrate_deprecated_signer_vtxos`]).
     Migratable,
-    /// The signer is deprecated with no cutoff advertised (`cutoff_date == 0`): rotate
+    /// The signer is deprecated with no cutoff advertised (`cutoff_date == None`): rotate
     /// immediately. The operator still co-signs now, so these outputs are still cooperatively
     /// migratable, but clients should migrate without delay.
     DueNow,
-    /// The signer's cutoff has passed (`cutoff_date != 0 && cutoff_date <= now`). The operator
+    /// The signer's cutoff has passed (`cutoff_date == Some(d)` where `d <= now`). The operator
     /// will no longer co-sign the old key — these funds cannot migrate cooperatively and instead
     /// drain to the active signer via the recover-on-sweep path once they expire.
     Expired,
@@ -403,10 +404,10 @@ pub struct DeprecatedSignerReport {
     pub signer_pk: XOnlyPublicKey,
     /// The signer's status, derived from its cutoff and the current time.
     pub status: DeprecatedSignerStatus,
-    /// The advertised cooperative-sign cutoff (Unix seconds); `0` means "rotate immediately".
-    pub cutoff_date: i64,
+    /// The advertised cooperative-sign cutoff (Unix seconds); `None` means "rotate immediately".
+    pub cutoff_date: Option<i64>,
     /// Seconds until the cutoff (`cutoff_date - now`); `None` when no future cutoff is advertised
-    /// (i.e. `cutoff_date == 0` or already passed).
+    /// (i.e. `cutoff_date` is `None` or already passed).
     pub seconds_until_cutoff: Option<i64>,
     /// Number of spendable (non-recoverable) VTXOs the wallet holds under this signer.
     pub vtxo_count: usize,
@@ -1685,15 +1686,19 @@ where
 
         let now = unix_now();
 
-        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| -> Option<i64> {
+        let is_pre_cutoff_deprecated = |server_pk: XOnlyPublicKey| {
+            server_info.deprecated_signers.iter().any(|ds| {
+                ds.pk.x_only_public_key().0 == server_pk
+                    && ds.cutoff_date.is_none_or(|cutoff| cutoff > now)
+            })
+        };
+
+        let cutoff_date_for = |server_pk: XOnlyPublicKey| {
             server_info
                 .deprecated_signers
                 .iter()
-                .find(|ds| {
-                    ds.pk.x_only_public_key().0 == server_pk
-                        && (ds.cutoff_date == 0 || ds.cutoff_date > now)
-                })
-                .map(|ds| ds.cutoff_date)
+                .find(|ds| ds.pk.x_only_public_key().0 == server_pk)
+                .and_then(|ds| ds.cutoff_date)
         };
 
         // `fetch_commitment_transaction_inputs` already drops PAST-cutoff deprecated inputs (the
@@ -1716,12 +1721,12 @@ where
                 );
                 continue;
             };
-            if let Some(cutoff_date) = is_pre_cutoff_deprecated(vtxo.server_pk()) {
+            if is_pre_cutoff_deprecated(vtxo.server_pk()) {
                 vtxo_candidates.push(MigrationVtxoRef {
                     outpoint: input.outpoint(),
                     amount: input.amount(),
                     signer_pk: vtxo.server_pk(),
-                    cutoff_date,
+                    cutoff_date: cutoff_date_for(vtxo.server_pk()),
                 });
             }
         }
@@ -1730,12 +1735,12 @@ where
         let mut boarding_candidates: Vec<MigrationVtxoRef> = Vec::new();
         for input in &boarding_inputs {
             let signer_pk = input.boarding_output().server_pk();
-            if let Some(cutoff_date) = is_pre_cutoff_deprecated(signer_pk) {
+            if is_pre_cutoff_deprecated(signer_pk) {
                 boarding_candidates.push(MigrationVtxoRef {
                     outpoint: input.outpoint(),
                     amount: input.amount(),
                     signer_pk,
-                    cutoff_date,
+                    cutoff_date: cutoff_date_for(signer_pk),
                 });
             }
         }
@@ -1872,7 +1877,7 @@ where
             let cutoff_date = ds.cutoff_date;
 
             // Status + `seconds_until_cutoff`, consistent with `is_signer_past_cutoff_at` /
-            // `is_pre_cutoff_deprecated`: cutoff `0` = rotate-now (still co-signable); a future
+            // `is_pre_cutoff_deprecated`: cutoff `None` = rotate-now (still co-signable); a future
             // cutoff = migratable; a passed cutoff = expired.
             let (status, seconds_until_cutoff) = classify_deprecated_signer(cutoff_date, now);
 
@@ -2549,7 +2554,7 @@ mod migration_tests {
             outpoint: OutPoint::new(Txid::from_byte_array([0u8; 32]), vout),
             amount,
             signer_pk,
-            cutoff_date: 0,
+            cutoff_date: None,
         }
     }
 
@@ -2668,8 +2673,8 @@ mod migration_tests {
     // ── classify_deprecated_signer ───────────────────────────────────────────
 
     #[test]
-    fn classify_cutoff_zero_is_due_now() {
-        let (status, secs) = classify_deprecated_signer(0, 1_000_000);
+    fn classify_cutoff_none_is_due_now() {
+        let (status, secs) = classify_deprecated_signer(None, 1_000_000);
         assert_eq!(status, DeprecatedSignerStatus::DueNow);
         assert_eq!(secs, None);
     }
@@ -2677,17 +2682,17 @@ mod migration_tests {
     #[test]
     fn classify_future_cutoff_is_migratable() {
         let now = 1_000_000i64;
-        let (status, secs) = classify_deprecated_signer(now + 86_400, now);
+        let (status, secs) = classify_deprecated_signer(Some(now + 86_400), now);
         assert_eq!(status, DeprecatedSignerStatus::Migratable);
         assert_eq!(secs, Some(86_400));
     }
 
     #[test]
     fn classify_exact_cutoff_boundary_is_expired() {
-        // cutoff_date <= now (and != 0) => expired. The boundary (cutoff == now) is past-cutoff,
+        // Some(d) where d <= now => expired. The boundary (cutoff == now) is past-cutoff,
         // matching `server::Info::is_signer_past_cutoff_at`.
         let now = 1_000_000i64;
-        let (status, secs) = classify_deprecated_signer(now, now);
+        let (status, secs) = classify_deprecated_signer(Some(now), now);
         assert_eq!(status, DeprecatedSignerStatus::Expired);
         assert_eq!(secs, None);
     }
@@ -2695,7 +2700,7 @@ mod migration_tests {
     #[test]
     fn classify_past_cutoff_is_expired() {
         let now = 1_000_000i64;
-        let (status, secs) = classify_deprecated_signer(now - 1, now);
+        let (status, secs) = classify_deprecated_signer(Some(now - 1), now);
         assert_eq!(status, DeprecatedSignerStatus::Expired);
         assert_eq!(secs, None);
     }

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -501,7 +501,7 @@ pub struct ScheduledSession {
 #[derive(Clone, Debug)]
 pub struct DeprecatedSigner {
     pub pk: PublicKey,
-    pub cutoff_date: i64,
+    pub cutoff_date: Option<i64>,
 }
 
 impl Info {
@@ -515,13 +515,12 @@ impl Info {
     }
 
     /// Returns `true` if `server_pk` is a deprecated signer whose cooperative-sign cutoff has
-    /// already passed at `now_unix_secs`. A `cutoff_date` of `0` means "rotate immediately" —
-    /// the operator still co-signs but clients should migrate without delay. It is therefore
-    /// NOT treated as past-cutoff here; use `migrate_deprecated_signer_vtxos` to handle it.
+    /// already passed at `now_unix_secs`. `None` means "rotate immediately" — the operator still
+    /// co-signs but clients should migrate without delay. It is therefore NOT treated as
+    /// past-cutoff here; use `migrate_deprecated_signer_vtxos` to handle it.
     pub fn is_signer_past_cutoff_at(&self, server_pk: XOnlyPublicKey, now_unix_secs: i64) -> bool {
         self.deprecated_signers.iter().any(|ds| {
-            ds.cutoff_date != 0
-                && ds.cutoff_date <= now_unix_secs
+            ds.cutoff_date.map_or(false, |d| d <= now_unix_secs)
                 && ds.pk.x_only_public_key().0 == server_pk
         })
     }
@@ -842,7 +841,7 @@ mod tests {
         pk(hex).x_only_public_key().0
     }
 
-    fn make_info(current_hex: &str, deprecated: Vec<(&str, i64)>) -> Info {
+    fn make_info(current_hex: &str, deprecated: Vec<(&str, Option<i64>)>) -> Info {
         let dummy_address: bitcoin::Address<NetworkUnchecked> =
             "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
                 .parse()
@@ -889,14 +888,14 @@ mod tests {
 
     #[test]
     fn all_server_keys_includes_deprecated_in_order() {
-        let info = make_info(PK_A, vec![(PK_B, 1000), (PK_C, 2000)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(1000)), (PK_C, Some(2000))]);
         let keys: Vec<_> = info.all_server_keys().collect();
         assert_eq!(keys, vec![xonly(PK_A), xonly(PK_B), xonly(PK_C)]);
     }
 
     #[test]
     fn all_server_keys_current_is_always_first() {
-        let info = make_info(PK_C, vec![(PK_A, 500), (PK_B, 600)]);
+        let info = make_info(PK_C, vec![(PK_A, Some(500)), (PK_B, Some(600))]);
         let keys: Vec<_> = info.all_server_keys().collect();
         assert_eq!(keys[0], xonly(PK_C));
     }
@@ -911,36 +910,36 @@ mod tests {
 
     #[test]
     fn unknown_key_is_not_past_cutoff() {
-        let info = make_info(PK_A, vec![(PK_B, 100)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(100))]);
         assert!(!info.is_signer_past_cutoff_at(xonly(PK_UNRELATED), 200));
     }
 
     #[test]
-    fn cutoff_zero_means_rotate_immediately_not_past_cutoff() {
-        // cutoff_date == 0 means "rotate now" but the operator still co-signs.
+    fn cutoff_none_means_rotate_immediately_not_past_cutoff() {
+        // cutoff_date == None means "rotate now" but the operator still co-signs.
         // is_signer_past_cutoff_at must return false so the key is not excluded from batches.
-        let info = make_info(PK_A, vec![(PK_B, 0)]);
+        let info = make_info(PK_A, vec![(PK_B, None)]);
         assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), 9_999_999));
     }
 
     #[test]
     fn future_cutoff_is_not_past() {
         let now = 1_000_000i64;
-        let info = make_info(PK_A, vec![(PK_B, now + 1)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(now + 1))]);
         assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
     }
 
     #[test]
     fn exact_cutoff_boundary_is_past() {
         let now = 1_000_000i64;
-        let info = make_info(PK_A, vec![(PK_B, now)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(now))]);
         assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
     }
 
     #[test]
     fn past_cutoff_is_past() {
         let now = 1_000_000i64;
-        let info = make_info(PK_A, vec![(PK_B, now - 1)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(now - 1))]);
         assert!(info.is_signer_past_cutoff_at(xonly(PK_B), now));
     }
 
@@ -948,7 +947,7 @@ mod tests {
     fn multiple_deprecated_only_past_key_is_flagged() {
         let now = 1_000_000i64;
         // PK_B: future (not past), PK_C: past
-        let info = make_info(PK_A, vec![(PK_B, now + 100), (PK_C, now - 100)]);
+        let info = make_info(PK_A, vec![(PK_B, Some(now + 100)), (PK_C, Some(now - 100))]);
         assert!(!info.is_signer_past_cutoff_at(xonly(PK_B), now));
         assert!(info.is_signer_past_cutoff_at(xonly(PK_C), now));
     }

--- a/ark-grpc/src/types.rs
+++ b/ark-grpc/src/types.rs
@@ -137,7 +137,7 @@ impl TryFrom<generated::ark::v1::DeprecatedSigner> for DeprecatedSigner {
 
         Ok(Self {
             pk,
-            cutoff_date: value.cutoff_date,
+            cutoff_date: (value.cutoff_date != 0).then_some(value.cutoff_date),
         })
     }
 }

--- a/ark-rest/src/conversions.rs
+++ b/ark-rest/src/conversions.rs
@@ -117,12 +117,13 @@ impl TryFrom<crate::models::DeprecatedSigner> for ark_core::server::DeprecatedSi
             .parse::<PublicKey>()
             .map_err(|e| ConversionError(format!("Invalid pubkey '{pubkey_str}': {e}")))?;
 
-        // A missing cutoffDate means "rotate immediately" (same as 0).
-        let cutoff_date = match value.cutoff_date {
-            Some(s) => i64::from_str(&s)
-                .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))?,
-            None => 0,
-        };
+        let cutoff_date = value
+            .cutoff_date
+            .map(|s| {
+                i64::from_str(&s)
+                    .map_err(|e| ConversionError(format!("Could not parse cutoff_date: {e:#}")))
+            })
+            .transpose()?;
 
         Ok(ark_core::server::DeprecatedSigner { pk, cutoff_date })
     }
@@ -615,16 +616,16 @@ mod tests {
     fn deprecated_signer_parses_cutoff_date() {
         let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), Some("12345")));
         let ds = result.expect("should succeed");
-        assert_eq!(ds.cutoff_date, 12345);
+        assert_eq!(ds.cutoff_date, Some(12345));
         assert_eq!(ds.pk.to_string(), PK_A);
     }
 
     #[test]
-    fn deprecated_signer_missing_cutoff_defaults_to_zero() {
-        // A missing cutoffDate means "rotate immediately" (cutoff_date == 0).
+    fn deprecated_signer_missing_cutoff_is_none() {
+        // A missing cutoffDate means "rotate immediately" (cutoff_date == None).
         let result = ark_core::server::DeprecatedSigner::try_from(model(Some(PK_A), None));
         let ds = result.expect("should succeed");
-        assert_eq!(ds.cutoff_date, 0);
+        assert_eq!(ds.cutoff_date, None);
     }
 
     #[test]

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -299,8 +299,8 @@ pub async fn e2e_signer_rotation_status_migratable() {
         "a future cutoff classifies as Migratable"
     );
     assert!(
-        row.cutoff_date > before_rotate,
-        "cutoff_date ({}) should be a future timestamp (> {before_rotate})",
+        row.cutoff_date.is_some_and(|d| d > before_rotate),
+        "cutoff_date ({:?}) should be a future timestamp (> {before_rotate})",
         row.cutoff_date
     );
     assert!(
@@ -316,10 +316,10 @@ pub async fn e2e_signer_rotation_status_migratable() {
 }
 
 /// Classification: a zero cutoff (`"0"`) makes the deprecated signer `DueNow` with
-/// `cutoff_date == 0` and no `seconds_until_cutoff`, exposed via `deprecated_signer_status()`.
+/// `cutoff_date == None` and no `seconds_until_cutoff`, exposed via `deprecated_signer_status()`.
 ///
 /// Mirrors ts-sdk `deprecatedSignerMigration.test.ts` DUE_NOW group (`status: "DUE_NOW"`,
-/// `cutoffDate` undefined). `rotate_signer("0")` advertises cutoff `0` ("rotate immediately",
+/// `cutoffDate` undefined). `rotate_signer("0")` advertises no cutoff ("rotate immediately",
 /// still co-signable).
 #[tokio::test]
 #[ignore = "requires regtest"]
@@ -364,8 +364,8 @@ pub async fn e2e_signer_rotation_status_due_now() {
         "a zero cutoff classifies as DueNow"
     );
     assert_eq!(
-        row.cutoff_date, 0,
-        "DueNow signer advertises cutoff_date == 0"
+        row.cutoff_date, None,
+        "DueNow signer advertises cutoff_date == None"
     );
     assert_eq!(
         row.seconds_until_cutoff, None,


### PR DESCRIPTION
None now canonically means "rotate immediately", distinct from a deliberately-set epoch timestamp. REST None maps to None; gRPC proto3 sentinel 0 maps to None at the conversion boundary.