### PR TITLE
Refresh server info by TTL

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -6,8 +6,8 @@
 # explicit --env. Precedence: --env > ../.env.regtest > regtest/.env > defaults.
 
 # arkd is run from these images (no Go-source build anymore).
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.9-rc.1
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.9-rc.1
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.10
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.10
 
 # arkd config the e2e suite relies on (ported from the old e2e-core.yml env /
 # .env.sample). Exit delays are multiples of 512 seconds; VTXO min amount 1 so

--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -532,7 +532,10 @@ async fn run_command<K: KeyProvider + 'static>(
             let offchain_balance = client.offchain_balance().await.map_err(|e| anyhow!(e))?;
 
             let boarding = {
-                let boarding_output = client.get_boarding_address().map_err(|e| anyhow!(e))?;
+                let boarding_output = client
+                    .get_boarding_address()
+                    .await
+                    .map_err(|e| anyhow!(e))?;
                 let outpoints = esplora_client
                     .find_outpoints(&boarding_output)
                     .await
@@ -567,21 +570,27 @@ async fn run_command<K: KeyProvider + 'static>(
             }
         }
         Commands::BoardingAddress => {
-            let boarding_address = client.get_boarding_address().map_err(|e| anyhow!(e))?;
+            let boarding_address = client
+                .get_boarding_address()
+                .await
+                .map_err(|e| anyhow!(e))?;
             println!(
                 "{}",
                 serde_json::json!({"address": boarding_address.to_string()})
             );
         }
         Commands::OffchainAddress => {
-            let (address, _) = client.get_offchain_address().map_err(|e| anyhow!(e))?;
+            let (address, _) = client
+                .get_offchain_address()
+                .await
+                .map_err(|e| anyhow!(e))?;
             let address = address.encode();
             println!("{}", serde_json::json!({"address": address}));
         }
         Commands::Settle { notes } => {
             let mut rng = thread_rng();
             // we need to call this because how our wallet works
-            let _ = client.get_boarding_address();
+            let _ = client.get_boarding_address().await;
 
             let maybe_batch_tx = match notes {
                 Some(notes_str) => {
@@ -750,10 +759,14 @@ async fn run_command<K: KeyProvider + 'static>(
 
             if client
                 .get_offchain_addresses()
+                .await
                 .map_err(|e| anyhow!(e))?
                 .is_empty()
             {
-                let (addr, _) = client.get_offchain_address().map_err(|e| anyhow!(e))?;
+                let (addr, _) = client
+                    .get_offchain_address()
+                    .await
+                    .map_err(|e| anyhow!(e))?;
                 tracing::info!(
                     address = %addr,
                     "Derived first offchain address so watcher has scripts to subscribe to"
@@ -773,7 +786,7 @@ async fn run_command<K: KeyProvider + 'static>(
             unreachable!("pending future never resolves");
         }
         Commands::SendOnchain { address, amount } => {
-            let network = client.server_info()?.network;
+            let network = client.server_info().await?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -802,7 +815,7 @@ async fn run_command<K: KeyProvider + 'static>(
                 })
                 .collect::<Result<Vec<_>>>()?;
 
-            let network = client.server_info()?.network;
+            let network = client.server_info().await?.network;
             let checked_address = address.clone().require_network(network)?;
 
             let mut rng = thread_rng();
@@ -1110,7 +1123,10 @@ async fn run_command<K: KeyProvider + 'static>(
             });
 
             // Get boarding outputs
-            let boarding_output = client.get_boarding_address().map_err(|e| anyhow!(e))?;
+            let boarding_output = client
+                .get_boarding_address()
+                .await
+                .map_err(|e| anyhow!(e))?;
             let outpoints = esplora_client
                 .find_outpoints(&boarding_output)
                 .await
@@ -1186,7 +1202,7 @@ async fn run_command<K: KeyProvider + 'static>(
             }
 
             // We need to call this because of how our wallet works
-            let _ = client.get_boarding_address();
+            let _ = client.get_boarding_address().await;
 
             let maybe_batch_tx = client
                 .settle_vtxos(&mut rng, &vtxo_outpoints, &boarding_outpoints)
@@ -1205,7 +1221,7 @@ async fn run_command<K: KeyProvider + 'static>(
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         Commands::EstimateFees { address, amount } => {
-            let network = client.server_info()?.network;
+            let network = client.server_info().await?.network;
             let mut rng = thread_rng();
 
             // Try parsing as ArkAddress first, then as Bitcoin address
@@ -1297,7 +1313,7 @@ async fn run_command<K: KeyProvider + 'static>(
             let selected = ark_core::coin_select::select_vtxos(
                 spendable,
                 amount,
-                client.server_info()?.dust,
+                client.server_info().await?.dust,
                 true,
             )
             .map_err(|e| anyhow!(e))?;
@@ -1430,7 +1446,7 @@ async fn run_command<K: KeyProvider + 'static>(
 
             let receiver = SendReceiver {
                 address: address.0,
-                amount: client.dust()?,
+                amount: client.dust().await?,
                 assets: vec![ark_core::server::Asset {
                     asset_id,
                     amount: *amount,

--- a/ark-client-sample/src/main.rs
+++ b/ark-client-sample/src/main.rs
@@ -10,16 +10,14 @@ use anyhow::Context;
 use anyhow::Result;
 use ark_bdk_wallet::Wallet;
 use ark_client::lightning_invoice::Bolt11Invoice;
-use ark_client::Bip32KeyProvider;
 use ark_client::Blockchain;
 use ark_client::ChainSwapAmount;
 use ark_client::ChainSwapDirection;
 use ark_client::Error;
-use ark_client::KeyProvider;
 use ark_client::OfflineClient;
+use ark_client::OfflineClientConfig;
 use ark_client::SpendStatus;
 use ark_client::SqliteSwapStorage;
-use ark_client::StaticKeyProvider;
 use ark_client::SwapAmount;
 use ark_client::TxStatus;
 use ark_core::asset::ControlAssetConfig;
@@ -54,7 +52,6 @@ use serde::Serialize;
 use std::fs;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -466,19 +463,21 @@ async fn main() -> Result<()> {
             )?;
             let wallet = Arc::new(wallet);
 
-            let client = OfflineClient::<_, _, _, Bip32KeyProvider>::new_with_bip32(
-                "sample-client".to_string(),
+            let client_config = OfflineClientConfig {
+                ark_server_url: config.ark_server_url,
+                boltz_url: config.boltz_url,
+                delegator_pk,
+                historical_delegator_pks: historical_delegator_pks.clone(),
+                ..Default::default()
+            };
+
+            let client = OfflineClient::with_bip32(
+                client_config,
                 xpriv,
                 None,
                 esplora_client.clone(),
                 wallet,
-                config.ark_server_url,
                 storage,
-                config.boltz_url,
-                None,
-                Duration::from_secs(30),
-                delegator_pk,
-                historical_delegator_pks.clone(),
             )
             .connect()
             .await
@@ -495,18 +494,20 @@ async fn main() -> Result<()> {
             let wallet = Wallet::new(kp, secp, Network::Regtest, config.esplora_url.as_str(), db)?;
             let wallet = Arc::new(wallet);
 
-            let client = OfflineClient::<_, _, _, StaticKeyProvider>::new_with_keypair(
-                "sample-client".to_string(),
+            let client_config = OfflineClientConfig {
+                ark_server_url: config.ark_server_url,
+                boltz_url: config.boltz_url,
+                delegator_pk,
+                historical_delegator_pks: historical_delegator_pks.clone(),
+                ..Default::default()
+            };
+
+            let client = OfflineClient::with_keypair(
+                client_config,
                 kp,
                 esplora_client.clone(),
                 wallet,
-                config.ark_server_url,
                 storage,
-                config.boltz_url,
-                None,
-                Duration::from_secs(30),
-                delegator_pk,
-                historical_delegator_pks.clone(),
             )
             .connect()
             .await
@@ -519,9 +520,9 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn run_command<K: KeyProvider + 'static>(
+async fn run_command(
     command: Commands,
-    client: ark_client::Client<EsploraClient, Wallet<InMemoryDb>, SqliteSwapStorage, K>,
+    client: ark_client::Client<EsploraClient, Wallet<InMemoryDb>, SqliteSwapStorage>,
     esplora_client: Arc<EsploraClient>,
 ) -> Result<()> {
     let client = Arc::new(client);

--- a/ark-client/src/asset.rs
+++ b/ark-client/src/asset.rs
@@ -51,8 +51,8 @@ where
             return Err(Error::ad_hoc("asset amount must be > 0"));
         }
 
-        let server_info = self.server_info()?;
-        let (own_address, _) = self.get_offchain_address()?;
+        let server_info = self.server_info().await?;
+        let (own_address, _) = self.get_offchain_address().await?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
         let selected_coins = select_vtxos(spendable, server_info.dust, server_info.dust, true)
@@ -60,7 +60,7 @@ where
             .context("failed to select coins for asset issuance")?;
 
         let issuance_inputs = self.build_vtxo_inputs(selected_coins, &script_pubkey_to_vtxo_map)?;
-        let (change_address, change_address_vtxo) = self.get_offchain_address()?;
+        let (change_address, change_address_vtxo) = self.get_offchain_address().await?;
 
         let SelfAssetIssuanceTransactions {
             ark_tx,
@@ -103,7 +103,7 @@ where
             return Err(Error::ad_hoc("reissue amount must be > 0"));
         }
 
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let asset_info = self
             .get_asset(asset_id)
             .await
@@ -151,8 +151,8 @@ where
         }
 
         let reissuance_inputs = self.build_vtxo_inputs(selected, &script_pubkey_to_vtxo_map)?;
-        let (self_address, _) = self.get_offchain_address()?;
-        let (change_address, change_address_vtxo) = self.get_offchain_address()?;
+        let (self_address, _) = self.get_offchain_address().await?;
+        let (change_address, change_address_vtxo) = self.get_offchain_address().await?;
 
         let AssetReissuanceTransactions {
             ark_tx,
@@ -188,7 +188,7 @@ where
             return Err(Error::ad_hoc("burn amount must be > 0"));
         }
 
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let (spendable, script_pubkey_to_vtxo_map) = self.spendable_virtual_vtxos().await?;
 
         let (asset_coins, asset_change) = select_vtxos_for_asset(&spendable, amount, asset_id)
@@ -233,8 +233,8 @@ where
         }
 
         let burn_inputs = self.build_vtxo_inputs(selected, &script_pubkey_to_vtxo_map)?;
-        let (own_address, _) = self.get_offchain_address()?;
-        let (change_address, change_address_vtxo) = self.get_offchain_address()?;
+        let (own_address, _) = self.get_offchain_address().await?;
+        let (change_address, change_address_vtxo) = self.get_offchain_address().await?;
 
         let offchain = build_asset_burn_transactions(
             &own_address,
@@ -271,7 +271,7 @@ where
             self.list_vtxos().await.context("failed to list VTXOs")?;
 
         let now = crate::utils::unix_now()?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let spendable = vtxo_list
             .spendable_offchain_at(&server_info, now, |script| {
                 script_pubkey_to_vtxo_map

--- a/ark-client/src/asset.rs
+++ b/ark-client/src/asset.rs
@@ -30,12 +30,11 @@ pub struct IssueAssetResult {
     pub asset_ids: Vec<AssetId>,
 }
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     /// Issue a new asset.
     ///

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -74,7 +74,7 @@ where
         R: Rng + CryptoRng + Clone,
     {
         // Get off-chain address and send all funds to this address, no change output 🦄
-        let (to_address, _) = self.get_offchain_address()?;
+        let (to_address, _) = self.get_offchain_address().await?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) =
             self.fetch_commitment_transaction_inputs(now).await?;
@@ -174,7 +174,7 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (to_address, _) = self.get_offchain_address()?;
+        let (to_address, _) = self.get_offchain_address().await?;
 
         let (boarding_inputs, vtxo_inputs, mut total_amount) = self
             .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
@@ -249,7 +249,7 @@ where
         R: Rng + CryptoRng + Clone,
     {
         // Get off-chain address and send all funds to this address, no change output.
-        let (to_address, _) = self.get_offchain_address()?;
+        let (to_address, _) = self.get_offchain_address().await?;
 
         let (all_boarding_inputs, all_vtxo_inputs, _) = self
             .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
@@ -326,7 +326,7 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address()?;
+        let (change_address, _) = self.get_offchain_address().await?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) = self
             .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
@@ -400,7 +400,7 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address()?;
+        let (change_address, _) = self.get_offchain_address().await?;
 
         let vtxo_inputs = self
             .selected_batch_settleable_vtxo_inputs(input_vtxos)
@@ -478,7 +478,7 @@ where
 
         let (vtxo_list, script_pubkey_to_vtxo_map) =
             self.list_vtxos().await.context("failed to get VTXO list")?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let now = crate::utils::unix_now()?;
 
         let matching_unspent = vtxo_list
@@ -554,7 +554,7 @@ where
         delegate_cosigner_pk: PublicKey,
     ) -> Result<Delegate, Error> {
         // Get off-chain address and send all funds to this address.
-        let (to_address, _) = self.get_offchain_address()?;
+        let (to_address, _) = self.get_offchain_address().await?;
 
         // Simply collect all VTXOs that can be settled.
         let (_, vtxo_inputs, _) = self
@@ -569,7 +569,7 @@ where
             return Err(Error::ad_hoc("no inputs to settle via delegate"));
         }
 
-        let server_info = &self.server_info()?;
+        let server_info = &self.server_info().await?;
 
         let mut outputs = vec![intent::Output::Offchain(TxOut {
             value: total_amount,
@@ -667,7 +667,7 @@ where
         tracing::debug!(intent_id, "Registered delegated intent");
 
         let network_client = self.network_client();
-        let server_info = &self.server_info()?;
+        let server_info = &self.server_info().await?;
 
         #[derive(Debug, PartialEq, Eq)]
         enum Step {
@@ -1104,7 +1104,7 @@ where
 
         // Snapshot once; reused for the boarding cutoff filter and the VTXO dust/cutoff logic
         // below.
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {
@@ -1218,6 +1218,7 @@ where
         vtxo_inputs: Vec<intent::Input>,
         output_type: BatchOutputType,
         intent_kind: PrepareIntentKind,
+        dust: Amount,
     ) -> Result<PreparedIntent, Error>
     where
         R: Rng + CryptoRng,
@@ -1253,8 +1254,6 @@ where
                 .chain(vtxo_inputs.clone())
                 .collect::<Vec<_>>()
         };
-
-        let dust = self.server_info()?.dust;
 
         let mut outputs = vec![];
 
@@ -1422,12 +1421,14 @@ where
     where
         R: Rng + CryptoRng,
     {
+        let server_info = self.server_info().await?;
         let prepared = self.prepare_intent(
             rng,
             onchain_inputs,
             vtxo_inputs,
             output_type,
             PrepareIntentKind::Register,
+            server_info.dust,
         )?;
 
         let PreparedIntent {
@@ -1444,7 +1445,7 @@ where
             .map(|i| i.outpoint())
             .collect::<Vec<_>>();
 
-        let server_info = &self.server_info()?;
+        let server_info = &server_info;
 
         let own_cosigner_kps = [cosigner_keypair];
         let own_cosigner_pks = own_cosigner_kps

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -19,6 +19,7 @@ use ark_core::batch::Delegate;
 use ark_core::batch::NonceKps;
 use ark_core::intent;
 use ark_core::script::extract_checksig_pubkeys;
+use ark_core::server;
 use ark_core::server::BatchTreeEventType;
 use ark_core::server::PartialSigTree;
 use ark_core::server::StreamEvent;
@@ -72,11 +73,14 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        // Get off-chain address and send all funds to this address, no change output 🦄
-        let (to_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) =
-            self.fetch_commitment_transaction_inputs(now).await?;
+        // Get off-chain address and send all funds to this address, no change output 🦄
+        let (to_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
+
+        let (boarding_inputs, vtxo_inputs, total_amount) = self
+            .fetch_commitment_transaction_inputs(&server_info, now)
+            .await?;
 
         tracing::debug!(
             offchain_adress = %to_address.encode(),
@@ -93,6 +97,7 @@ where
         let join_next_batch = || async {
             self.join_next_batch(
                 &mut rng.clone(),
+                &server_info,
                 boarding_inputs.clone(),
                 vtxo_inputs.clone(),
                 BatchOutputType::Board {
@@ -107,7 +112,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(0))
             .sleep(sleep)
-            // TODO: Use `when` to only retry certain errors.
+            .when(|err| !err.is_server_info_changed())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}",);
             })
@@ -136,11 +141,13 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (vtxo_list, _) = self.list_vtxos().await?;
+        let server_info = self.server_info().await?;
+
+        let (vtxo_list, _) = self.list_vtxos_with_server_info(&server_info).await?;
         let vtxo_outpoints: Vec<OutPoint> = vtxo_list.recoverable().map(|v| v.outpoint).collect();
 
         let (boarding_inputs, _, _) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
         let boarding_outpoints: Vec<OutPoint> =
             boarding_inputs.iter().map(|i| i.outpoint()).collect();
@@ -156,7 +163,7 @@ where
             "Attempting to settle expired/recoverable VTXOs and boarding outputs"
         );
 
-        self.settle_vtxos(rng, &vtxo_outpoints, &boarding_outpoints)
+        self.settle_vtxos_with_server_info(rng, &server_info, &vtxo_outpoints, &boarding_outpoints)
             .await
     }
 
@@ -173,10 +180,12 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (to_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
+
+        let (to_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         let (boarding_inputs, vtxo_inputs, mut total_amount) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
 
         // Convert arknotes to intent inputs and add their value to total
@@ -209,6 +218,7 @@ where
         let join_next_batch = || async {
             self.join_next_batch(
                 &mut rng.clone(),
+                &server_info,
                 boarding_inputs.clone(),
                 all_vtxo_inputs.clone(),
                 BatchOutputType::Board {
@@ -222,6 +232,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(0))
             .sleep(sleep)
+            .when(|err| !err.is_server_info_changed())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
             })
@@ -247,11 +258,26 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
+        let server_info = self.server_info().await?;
+        self.settle_vtxos_with_server_info(rng, &server_info, vtxo_outpoints, boarding_outpoints)
+            .await
+    }
+
+    pub(crate) async fn settle_vtxos_with_server_info<R>(
+        &self,
+        rng: &mut R,
+        server_info: &server::Info,
+        vtxo_outpoints: &[OutPoint],
+        boarding_outpoints: &[OutPoint],
+    ) -> Result<Option<Txid>, Error>
+    where
+        R: Rng + CryptoRng + Clone,
+    {
         // Get off-chain address and send all funds to this address, no change output.
-        let (to_address, _) = self.get_offchain_address().await?;
+        let (to_address, _) = self.get_offchain_address_with_server_info(server_info)?;
 
         let (all_boarding_inputs, all_vtxo_inputs, _) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(server_info, crate::utils::unix_now()?)
             .await?;
 
         // Filter boarding inputs to only those specified.
@@ -289,6 +315,7 @@ where
         let join_next_batch = || async {
             self.join_next_batch(
                 &mut rng.clone(),
+                server_info,
                 boarding_inputs.clone(),
                 vtxo_inputs.clone(),
                 BatchOutputType::Board {
@@ -303,6 +330,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(0))
             .sleep(sleep)
+            .when(|err| !err.is_server_info_changed())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}",);
             })
@@ -325,10 +353,12 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
+
+        let (change_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
 
         let onchain_fee = self.eval_onchain_output_fee(ark_fees::Output {
@@ -359,6 +389,7 @@ where
         let join_next_batch = || async {
             self.join_next_batch(
                 &mut rng.clone(),
+                &server_info,
                 boarding_inputs.clone(),
                 vtxo_inputs.clone(),
                 BatchOutputType::OffBoard {
@@ -375,7 +406,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(3))
             .sleep(sleep)
-            // TODO: Use `when` to only retry certain errors.
+            .when(|err| !err.is_server_info_changed())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
             })
@@ -399,10 +430,12 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
+
+        let (change_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         let vtxo_inputs = self
-            .selected_batch_settleable_vtxo_inputs(input_vtxos)
+            .selected_batch_settleable_vtxo_inputs(&server_info, input_vtxos)
             .await?;
 
         if vtxo_inputs.is_empty() {
@@ -441,6 +474,7 @@ where
         let join_next_batch = || async {
             self.join_next_batch(
                 &mut rng.clone(),
+                &server_info,
                 Vec::new(),
                 vtxo_inputs.clone(),
                 BatchOutputType::OffBoard {
@@ -457,7 +491,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(3))
             .sleep(sleep)
-            // TODO: Use `when` to only retry certain errors.
+            .when(|err| !err.is_server_info_changed())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
             })
@@ -471,13 +505,15 @@ where
 
     pub(crate) async fn selected_batch_settleable_vtxo_inputs(
         &self,
+        server_info: &server::Info,
         input_vtxos: impl IntoIterator<Item = OutPoint>,
     ) -> Result<Vec<intent::Input>, Error> {
         let requested: HashSet<OutPoint> = input_vtxos.into_iter().collect();
 
-        let (vtxo_list, script_pubkey_to_vtxo_map) =
-            self.list_vtxos().await.context("failed to get VTXO list")?;
-        let server_info = self.server_info().await?;
+        let (vtxo_list, script_pubkey_to_vtxo_map) = self
+            .list_vtxos_with_server_info(server_info)
+            .await
+            .context("failed to get VTXO list")?;
         let now = crate::utils::unix_now()?;
 
         let matching_unspent = vtxo_list
@@ -486,7 +522,7 @@ where
             .collect::<Vec<_>>();
 
         let settleable_outpoints = vtxo_list
-            .batch_settleable_at(&server_info, now, |script| {
+            .batch_settleable_at(server_info, now, |script| {
                 script_pubkey_to_vtxo_map
                     .get(script)
                     .map(|vtxo| vtxo.server_pk())
@@ -552,12 +588,14 @@ where
         &self,
         delegate_cosigner_pk: PublicKey,
     ) -> Result<Delegate, Error> {
+        let server_info = self.server_info().await?;
+
         // Get off-chain address and send all funds to this address.
-        let (to_address, _) = self.get_offchain_address().await?;
+        let (to_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         // Simply collect all VTXOs that can be settled.
         let (_, vtxo_inputs, _) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
 
         let total_amount = vtxo_inputs
@@ -567,8 +605,6 @@ where
         if vtxo_inputs.is_empty() {
             return Err(Error::ad_hoc("no inputs to settle via delegate"));
         }
-
-        let server_info = &self.server_info().await?;
 
         let mut outputs = vec![intent::Output::Offchain(TxOut {
             value: total_amount,
@@ -654,6 +690,8 @@ where
             ));
         }
 
+        let server_info = self.server_info().await?;
+
         // Register the pre-signed intent
         let intent_id = timeout_op(
             self.inner.timeout,
@@ -666,7 +704,6 @@ where
         tracing::debug!(intent_id, "Registered delegated intent");
 
         let network_client = self.network_client();
-        let server_info = &self.server_info().await?;
 
         #[derive(Debug, PartialEq, Eq)]
         enum Step {
@@ -1088,6 +1125,7 @@ where
     /// upcoming batch.
     pub(crate) async fn fetch_commitment_transaction_inputs(
         &self,
+        server_info: &server::Info,
         now: i64,
     ) -> Result<(Vec<batch::OnChainInput>, Vec<intent::Input>, Amount), Error> {
         let now = u64::try_from(now).map_err(|_| Error::ad_hoc("negative timestamp"))?;
@@ -1100,10 +1138,6 @@ where
 
         // To track unique outpoints and prevent duplicates
         let mut seen_outpoints = HashSet::new();
-
-        // Snapshot once; reused for the boarding cutoff filter and the VTXO dust/cutoff logic
-        // below.
-        let server_info = self.server_info().await?;
 
         // Find outpoints for each boarding output.
         for boarding_output in boarding_outputs {
@@ -1157,12 +1191,13 @@ where
             }
         }
 
-        let (vtxo_list, script_pubkey_to_vtxo_map) = self.list_vtxos().await?;
+        let (vtxo_list, script_pubkey_to_vtxo_map) =
+            self.list_vtxos_with_server_info(server_info).await?;
         // Reuse the caller-supplied timestamp (not a fresh wall-clock) so the VTXO cutoff filter
         // below is evaluated against the same instant as the boarding filter above, and so a
         // test-injected `now` deterministically controls both.
         let settleable_vtxos: Vec<_> = vtxo_list
-            .batch_settleable_at(&server_info, now as i64, |script| {
+            .batch_settleable_at(server_info, now as i64, |script| {
                 script_pubkey_to_vtxo_map
                     .get(script)
                     .map(|vtxo| vtxo.server_pk())
@@ -1413,6 +1448,7 @@ where
     pub(crate) async fn join_next_batch<R>(
         &self,
         rng: &mut R,
+        server_info: &server::Info,
         onchain_inputs: Vec<batch::OnChainInput>,
         vtxo_inputs: Vec<intent::Input>,
         output_type: BatchOutputType,
@@ -1420,7 +1456,6 @@ where
     where
         R: Rng + CryptoRng,
     {
-        let server_info = self.server_info().await?;
         let prepared = self.prepare_intent(
             rng,
             onchain_inputs,
@@ -1443,8 +1478,6 @@ where
             .iter()
             .map(|i| i.outpoint())
             .collect::<Vec<_>>();
-
-        let server_info = &server_info;
 
         let own_cosigner_kps = [cosigner_keypair];
         let own_cosigner_pks = own_cosigner_kps

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -50,12 +50,11 @@ use rand::Rng;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     /// Settle _all_ prior VTXOs and boarding outputs into the next batch, generating new confirmed
     /// VTXOs.

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -771,7 +771,7 @@ where
 
         let script_pubkey = vhtlc.script_pubkey();
 
-        let (refund_address, _) = self.get_offchain_address().await?;
+        let (refund_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
         let refund_amount = swap_data.amount;
 
         let vhtlc_input = intent::Input::new(
@@ -795,6 +795,7 @@ where
         let commitment_txid = self
             .join_next_batch(
                 rng,
+                &server_info,
                 Vec::new(),
                 vec![vhtlc_input],
                 BatchOutputType::Board {

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -20,6 +20,7 @@ use ark_core::send::OffchainTransactions;
 use ark_core::send::SendReceiver;
 use ark_core::send::VtxoInput;
 use ark_core::server::parse_sequence_number;
+use ark_core::server::Info;
 use ark_core::server::PendingTx;
 use ark_core::vhtlc::VhtlcOptions;
 use ark_core::vhtlc::VhtlcScript;
@@ -544,9 +545,10 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap_data.refund_public_key.into(),
@@ -592,7 +594,7 @@ where
             vhtlc_outpoint.clone()
         };
 
-        let (refund_address, _) = self.get_offchain_address()?;
+        let (refund_address, _) = self.get_offchain_address().await?;
         let refund_amount = swap_data.amount;
 
         let outputs = vec![SendReceiver {
@@ -709,9 +711,10 @@ where
             .ok_or(Error::ad_hoc("Submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap_data.refund_public_key.into(),
@@ -769,7 +772,7 @@ where
 
         let script_pubkey = vhtlc.script_pubkey();
 
-        let (refund_address, _) = self.get_offchain_address()?;
+        let (refund_address, _) = self.get_offchain_address().await?;
         let refund_amount = swap_data.amount;
 
         let vhtlc_input = intent::Input::new(
@@ -821,9 +824,10 @@ where
             .ok_or(Error::ad_hoc("submarine swap not found"))?;
 
         let timeout_block_heights = swap_data.timeout_block_heights;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap_data.refund_public_key.into(),
@@ -869,7 +873,7 @@ where
             vhtlc_outpoint.clone()
         };
 
-        let (refund_address, _) = self.get_offchain_address()?;
+        let (refund_address, _) = self.get_offchain_address().await?;
         let refund_amount = swap_data.amount;
 
         let outputs = vec![SendReceiver {
@@ -1045,7 +1049,7 @@ where
 
     // Reverse submarine swap.
 
-    fn validate_reverse_recipient_address(
+    async fn validate_reverse_recipient_address(
         &self,
         recipient_address: Option<&ArkAddress>,
     ) -> Result<(), Error> {
@@ -1053,7 +1057,7 @@ where
             return Ok(());
         };
 
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let server_signer: XOnlyPublicKey = server_info.signer_pk.into();
         if recipient_address.server() != server_signer {
             return Err(Error::consumer(format!(
@@ -1065,14 +1069,16 @@ where
         Ok(())
     }
 
-    fn reverse_claim_address(&self, swap: &ReverseSwapData) -> Result<ArkAddress, Error> {
+    async fn reverse_claim_address(&self, swap: &ReverseSwapData) -> Result<ArkAddress, Error> {
         if let Some(address) = swap.claim_address {
-            self.validate_reverse_recipient_address(Some(&address))?;
+            self.validate_reverse_recipient_address(Some(&address))
+                .await?;
             return Ok(address);
         }
 
         let (address, _) = self
             .get_offchain_address()
+            .await
             .context("failed to get offchain address")?;
 
         Ok(address)
@@ -1233,7 +1239,8 @@ where
         description: Option<String>,
     ) -> Result<ReverseSwapResult, Error> {
         validate_invoice_description(description.as_deref())?;
-        self.validate_reverse_recipient_address(recipient_address.as_ref())?;
+        self.validate_reverse_recipient_address(recipient_address.as_ref())
+            .await?;
 
         let preimage_hash = ripemd160::Hash::hash(preimage_hash_sha256.as_byte_array());
 
@@ -1426,9 +1433,10 @@ where
         tracing::debug!(swap_id, "Claiming VHTLC with verified preimage");
 
         let timeout_block_heights = swap.timeout_block_heights;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap.refund_public_key.into(),
@@ -1475,7 +1483,7 @@ where
             vhtlc_outpoint.clone()
         };
 
-        let claim_address = self.reverse_claim_address(&swap)?;
+        let claim_address = self.reverse_claim_address(&swap).await?;
         let claim_amount = swap.amount;
 
         let outputs = vec![SendReceiver {
@@ -1672,9 +1680,10 @@ where
         tracing::debug!("Ark transaction for swap found");
 
         let timeout_block_heights = swap.timeout_block_heights;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap.refund_public_key.into(),
@@ -1721,7 +1730,7 @@ where
             vhtlc_outpoint.clone()
         };
 
-        let claim_address = self.reverse_claim_address(&swap)?;
+        let claim_address = self.reverse_claim_address(&swap).await?;
         let claim_amount = swap.amount;
 
         let outputs = vec![SendReceiver {
@@ -2089,12 +2098,13 @@ where
                  (this swap's server lockup is on-chain BTC, not an Ark VHTLC)"
             ))
         })?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let expected_address = ArkAddress::decode(&swap.server_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid server lockup address: {e}")))?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap.server_refund_public_key.into(),
@@ -2141,6 +2151,7 @@ where
 
         let (claim_address, _) = self
             .get_offchain_address()
+            .await
             .context("failed to get offchain address")?;
         let claim_amount = swap.server_lockup_amount;
 
@@ -2446,13 +2457,14 @@ where
         })?;
 
         let preimage_hash = ripemd160::Hash::hash(swap.preimage_hash.as_byte_array());
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         // User's lockup VHTLC: sender=user(refund), receiver=server(claim)
         let expected_address = ArkAddress::decode(&swap.user_lockup_address)
             .map_err(|e| Error::ad_hoc(format!("invalid user lockup address: {e}")))?;
 
         let vhtlc = self.reconstruct_vhtlc_for_address(
+            &server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: swap.refund_public_key.into(),
@@ -2498,7 +2510,7 @@ where
                 .clone()
         };
 
-        let (refund_address, _) = self.get_offchain_address()?;
+        let (refund_address, _) = self.get_offchain_address().await?;
         let refund_amount = swap.user_lockup_amount;
 
         let outputs = vec![SendReceiver::bitcoin(refund_address, refund_amount)];
@@ -3372,10 +3384,10 @@ where
     /// the VHTLC was built with the old key, so we must try deprecated keys to find the right one.
     fn reconstruct_vhtlc_for_address(
         &self,
+        server_info: &Info,
         mk_opts: impl Fn(XOnlyPublicKey) -> Result<VhtlcOptions, Error>,
         expected_address: &ArkAddress,
     ) -> Result<VhtlcScript, Error> {
-        let server_info = self.server_info()?;
         reconstruct_vhtlc_from_keys(
             server_info.all_server_keys(),
             server_info.network,
@@ -3387,6 +3399,7 @@ where
     /// Reconstruct a [`VhtlcScript`] from swap data fields, trying current + deprecated signers.
     fn build_vhtlc_script(
         &self,
+        server_info: &Info,
         claim_public_key: PublicKey,
         refund_public_key: PublicKey,
         preimage_hash: ripemd160::Hash,
@@ -3406,6 +3419,7 @@ where
                 })?;
 
         self.reconstruct_vhtlc_for_address(
+            server_info,
             |server| {
                 Ok(VhtlcOptions {
                     sender: refund_public_key.inner.x_only_public_key().0,
@@ -3483,6 +3497,7 @@ where
             .await
             .context("failed to list reverse swaps")?;
 
+        let server_info = self.server_info().await?;
         let mut infos = Vec::new();
 
         for swap in &submarine_swaps {
@@ -3500,6 +3515,7 @@ where
             }
 
             let vhtlc = self.build_vhtlc_script(
+                &server_info,
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,
@@ -3543,6 +3559,7 @@ where
             }
 
             let vhtlc = self.build_vhtlc_script(
+                &server_info,
                 swap.claim_public_key,
                 swap.refund_public_key,
                 swap.preimage_hash,

--- a/ark-client/src/boltz.rs
+++ b/ark-client/src/boltz.rs
@@ -172,12 +172,11 @@ pub struct PendingVhtlcSpendTx {
     pub pending_tx: PendingTx,
 }
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     // Submarine swap.
 

--- a/ark-client/src/coin_select.rs
+++ b/ark-client/src/coin_select.rs
@@ -23,8 +23,8 @@ use std::time::Duration;
 /// https://github.com/bitcoindevkit/coin-select.
 ///
 /// TODO: Part of this logic needs to be extracted into `ark-core`.
-pub async fn coin_select_for_onchain<B, W, S, K>(
-    client: &Client<B, W, S, K>,
+pub async fn coin_select_for_onchain<B, W, S>(
+    client: &Client<B, W, S>,
     target_amount: Amount,
 ) -> Result<
     (
@@ -37,7 +37,6 @@ where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     let boarding_outputs = client.inner.wallet.get_boarding_outputs()?;
 

--- a/ark-client/src/coin_select.rs
+++ b/ark-client/src/coin_select.rs
@@ -89,7 +89,7 @@ where
 
     let mut selected_vtxo_outputs = HashSet::new();
 
-    for (_, vtxo) in client.get_offchain_addresses()? {
+    for (_, vtxo) in client.get_offchain_addresses().await? {
         if target_amount <= selected_amount {
             return Ok((
                 selected_boarding_outputs.into_iter().collect(),

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -53,7 +53,7 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address()?;
+        let (change_address, _) = self.get_offchain_address().await?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) = self
             .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
@@ -85,6 +85,7 @@ where
                 change_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
+            self.server_info().await?.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -144,6 +145,7 @@ where
                 to_amount: total_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
+            self.server_info().await?.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -187,7 +189,7 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address()?;
+        let (change_address, _) = self.get_offchain_address().await?;
 
         let vtxo_inputs = self
             .selected_batch_settleable_vtxo_inputs(input_vtxos)
@@ -228,6 +230,7 @@ where
                 change_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
+            self.server_info().await?.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -295,6 +298,7 @@ where
                 to_amount: total_input_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
+            self.server_info().await?.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -4,7 +4,6 @@ use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
 use crate::Client;
 use crate::Error;
-use crate::KeyProvider;
 use crate::SwapStorage;
 use ark_core::ArkAddress;
 use bitcoin::Address;
@@ -14,12 +13,11 @@ use bitcoin::SignedAmount;
 use rand::CryptoRng;
 use rand::Rng;
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: crate::Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: KeyProvider,
 {
     /// Estimates the fee to collaboratively redeem VTXOs to an on-chain Bitcoin address.
     ///

--- a/ark-client/src/fee_estimation.rs
+++ b/ark-client/src/fee_estimation.rs
@@ -51,10 +51,12 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
+
+        let (change_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         let (boarding_inputs, vtxo_inputs, total_amount) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
 
         let change_amount = total_amount.checked_sub(to_amount).ok_or_else(|| {
@@ -83,7 +85,7 @@ where
                 change_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
-            self.server_info().await?.dust,
+            server_info.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -123,8 +125,10 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
+        let server_info = self.server_info().await?;
+
         let (boarding_inputs, vtxo_inputs, total_amount) = self
-            .fetch_commitment_transaction_inputs(crate::utils::unix_now()?)
+            .fetch_commitment_transaction_inputs(&server_info, crate::utils::unix_now()?)
             .await?;
 
         tracing::info!(
@@ -143,7 +147,7 @@ where
                 to_amount: total_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
-            self.server_info().await?.dust,
+            server_info.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -187,10 +191,12 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
-        let (change_address, _) = self.get_offchain_address().await?;
+        let server_info = self.server_info().await?;
+
+        let (change_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
         let vtxo_inputs = self
-            .selected_batch_settleable_vtxo_inputs(input_vtxos)
+            .selected_batch_settleable_vtxo_inputs(&server_info, input_vtxos)
             .await?;
 
         if vtxo_inputs.is_empty() {
@@ -228,7 +234,7 @@ where
                 change_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
-            self.server_info().await?.dust,
+            server_info.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;
@@ -268,8 +274,10 @@ where
     where
         R: Rng + CryptoRng + Clone,
     {
+        let server_info = self.server_info().await?;
+
         let vtxo_inputs = self
-            .selected_batch_settleable_vtxo_inputs(input_vtxos)
+            .selected_batch_settleable_vtxo_inputs(&server_info, input_vtxos)
             .await?;
 
         if vtxo_inputs.is_empty() {
@@ -296,7 +304,7 @@ where
                 to_amount: total_input_amount,
             },
             batch::PrepareIntentKind::EstimateFee,
-            self.server_info().await?.dust,
+            server_info.dust,
         )?;
 
         let amount = self.network_client().estimate_fees(intent.intent).await?;

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -44,6 +44,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
+use std::time::Instant;
 
 pub mod error;
 pub mod key_provider;
@@ -101,6 +102,8 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// Default Boltz `referralId` sent with swap creation requests when the caller does not
 /// provide one. Identifies traffic originating from this SDK.
 pub const DEFAULT_BOLTZ_REFERRAL_ID: &str = "arkade-rs-SDK";
+
+const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 
 /// A client to interact with Ark Server
 ///
@@ -324,11 +327,13 @@ pub struct OfflineClient<B, W, S, K> {
 pub struct Client<B, W, S, K> {
     inner: OfflineClient<B, W, S, K>,
     state: Arc<RwLock<ServerState>>,
+    server_info_refresh_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 struct ServerState {
     server_info: server::Info,
     fee_estimator: ark_fees::Estimator,
+    server_info_refreshed_at: Instant,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -662,8 +667,9 @@ where
 
         let fee_estimator = build_fee_estimator(&server_info)?;
         let state = Arc::new(RwLock::new(ServerState {
-            server_info,
+            server_info: server_info.clone(),
             fee_estimator,
+            server_info_refreshed_at: Instant::now(),
         }));
         let hook_state = state.clone();
         self.network_client
@@ -672,29 +678,23 @@ where
                     .map_err(|err| Box::new(err) as Box<dyn std::error::Error + Send + Sync>)
             });
 
-        let client = Client { inner: self, state };
-
-        if let Err(error) = client.discover_keys(DEFAULT_GAP_LIMIT).await {
-            tracing::warn!(?error, "Failed during key discovery");
+        let client = Client {
+            inner: self,
+            state,
+            server_info_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
 
         // Eagerly persist boarding rows for every signer/delay candidate the wallet should watch.
         // The migration boarding leg reads the wallet DB only; without this connect-time seed, a
         // deprecated-signer boarding UTXO could be invisible until the caller happened to call
         // `get_boarding_addresses()`. Re-persisting is idempotent, so it is safe on every connect.
-        match client.server_info() {
-            Ok(server_info) => {
-                if let Err(error) = client.persist_watch_boarding_outputs(&server_info) {
-                    tracing::warn!(?error, "Failed to persist boarding outputs at connect");
-                }
-            }
-            Err(error) => {
-                tracing::warn!(
-                    ?error,
-                    "Failed to read server info for boarding persistence"
-                );
-            }
+        if let Err(error) = client.persist_watch_boarding_outputs(&server_info) {
+            tracing::warn!(?error, "Failed to persist boarding outputs at connect");
         }
+
+        if let Err(error) = client.discover_keys(DEFAULT_GAP_LIMIT).await {
+            tracing::warn!(?error, "Failed during key discovery");
+        };
 
         Ok(client)
     }
@@ -725,6 +725,7 @@ fn update_server_state(
         .map_err(|_| Error::ad_hoc("client server state lock poisoned"))?;
     state.server_info = server_info;
     state.fee_estimator = fee_estimator;
+    state.server_info_refreshed_at = Instant::now();
     Ok(())
 }
 
@@ -735,11 +736,29 @@ where
     S: SwapStorage + 'static,
     K: KeyProvider,
 {
-    /// Returns the latest cached Ark server info.
-    pub fn server_info(&self) -> Result<server::Info, Error> {
+    /// Returns Ark server info, refreshing the cached snapshot when its TTL has expired.
+    pub async fn server_info(&self) -> Result<server::Info, Error> {
+        // Fast path avoids taking the async mutex while the cache is fresh.
+        if let Some(server_info) = self.cached_server_info_if_fresh()? {
+            return Ok(server_info);
+        }
+
+        let _guard = self.server_info_refresh_lock.lock().await;
+        // Re-check after acquiring the mutex: another task may have refreshed while we waited.
+        if let Some(server_info) = self.cached_server_info_if_fresh()? {
+            return Ok(server_info);
+        }
+
+        self.refresh_server_info_unlocked().await
+    }
+
+    fn cached_server_info_if_fresh(&self) -> Result<Option<server::Info>, Error> {
         self.state
             .read()
-            .map(|state| state.server_info.clone())
+            .map(|state| {
+                (state.server_info_refreshed_at.elapsed() < SERVER_INFO_TTL)
+                    .then(|| state.server_info.clone())
+            })
             .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
     }
 
@@ -756,23 +775,31 @@ where
             .map_err(Error::ad_hoc)
     }
 
-    /// Refresh cached `/info` data.
+    /// Force-fetch the latest Ark server `/info` and replace the cached server state.
     ///
-    /// Useful after an out-of-band server restart or signer rotation, and also used by guarded RPC
-    /// clients after arkd reports stale client state.
+    /// This bypasses the TTL used by [`Self::server_info`]. Concurrent refreshes are serialized
+    /// with the same refresh gate used by TTL-based refreshes.
     ///
-    /// The refreshed snapshot includes the server's current
-    /// [`server::Info::deprecated_signers`]. The background watcher's migration arm then observes
-    /// those freshly advertised deprecated signers on its next pass and rotates funds off them via
-    /// [`Self::migrate_deprecated_signer_vtxos`].
-    pub async fn refresh_server_info(&self) -> Result<(), Error> {
+    /// Returns the freshly fetched server info. The refreshed snapshot includes the server's
+    /// current [`server::Info::deprecated_signers`], allowing subsequent wallet operations to
+    /// observe signer rotations.
+    pub async fn refresh_server_info(&self) -> Result<server::Info, Error> {
+        let _guard = self.server_info_refresh_lock.lock().await;
+        self.refresh_server_info_unlocked().await
+    }
+
+    /// Fetch `/info` and update cached server state without acquiring the refresh gate.
+    ///
+    /// Callers must already hold `server_info_refresh_lock`, or otherwise guarantee that
+    /// concurrent refreshes are serialized.
+    async fn refresh_server_info_unlocked(&self) -> Result<server::Info, Error> {
         let server_info = timeout_op(self.inner.timeout, self.network_client().get_info())
             .await
             .context("Failed to refresh Ark server info")??;
 
-        update_server_state(&self.state, server_info)?;
+        update_server_state(&self.state, server_info.clone())?;
 
-        Ok(())
+        Ok(server_info)
     }
 
     /// Returns the currently configured delegator pubkey, if any.
@@ -792,8 +819,8 @@ where
     ///
     /// For HD wallets, this will derive a new address each time it's called.
     /// For static key providers, this will always return the same address.
-    pub fn get_offchain_address(&self) -> Result<(ArkAddress, Vtxo), Error> {
-        let server_info = &self.server_info()?;
+    pub async fn get_offchain_address(&self) -> Result<(ArkAddress, Vtxo), Error> {
+        let server_info = self.server_info().await?;
 
         let server_signer = server_info.signer_pk.into();
         let owner = self
@@ -801,7 +828,7 @@ where
             .public_key()
             .into();
 
-        let vtxo = self.make_vtxo(server_signer, owner)?;
+        let vtxo = self.make_vtxo(&server_info, server_signer, owner)?;
 
         let ark_address = vtxo.to_ark_address();
 
@@ -814,8 +841,8 @@ where
     /// (3-leaf) addresses for each key, so that VTXOs at either address are visible. If
     /// historical delegator keys are set via `historical_delegator_pks` passed to
     /// [`OfflineClient::new`], addresses for those are included too.
-    pub fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
-        let server_info = &self.server_info()?;
+    pub async fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
+        let server_info = &self.server_info().await?;
         let pks = self.inner.key_provider.get_cached_pks()?;
 
         // Build addresses for current signer + all deprecated signers so VTXOs under any
@@ -873,10 +900,10 @@ where
     /// configured, otherwise a standard 2-leaf default VTXO.
     fn make_vtxo(
         &self,
+        server_info: &server::Info,
         server_signer: XOnlyPublicKey,
         owner: XOnlyPublicKey,
     ) -> Result<Vtxo, Error> {
-        let server_info = &self.server_info()?;
         match self.inner.delegator_pk {
             Some(delegator) => Vtxo::new_with_delegator(
                 self.secp(),
@@ -914,7 +941,7 @@ where
             return Ok(0);
         }
 
-        let server_info = &self.server_info()?;
+        let server_info = &self.server_info().await?;
         // Discover against current + all deprecated signers so that user keys used before a
         // rotation are still found when recovering from seed.
         let all_server_keys: Vec<XOnlyPublicKey> = server_info.all_server_keys().collect();
@@ -1025,8 +1052,8 @@ where
     }
 
     // At the moment we are always generating the same address.
-    pub fn get_boarding_address(&self) -> Result<Address, Error> {
-        let server_info = &self.server_info()?;
+    pub async fn get_boarding_address(&self) -> Result<Address, Error> {
+        let server_info = &self.server_info().await?;
 
         let boarding_output = self.inner.wallet.new_boarding_output(
             server_info.signer_pk.into(),
@@ -1041,8 +1068,8 @@ where
         self.inner.wallet.get_onchain_address()
     }
 
-    pub fn get_boarding_addresses(&self) -> Result<Vec<Address>, Error> {
-        let server_info = &self.server_info()?;
+    pub async fn get_boarding_addresses(&self) -> Result<Vec<Address>, Error> {
+        let server_info = &self.server_info().await?;
 
         // Persist a boarding output for every (signer, exit-delay) candidate and return the
         // de-duplicated addresses. This is the watch/history surface: it covers the current signer
@@ -1106,7 +1133,7 @@ where
     }
 
     pub async fn list_vtxos(&self) -> Result<(VtxoList, HashMap<ScriptBuf, Vtxo>), Error> {
-        let ark_addresses = self.get_offchain_addresses()?;
+        let ark_addresses = self.get_offchain_addresses().await?;
 
         let script_pubkey_to_vtxo_map = ark_addresses
             .iter()
@@ -1129,7 +1156,7 @@ where
             .await
             .context("failed to get VTXOs for addresses")?;
 
-        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info().await?.dust, virtual_tx_outpoints);
 
         Ok(vtxo_list)
     }
@@ -1138,7 +1165,7 @@ where
         &self,
         outpoints: Vec<OutPoint>,
     ) -> Result<(VtxoList, HashMap<ScriptBuf, Vtxo>), Error> {
-        let ark_addresses = self.get_offchain_addresses()?;
+        let ark_addresses = self.get_offchain_addresses().await?;
 
         let script_pubkey_to_vtxo_map = ark_addresses
             .iter()
@@ -1161,7 +1188,7 @@ where
             })
             .collect();
 
-        let vtxo_list = VtxoList::new(self.server_info()?.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(self.server_info().await?.dust, virtual_tx_outpoints);
 
         Ok((vtxo_list, script_pubkey_to_vtxo_map))
     }
@@ -1186,7 +1213,7 @@ where
     pub async fn offchain_balance(&self) -> Result<OffChainBalance, Error> {
         let (vtxo_list, script_map) = self.list_vtxos().await.context("failed to list VTXOs")?;
         let now = unix_now()?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
 
         let spendable_outpoints: HashSet<OutPoint> = vtxo_list
             .spendable_offchain_at(&server_info, now, |script| {
@@ -1255,7 +1282,7 @@ where
         let mut boarding_transactions = Vec::new();
         let mut boarding_commitment_transactions = Vec::new();
 
-        let boarding_addresses = self.get_boarding_addresses()?;
+        let boarding_addresses = self.get_boarding_addresses().await?;
         for boarding_address in boarding_addresses.iter() {
             let outpoints = timeout_op(
                 self.inner.timeout,
@@ -1368,8 +1395,8 @@ where
     }
 
     /// The server's dust threshold amount.
-    pub fn dust(&self) -> Result<Amount, Error> {
-        Ok(self.server_info()?.dust)
+    pub async fn dust(&self) -> Result<Amount, Error> {
+        Ok(self.server_info().await?.dust)
     }
 
     pub fn network_client(&self) -> ark_grpc::Client {
@@ -1544,6 +1571,9 @@ mod digest_guard_tests {
     use bitcoin::key::Secp256k1;
     use bitcoin::secp256k1::SecretKey;
     use bitcoin::Address;
+    use bitcoin::FeeRate;
+    use bitcoin::Network;
+    use bitcoin::Psbt;
     use std::convert::Infallible;
     use std::future::Future;
     use std::pin::Pin;
@@ -1567,6 +1597,119 @@ mod digest_guard_tests {
     struct MockState {
         get_info_calls: AtomicUsize,
         list_vtxos_calls: AtomicUsize,
+    }
+
+    #[derive(Clone)]
+    struct DummyBlockchain;
+
+    impl Blockchain for DummyBlockchain {
+        async fn find_outpoints(&self, _address: &Address) -> Result<Vec<ExplorerUtxo>, Error> {
+            Ok(Vec::new())
+        }
+
+        async fn find_tx(&self, _txid: &Txid) -> Result<Option<Transaction>, Error> {
+            Ok(None)
+        }
+
+        async fn get_tx_status(&self, _txid: &Txid) -> Result<TxStatus, Error> {
+            Ok(TxStatus { confirmed_at: None })
+        }
+
+        async fn get_output_status(&self, _txid: &Txid, _vout: u32) -> Result<SpendStatus, Error> {
+            Ok(SpendStatus { spend_txid: None })
+        }
+
+        async fn broadcast(&self, _tx: &Transaction) -> Result<(), Error> {
+            Ok(())
+        }
+
+        async fn get_fee_rate(&self) -> Result<f64, Error> {
+            Ok(1.0)
+        }
+
+        async fn broadcast_package(&self, _txs: &[&Transaction]) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+
+    struct DummyWallet {
+        keypair: Keypair,
+        secp: Secp256k1<All>,
+    }
+
+    impl DummyWallet {
+        fn new() -> Self {
+            let secp = Secp256k1::new();
+            let secret_key = SecretKey::from_slice(&[2; 32]).unwrap();
+            let keypair = Keypair::from_secret_key(&secp, &secret_key);
+            Self { keypair, secp }
+        }
+    }
+
+    impl BoardingWallet for DummyWallet {
+        fn new_boarding_output(
+            &self,
+            server_pubkey: XOnlyPublicKey,
+            exit_delay: bitcoin::Sequence,
+            network: Network,
+        ) -> Result<BoardingOutput, Error> {
+            let owner = self.keypair.x_only_public_key().0;
+            BoardingOutput::new(&self.secp, server_pubkey, owner, exit_delay, network)
+                .map_err(Into::into)
+        }
+
+        fn get_boarding_outputs(&self) -> Result<Vec<BoardingOutput>, Error> {
+            Ok(Vec::new())
+        }
+
+        fn sign_for_pk(
+            &self,
+            _pk: &XOnlyPublicKey,
+            msg: &bitcoin::secp256k1::Message,
+        ) -> Result<bitcoin::secp256k1::schnorr::Signature, Error> {
+            Ok(self.secp.sign_schnorr_no_aux_rand(msg, &self.keypair))
+        }
+    }
+
+    impl OnchainWallet for DummyWallet {
+        fn get_onchain_address(&self) -> Result<Address, Error> {
+            Ok(Address::p2tr(
+                &self.secp,
+                self.keypair.x_only_public_key().0,
+                None,
+                Network::Regtest,
+            ))
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn balance(&self) -> Result<wallet::Balance, Error> {
+            Ok(wallet::Balance {
+                immature: Amount::ZERO,
+                trusted_pending: Amount::ZERO,
+                untrusted_pending: Amount::ZERO,
+                confirmed: Amount::ZERO,
+            })
+        }
+
+        fn prepare_send_to_address(
+            &self,
+            _address: Address,
+            _amount: Amount,
+            _fee_rate: FeeRate,
+        ) -> Result<Psbt, Error> {
+            Err(Error::wallet("not implemented"))
+        }
+
+        fn sign(&self, _psbt: &mut Psbt) -> Result<bool, Error> {
+            Ok(true)
+        }
+
+        fn select_coins(&self, _target_amount: Amount) -> Result<UtxoCoinSelection, Error> {
+            Err(Error::wallet("not implemented"))
+        }
     }
 
     impl Service<http::Request<Body>> for MockArkServer {
@@ -1675,13 +1818,49 @@ mod digest_guard_tests {
         }
     }
 
+    async fn connect_test_client(
+        mock: MockArkServer,
+    ) -> Client<DummyBlockchain, DummyWallet, InMemorySwapStorage, StaticKeyProvider> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        let indexer_mock = MockIndexerServer(mock.clone());
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(mock)
+                .add_service(indexer_mock)
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        let secp = Secp256k1::new();
+        let keypair = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[3; 32]).unwrap());
+        OfflineClient::<DummyBlockchain, DummyWallet, InMemorySwapStorage, StaticKeyProvider>::new_with_keypair(
+            "test".to_string(),
+            keypair,
+            Arc::new(DummyBlockchain),
+            Arc::new(DummyWallet::new()),
+            format!("http://{addr}"),
+            Arc::new(InMemorySwapStorage::default()),
+            "http://127.0.0.1:1".to_string(),
+            None,
+            Duration::from_secs(30),
+            None,
+            vec![],
+        )
+        .connect()
+        .await
+        .unwrap()
+    }
+
     fn info_response(digest: &str) -> test_utils::GetInfoResponse {
         let secp = Secp256k1::new();
         let secret_key = SecretKey::from_slice(&[1; 32]).unwrap();
         let keypair = Keypair::from_secret_key(&secp, &secret_key);
         let public_key = bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
         let (xonly, _) = keypair.x_only_public_key();
-        let address = Address::p2tr(&secp, xonly, None, bitcoin::Network::Regtest);
+        let address = Address::p2tr(&secp, xonly, None, Network::Regtest);
 
         test_utils::GetInfoResponse {
             version: "0.9.9".to_string(),
@@ -1706,6 +1885,38 @@ mod digest_guard_tests {
             max_tx_weight: 0,
             max_op_return_outputs: 0,
         }
+    }
+
+    #[tokio::test]
+    async fn server_info_uses_fresh_cache_without_refetching() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mock = MockArkServer::default();
+        let state = mock.state.clone();
+        let client = connect_test_client(mock).await;
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
+
+        let info = client.server_info().await.unwrap();
+        assert_eq!(info.digest, "fresh-digest");
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn server_info_refreshes_expired_cache_once_for_concurrent_callers() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mock = MockArkServer::default();
+        let state = mock.state.clone();
+        let client = Arc::new(connect_test_client(mock).await);
+        client.state.write().unwrap().server_info_refreshed_at =
+            Instant::now() - SERVER_INFO_TTL - Duration::from_secs(1);
+
+        let a = Arc::clone(&client);
+        let b = Arc::clone(&client);
+        let (info_a, info_b) = tokio::join!(a.server_info(), b.server_info());
+        assert_eq!(info_a.unwrap().digest, "fresh-digest");
+        assert_eq!(info_b.unwrap().digest, "fresh-digest");
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
@@ -1736,6 +1947,7 @@ mod digest_guard_tests {
             server_info: initial_info,
             fee_estimator: build_fee_estimator(&info_response("stale-digest").try_into().unwrap())
                 .unwrap(),
+            server_info_refreshed_at: Instant::now() - SERVER_INFO_TTL - Duration::from_secs(1),
         }));
         let hook_state = cached_state.clone();
         inner.set_info_refresh_hook(move |server_info| {
@@ -1755,9 +1967,8 @@ mod digest_guard_tests {
         assert!(Error::from(err).is_server_info_changed());
         assert_eq!(state.list_vtxos_calls.load(Ordering::SeqCst), 1);
         assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(
-            cached_state.read().unwrap().server_info.digest,
-            "fresh-digest"
-        );
+        let refreshed_state = cached_state.read().unwrap();
+        assert_eq!(refreshed_state.server_info.digest, "fresh-digest");
+        assert!(refreshed_state.server_info_refreshed_at.elapsed() < SERVER_INFO_TTL);
     }
 }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -103,7 +103,64 @@ pub const DEFAULT_GAP_LIMIT: u32 = 20;
 /// provide one. Identifies traffic originating from this SDK.
 pub const DEFAULT_BOLTZ_REFERRAL_ID: &str = "arkade-rs-SDK";
 
-const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
+/// Default mainnet Arkade server URL.
+pub const ARKADE_MAINNET_URL: &str = "https://arkade.computer";
+
+/// Default mutinynet Arkade server URL.
+pub const ARKADE_MUTINYNET_URL: &str = "https://mutinynet.arkade.sh";
+
+/// Default mainnet Boltz API URL.
+pub const BOLTZ_MAINNET_URL: &str = "https://api.boltz.exchange";
+
+/// Default mutinynet Boltz API URL.
+pub const BOLTZ_MUTINYNET_URL: &str = "https://api.boltz.mutinynet.arkade.sh";
+
+/// Default timeout for network operations.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default maximum age for cached Ark server info.
+pub const DEFAULT_SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Boltz referral ID behavior for swap creation requests.
+#[derive(Clone, Debug, Default)]
+pub enum BoltzReferralId {
+    /// Use [`DEFAULT_BOLTZ_REFERRAL_ID`].
+    #[default]
+    Default,
+    /// Send no `referralId` field with Boltz swap creation requests.
+    Disabled,
+    /// Send a custom `referralId` field with Boltz swap creation requests.
+    Custom(String),
+}
+
+/// Configuration for constructing an [`OfflineClient`].
+///
+/// The default configuration targets mainnet. Set [`Self::server_info_ttl`] to
+/// [`Duration::ZERO`] to refresh server info on every access.
+#[derive(Clone, Debug)]
+pub struct OfflineClientConfig {
+    pub ark_server_url: String,
+    pub boltz_url: String,
+    pub timeout: Duration,
+    pub server_info_ttl: Duration,
+    pub boltz_referral_id: BoltzReferralId,
+    pub delegator_pk: Option<XOnlyPublicKey>,
+    pub historical_delegator_pks: Vec<XOnlyPublicKey>,
+}
+
+impl Default for OfflineClientConfig {
+    fn default() -> Self {
+        Self {
+            ark_server_url: ARKADE_MAINNET_URL.to_string(),
+            boltz_url: BOLTZ_MAINNET_URL.to_string(),
+            timeout: DEFAULT_TIMEOUT,
+            server_info_ttl: DEFAULT_SERVER_INFO_TTL,
+            boltz_referral_id: BoltzReferralId::default(),
+            delegator_pk: None,
+            historical_delegator_pks: Vec::new(),
+        }
+    }
+}
 
 /// A client to interact with Ark Server
 ///
@@ -112,9 +169,9 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 /// ```rust
 /// # use std::future::Future;
 /// # use std::str::FromStr;
-/// # use std::time::Duration;
 /// # use ark_client::{Blockchain, Client, Error, SpendStatus, TxStatus};
 /// # use ark_client::OfflineClient;
+/// # use ark_client::OfflineClientConfig;
 /// # use bitcoin::key::Keypair;
 /// # use bitcoin::secp256k1::{Message, SecretKey};
 /// # use std::sync::Arc;
@@ -123,7 +180,6 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 /// # use ark_client::wallet::{Balance, BoardingWallet, OnchainWallet, Persistence};
 /// # use ark_client::InMemorySwapStorage;
 /// # use ark_core::{BoardingOutput, UtxoCoinSelection, ExplorerUtxo};
-/// # use ark_client::StaticKeyProvider;
 ///
 /// struct MyBlockchain {}
 /// #
@@ -237,7 +293,7 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 /// # }
 /// #
 /// // Initialize the client with a static keypair
-/// async fn init_client_with_keypair() -> Result<Client<MyBlockchain, MyWallet, InMemorySwapStorage, ark_client::StaticKeyProvider>, ark_client::Error> {
+/// async fn init_client_with_keypair() -> Result<Client<MyBlockchain, MyWallet, InMemorySwapStorage>, ark_client::Error> {
 ///     // Create a keypair for signing transactions
 ///     let secp = bitcoin::key::Secp256k1::new();
 ///     let secret_key = SecretKey::from_str("your_private_key_here").unwrap();
@@ -246,21 +302,19 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 ///     // Initialize blockchain and wallet implementations
 ///     let blockchain = Arc::new(MyBlockchain::new("https://esplora.example.com"));
 ///     let wallet = Arc::new(MyWallet {});
-///     let timeout = Duration::from_secs(30);
 ///
-///     // Create the offline client (backward compatible method)
-///     let offline_client = OfflineClient::<MyBlockchain, MyWallet, InMemorySwapStorage, StaticKeyProvider>::new_with_keypair(
-///         "my-ark-client".to_string(),
+///     let config = OfflineClientConfig {
+///         ark_server_url: "https://ark-server.example.com".to_string(),
+///         boltz_url: "http://boltz.example.com".to_string(),
+///         ..Default::default()
+///     };
+///
+///     let offline_client = OfflineClient::with_keypair(
+///         config,
 ///         keypair,
 ///         blockchain,
 ///         wallet,
-///         "https://ark-server.example.com".to_string(),
 ///         Arc::new(InMemorySwapStorage::default()),
-///         "http://boltz.example.com".to_string(),
-///         None,
-///         timeout,
-///         None,
-///         vec![],
 ///     );
 ///
 ///     // Connect to the Ark server and get server info
@@ -271,31 +325,28 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 ///
 /// // Initialize the client with a BIP32 HD wallet
 /// # use bitcoin::bip32::{Xpriv, DerivationPath};
-/// async fn init_client_with_bip32() -> Result<Client<MyBlockchain, MyWallet, InMemorySwapStorage, ark_client::Bip32KeyProvider>, ark_client::Error> {
+/// async fn init_client_with_bip32() -> Result<Client<MyBlockchain, MyWallet, InMemorySwapStorage>, ark_client::Error> {
 ///     // Create a BIP32 master key and derivation path
 ///     let master_key = Xpriv::from_str("xprv...").unwrap();
 ///     let derivation_path = DerivationPath::from_str("m/84'/0'/0'/0/0").unwrap();
 ///
-///     let key_provider = Arc::new(ark_client::Bip32KeyProvider::new(master_key, derivation_path));
-///
 ///     // Initialize blockchain and wallet implementations
 ///     let blockchain = Arc::new(MyBlockchain::new("https://esplora.example.com"));
 ///     let wallet = Arc::new(MyWallet {});
-///     let timeout = Duration::from_secs(30);
 ///
-///     // Create the offline client with BIP32 key provider
-///     let offline_client = OfflineClient::new(
-///         "my-ark-client".to_string(),
-///         key_provider,
+///     let config = OfflineClientConfig {
+///         ark_server_url: "https://ark-server.example.com".to_string(),
+///         boltz_url: "http://boltz.example.com".to_string(),
+///         ..Default::default()
+///     };
+///
+///     let offline_client = OfflineClient::with_bip32(
+///         config,
+///         master_key,
+///         Some(derivation_path),
 ///         blockchain,
 ///         wallet,
-///         "https://ark-server.example.com".to_string(),
 ///         Arc::new(InMemorySwapStorage::default()),
-///         "http://boltz.example.com".to_string(),
-///         None,
-///         timeout,
-///         None,
-///         vec![],
 ///     );
 ///
 ///     // Connect to the Ark server and get server info
@@ -305,11 +356,10 @@ const SERVER_INFO_TTL: Duration = Duration::from_secs(15 * 60);
 /// }
 /// ```
 #[derive(Clone)]
-pub struct OfflineClient<B, W, S, K> {
+pub struct OfflineClient<B, W, S> {
     // TODO: We could introduce a generic interface so that consumers can use either GRPC or REST.
     network_client: ark_grpc::Client,
-    pub name: String,
-    key_provider: Arc<K>,
+    key_provider: Arc<dyn KeyProvider>,
     blockchain: Arc<B>,
     secp: Secp256k1<All>,
     wallet: Arc<W>,
@@ -317,6 +367,7 @@ pub struct OfflineClient<B, W, S, K> {
     boltz_url: String,
     boltz_referral_id: Option<String>,
     timeout: Duration,
+    server_info_ttl: Duration,
     delegator_pk: Option<XOnlyPublicKey>,
     historical_delegator_pks: Vec<XOnlyPublicKey>,
 }
@@ -324,8 +375,8 @@ pub struct OfflineClient<B, W, S, K> {
 /// A client to interact with Ark server
 ///
 /// See [`OfflineClient`] docs for details.
-pub struct Client<B, W, S, K> {
-    inner: OfflineClient<B, W, S, K>,
+pub struct Client<B, W, S> {
+    inner: OfflineClient<B, W, S>,
     state: Arc<RwLock<ServerState>>,
     server_info_refresh_lock: Arc<tokio::sync::Mutex<()>>,
 }
@@ -422,179 +473,85 @@ pub trait Blockchain {
     ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
-impl<B, W, S, K> OfflineClient<B, W, S, K>
+impl<B, W, S> OfflineClient<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: KeyProvider,
 {
-    /// Create a new offline client with a generic key provider
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Client identifier
-    /// * `key_provider` - Implementation of KeyProvider trait (StaticKeyProvider, Bip32KeyProvider,
-    ///   etc.)
-    /// * `blockchain` - Blockchain interface implementation
-    /// * `wallet` - Wallet implementation
-    /// * `ark_server_url` - URL of the Ark server
-    /// * `swap_storage` - Storage implementation for swap data
-    /// * `boltz_url` - URL of the Boltz server
-    /// * `boltz_referral_id` - Boltz referral ID to be included in all swap creation requests as
-    ///   the `referralId` field. When `None`, defaults to [`DEFAULT_BOLTZ_REFERRAL_ID`]. To send no
-    ///   referral ID at all, call [`OfflineClient::with_boltz_referral_id`] with `None` after
-    ///   construction.
-    /// * `timeout` - Timeout duration for network operations
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        name: String,
-        key_provider: Arc<K>,
+    /// Create a new offline client with a generic key provider.
+    pub fn with_key_provider(
+        config: OfflineClientConfig,
+        key_provider: Arc<dyn KeyProvider>,
         blockchain: Arc<B>,
         wallet: Arc<W>,
-        ark_server_url: String,
         swap_storage: Arc<S>,
-        boltz_url: String,
-        boltz_referral_id: Option<String>,
-        timeout: Duration,
-        delegator_pk: Option<XOnlyPublicKey>,
-        historical_delegator_pks: Vec<XOnlyPublicKey>,
     ) -> Self {
         let secp = Secp256k1::new();
-
-        let network_client = ark_grpc::Client::new(ark_server_url);
+        let network_client = ark_grpc::Client::new(config.ark_server_url);
 
         // Normalize historical delegator keys once (preserve order, remove duplicates), then
         // ensure the current delegator key is present at the front.
         let mut seen = HashSet::new();
-        let mut historical_delegator_pks: Vec<_> = historical_delegator_pks
+        let mut historical_delegator_pks: Vec<_> = config
+            .historical_delegator_pks
             .into_iter()
             .filter(|pk| seen.insert(*pk))
             .collect();
 
-        if let Some(pk) = delegator_pk {
+        if let Some(pk) = config.delegator_pk {
             historical_delegator_pks.retain(|k| *k != pk);
             historical_delegator_pks.insert(0, pk);
         }
 
-        let boltz_referral_id =
-            boltz_referral_id.or_else(|| Some(DEFAULT_BOLTZ_REFERRAL_ID.to_string()));
+        let boltz_referral_id = match config.boltz_referral_id {
+            BoltzReferralId::Default => Some(DEFAULT_BOLTZ_REFERRAL_ID.to_string()),
+            BoltzReferralId::Disabled => None,
+            BoltzReferralId::Custom(referral_id) => Some(referral_id),
+        };
 
         Self {
             network_client,
-            name,
             key_provider,
             blockchain,
             secp,
             wallet,
             swap_storage,
-            boltz_url,
+            boltz_url: config.boltz_url.trim_end_matches('/').to_string(),
             boltz_referral_id,
-            timeout,
-            delegator_pk,
+            timeout: config.timeout,
+            server_info_ttl: config.server_info_ttl,
+            delegator_pk: config.delegator_pk,
             historical_delegator_pks,
         }
     }
 
-    /// Override the Boltz referral ID after construction.
-    ///
-    /// Pass `Some(...)` to set a custom value, or `None` to send no `referralId` field with
-    /// swap creation requests (this opts out of the SDK default).
-    pub fn with_boltz_referral_id(mut self, boltz_referral_id: Option<String>) -> Self {
-        self.boltz_referral_id = boltz_referral_id;
-        self
-    }
-
-    /// Create a new offline client with a static keypair (backward compatible)
-    ///
-    /// This is a convenience method that wraps a single keypair in a StaticKeyProvider.
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Client identifier
-    /// * `kp` - Static keypair for signing
-    /// * `blockchain` - Blockchain interface implementation
-    /// * `wallet` - Wallet implementation
-    /// * `ark_server_url` - URL of the Ark server
-    /// * `swap_storage` - Storage implementation for swap data
-    /// * `boltz_url` - URL of the Boltz server
-    /// * `timeout` - Timeout duration for network operations
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_keypair(
-        name: String,
+    /// Create a new offline client with a static keypair.
+    pub fn with_keypair(
+        config: OfflineClientConfig,
         kp: Keypair,
         blockchain: Arc<B>,
         wallet: Arc<W>,
-        ark_server_url: String,
         swap_storage: Arc<S>,
-        boltz_url: String,
-        boltz_referral_id: Option<String>,
-        timeout: Duration,
-        delegator_pk: Option<XOnlyPublicKey>,
-        historical_delegator_pks: Vec<XOnlyPublicKey>,
-    ) -> OfflineClient<B, W, S, StaticKeyProvider> {
+    ) -> Self {
         let key_provider = Arc::new(StaticKeyProvider::new(kp));
-
-        OfflineClient::new(
-            name,
-            key_provider,
-            blockchain,
-            wallet,
-            ark_server_url,
-            swap_storage,
-            boltz_url,
-            boltz_referral_id,
-            timeout,
-            delegator_pk,
-            historical_delegator_pks,
-        )
+        Self::with_key_provider(config, key_provider, blockchain, wallet, swap_storage)
     }
 
-    /// Create a new offline client with an [`Xpriv`]
-    ///
-    /// # Arguments
-    ///
-    /// * `name` - Client identifier
-    /// * `xpriv` - BIP32 Xpriv
-    /// * `blockchain` - Blockchain interface implementation
-    /// * `wallet` - Wallet implementation
-    /// * `ark_server_url` - URL of the Ark server
-    /// * `swap_storage` - Storage implementation for swap data
-    /// * `boltz_url` - URL of the Boltz server
-    /// * `timeout` - Timeout duration for network operations
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_bip32(
-        name: String,
+    /// Create a new offline client with an [`Xpriv`].
+    pub fn with_bip32(
+        config: OfflineClientConfig,
         xpriv: Xpriv,
         path: Option<DerivationPath>,
         blockchain: Arc<B>,
         wallet: Arc<W>,
-        ark_server_url: String,
         swap_storage: Arc<S>,
-        boltz_url: String,
-        boltz_referral_id: Option<String>,
-        timeout: Duration,
-        delegator_pk: Option<XOnlyPublicKey>,
-        historical_delegator_pks: Vec<XOnlyPublicKey>,
-    ) -> OfflineClient<B, W, S, Bip32KeyProvider> {
+    ) -> Self {
         let path = path.unwrap_or(
             DerivationPath::from_str(DEFAULT_DERIVATION_PATH).expect("valid derivation path"),
         );
         let key_provider = Arc::new(Bip32KeyProvider::new(xpriv, path));
-
-        OfflineClient::new(
-            name,
-            key_provider,
-            blockchain,
-            wallet,
-            ark_server_url,
-            swap_storage,
-            boltz_url,
-            boltz_referral_id,
-            timeout,
-            delegator_pk,
-            historical_delegator_pks,
-        )
+        Self::with_key_provider(config, key_provider, blockchain, wallet, swap_storage)
     }
 
     /// Returns the currently configured delegator pubkey, if any.
@@ -612,7 +569,7 @@ where
     /// # Errors
     ///
     /// Returns an error if the connection fails or times out.
-    pub async fn connect(mut self) -> Result<Client<B, W, S, K>, Error> {
+    pub async fn connect(mut self) -> Result<Client<B, W, S>, Error> {
         timeout_op(self.timeout, self.network_client.connect())
             .await
             .context("Failed to connect to Ark server")??;
@@ -630,7 +587,7 @@ where
     pub async fn connect_with_retries(
         mut self,
         max_retries: usize,
-    ) -> Result<Client<B, W, S, K>, Error> {
+    ) -> Result<Client<B, W, S>, Error> {
         let mut n_retries = 0;
         while n_retries < max_retries {
             let res = timeout_op(self.timeout, self.network_client.connect())
@@ -654,16 +611,12 @@ where
         self.finish_connect().await
     }
 
-    async fn finish_connect(mut self) -> Result<Client<B, W, S, K>, Error> {
+    async fn finish_connect(mut self) -> Result<Client<B, W, S>, Error> {
         let server_info = timeout_op(self.timeout, self.network_client.get_info())
             .await
             .context("Failed to get Ark server info")??;
 
-        tracing::debug!(
-            name = self.name,
-            ark_server_url = ?self.network_client,
-            "Connected to Ark server"
-        );
+        tracing::debug!(ark_server_url = ?self.network_client, "Connected to Ark server");
 
         let fee_estimator = build_fee_estimator(&server_info)?;
         let state = Arc::new(RwLock::new(ServerState {
@@ -729,12 +682,11 @@ fn update_server_state(
     Ok(())
 }
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: KeyProvider,
 {
     /// Returns Ark server info, refreshing the cached snapshot when its TTL has expired.
     pub async fn server_info(&self) -> Result<server::Info, Error> {
@@ -756,7 +708,7 @@ where
         self.state
             .read()
             .map(|state| {
-                (state.server_info_refreshed_at.elapsed() < SERVER_INFO_TTL)
+                (state.server_info_refreshed_at.elapsed() < self.inner.server_info_ttl)
                     .then(|| state.server_info.clone())
             })
             .map_err(|_| Error::ad_hoc("client server state lock poisoned"))
@@ -814,7 +766,7 @@ where
 
     /// Get a new offchain receiving address.
     ///
-    /// When a delegator is configured (via `delegator_pk` passed to [`OfflineClient::new`]),
+    /// When a delegator is configured (via [`OfflineClientConfig::delegator_pk`]),
     /// returns a 3-leaf delegate address. Otherwise returns a standard 2-leaf address.
     ///
     /// For HD wallets, this will derive a new address each time it's called.
@@ -840,7 +792,7 @@ where
     /// When a delegator is configured, this returns **both** the default (2-leaf) and delegate
     /// (3-leaf) addresses for each key, so that VTXOs at either address are visible. If
     /// historical delegator keys are set via `historical_delegator_pks` passed to
-    /// [`OfflineClient::new`], addresses for those are included too.
+    /// [`OfflineClientConfig::historical_delegator_pks`], addresses for those are included too.
     pub async fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
         let server_info = &self.server_info().await?;
         let pks = self.inner.key_provider.get_cached_pks()?;
@@ -1820,7 +1772,7 @@ mod digest_guard_tests {
 
     async fn connect_test_client(
         mock: MockArkServer,
-    ) -> Client<DummyBlockchain, DummyWallet, InMemorySwapStorage, StaticKeyProvider> {
+    ) -> Client<DummyBlockchain, DummyWallet, InMemorySwapStorage> {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
@@ -1836,18 +1788,16 @@ mod digest_guard_tests {
 
         let secp = Secp256k1::new();
         let keypair = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[3; 32]).unwrap());
-        OfflineClient::<DummyBlockchain, DummyWallet, InMemorySwapStorage, StaticKeyProvider>::new_with_keypair(
-            "test".to_string(),
+        OfflineClient::<DummyBlockchain, DummyWallet, InMemorySwapStorage>::with_keypair(
+            OfflineClientConfig {
+                ark_server_url: format!("http://{addr}"),
+                boltz_url: "http://127.0.0.1:1".to_string(),
+                ..Default::default()
+            },
             keypair,
             Arc::new(DummyBlockchain),
             Arc::new(DummyWallet::new()),
-            format!("http://{addr}"),
             Arc::new(InMemorySwapStorage::default()),
-            "http://127.0.0.1:1".to_string(),
-            None,
-            Duration::from_secs(30),
-            None,
-            vec![],
         )
         .connect()
         .await
@@ -1902,6 +1852,22 @@ mod digest_guard_tests {
     }
 
     #[tokio::test]
+    async fn server_info_zero_ttl_always_refreshes() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let mock = MockArkServer::default();
+        let state = mock.state.clone();
+        let mut client = connect_test_client(mock).await;
+        client.inner.server_info_ttl = Duration::ZERO;
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
+
+        client.server_info().await.unwrap();
+        client.server_info().await.unwrap();
+
+        assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
     async fn server_info_refreshes_expired_cache_once_for_concurrent_callers() {
         let _ = rustls::crypto::ring::default_provider().install_default();
 
@@ -1909,7 +1875,7 @@ mod digest_guard_tests {
         let state = mock.state.clone();
         let client = Arc::new(connect_test_client(mock).await);
         client.state.write().unwrap().server_info_refreshed_at =
-            Instant::now() - SERVER_INFO_TTL - Duration::from_secs(1);
+            Instant::now() - DEFAULT_SERVER_INFO_TTL - Duration::from_secs(1);
 
         let a = Arc::clone(&client);
         let b = Arc::clone(&client);
@@ -1947,7 +1913,9 @@ mod digest_guard_tests {
             server_info: initial_info,
             fee_estimator: build_fee_estimator(&info_response("stale-digest").try_into().unwrap())
                 .unwrap(),
-            server_info_refreshed_at: Instant::now() - SERVER_INFO_TTL - Duration::from_secs(1),
+            server_info_refreshed_at: Instant::now()
+                - DEFAULT_SERVER_INFO_TTL
+                - Duration::from_secs(1),
         }));
         let hook_state = cached_state.clone();
         inner.set_info_refresh_hook(move |server_info| {
@@ -1969,6 +1937,6 @@ mod digest_guard_tests {
         assert_eq!(state.get_info_calls.load(Ordering::SeqCst), 1);
         let refreshed_state = cached_state.read().unwrap();
         assert_eq!(refreshed_state.server_info.digest, "fresh-digest");
-        assert!(refreshed_state.server_info_refreshed_at.elapsed() < SERVER_INFO_TTL);
+        assert!(refreshed_state.server_info_refreshed_at.elapsed() < DEFAULT_SERVER_INFO_TTL);
     }
 }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -773,14 +773,20 @@ where
     /// For static key providers, this will always return the same address.
     pub async fn get_offchain_address(&self) -> Result<(ArkAddress, Vtxo), Error> {
         let server_info = self.server_info().await?;
+        self.get_offchain_address_with_server_info(&server_info)
+    }
 
+    pub(crate) fn get_offchain_address_with_server_info(
+        &self,
+        server_info: &server::Info,
+    ) -> Result<(ArkAddress, Vtxo), Error> {
         let server_signer = server_info.signer_pk.into();
         let owner = self
             .next_keypair(KeypairIndex::LastUnused)?
             .public_key()
             .into();
 
-        let vtxo = self.make_vtxo(&server_info, server_signer, owner)?;
+        let vtxo = self.make_vtxo(server_info, server_signer, owner)?;
 
         let ark_address = vtxo.to_ark_address();
 
@@ -794,7 +800,14 @@ where
     /// historical delegator keys are set via `historical_delegator_pks` passed to
     /// [`OfflineClientConfig::historical_delegator_pks`], addresses for those are included too.
     pub async fn get_offchain_addresses(&self) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
-        let server_info = &self.server_info().await?;
+        let server_info = self.server_info().await?;
+        self.get_offchain_addresses_with_server_info(&server_info)
+    }
+
+    pub(crate) fn get_offchain_addresses_with_server_info(
+        &self,
+        server_info: &server::Info,
+    ) -> Result<Vec<(ArkAddress, Vtxo)>, Error> {
         let pks = self.inner.key_provider.get_cached_pks()?;
 
         // Build addresses for current signer + all deprecated signers so VTXOs under any
@@ -1085,7 +1098,15 @@ where
     }
 
     pub async fn list_vtxos(&self) -> Result<(VtxoList, HashMap<ScriptBuf, Vtxo>), Error> {
-        let ark_addresses = self.get_offchain_addresses().await?;
+        let server_info = self.server_info().await?;
+        self.list_vtxos_with_server_info(&server_info).await
+    }
+
+    pub(crate) async fn list_vtxos_with_server_info(
+        &self,
+        server_info: &server::Info,
+    ) -> Result<(VtxoList, HashMap<ScriptBuf, Vtxo>), Error> {
+        let ark_addresses = self.get_offchain_addresses_with_server_info(server_info)?;
 
         let script_pubkey_to_vtxo_map = ark_addresses
             .iter()
@@ -1094,7 +1115,9 @@ where
 
         let addresses = ark_addresses.iter().map(|(a, _)| a).copied();
 
-        let vtxo_list = self.list_vtxos_for_addresses(addresses).await?;
+        let vtxo_list = self
+            .list_vtxos_for_addresses_with_server_info(server_info, addresses)
+            .await?;
 
         Ok((vtxo_list, script_pubkey_to_vtxo_map))
     }
@@ -1103,12 +1126,22 @@ where
         &self,
         addresses: impl Iterator<Item = ArkAddress>,
     ) -> Result<VtxoList, Error> {
+        let server_info = self.server_info().await?;
+        self.list_vtxos_for_addresses_with_server_info(&server_info, addresses)
+            .await
+    }
+
+    pub(crate) async fn list_vtxos_for_addresses_with_server_info(
+        &self,
+        server_info: &server::Info,
+        addresses: impl Iterator<Item = ArkAddress>,
+    ) -> Result<VtxoList, Error> {
         let virtual_tx_outpoints = self
             .get_virtual_tx_outpoints(addresses)
             .await
             .context("failed to get VTXOs for addresses")?;
 
-        let vtxo_list = VtxoList::new(self.server_info().await?.dust, virtual_tx_outpoints);
+        let vtxo_list = VtxoList::new(server_info.dust, virtual_tx_outpoints);
 
         Ok(vtxo_list)
     }

--- a/ark-client/src/migration.rs
+++ b/ark-client/src/migration.rs
@@ -383,12 +383,13 @@ where
         // `fetch_commitment_transaction_inputs` already drops PAST-cutoff deprecated inputs (the
         // operator won't co-sign the old key). We narrow further to the PRE-cutoff deprecated
         // inputs, which is exactly the cooperatively-migratable set.
-        let (boarding_inputs, vtxo_inputs, _) =
-            self.fetch_commitment_transaction_inputs(now).await?;
+        let (boarding_inputs, vtxo_inputs, _) = self
+            .fetch_commitment_transaction_inputs(&server_info, now)
+            .await?;
 
         // The VTXO inputs only expose their script pubkey, so resolve each one's signer via the
         // script -> VTXO map (the same mapping `offchain_balance`/`settle_at` rely on).
-        let (_, script_map) = self.list_vtxos().await?;
+        let (_, script_map) = self.list_vtxos_with_server_info(&server_info).await?;
 
         // Build the candidate (outpoint, amount, signer, cutoff) list for the VTXO leg.
         let mut vtxo_candidates: Vec<MigrationVtxoRef> = Vec::new();
@@ -440,10 +441,24 @@ where
 
         // Run each leg independently so a failure in one does not suppress the other.
         let vtxo_leg = self
-            .run_migration_leg(rng, vtxo_candidates, vtxo_max_amount, dust, true)
+            .run_migration_leg(
+                rng,
+                &server_info,
+                vtxo_candidates,
+                vtxo_max_amount,
+                dust,
+                true,
+            )
             .await?;
         let boarding_leg = self
-            .run_migration_leg(rng, boarding_candidates, vtxo_max_amount, dust, false)
+            .run_migration_leg(
+                rng,
+                &server_info,
+                boarding_candidates,
+                vtxo_max_amount,
+                dust,
+                false,
+            )
             .await?;
 
         Ok(DeprecatedSignerMigrationReport {
@@ -493,7 +508,10 @@ where
             next_sweep_eta: Option<i64>,
         }
 
-        let (vtxo_list, script_map) = self.list_vtxos().await.context("failed to list VTXOs")?;
+        let (vtxo_list, script_map) = self
+            .list_vtxos_with_server_info(&server_info)
+            .await
+            .context("failed to list VTXOs")?;
         let mut vtxo_aggs: HashMap<XOnlyPublicKey, VtxoAgg> = HashMap::new();
         for v in vtxo_list.all_unspent() {
             let Some(vtxo) = script_map.get(&v.script) else {
@@ -623,6 +641,7 @@ where
     async fn run_migration_leg<R>(
         &self,
         rng: &mut R,
+        server_info: &ark_core::server::Info,
         candidates: Vec<MigrationVtxoRef>,
         vtxo_max_amount: Option<Amount>,
         dust: Amount,
@@ -657,9 +676,11 @@ where
 
         let selected_outpoints: Vec<OutPoint> = selected.iter().map(|c| c.outpoint).collect();
         let settle_result = if is_vtxo_leg {
-            self.settle_vtxos(rng, &selected_outpoints, &[]).await
+            self.settle_vtxos_with_server_info(rng, server_info, &selected_outpoints, &[])
+                .await
         } else {
-            self.settle_vtxos(rng, &[], &selected_outpoints).await
+            self.settle_vtxos_with_server_info(rng, server_info, &[], &selected_outpoints)
+                .await
         };
 
         // Capture (rather than propagate) the settle error so the caller can still run the other

--- a/ark-client/src/migration.rs
+++ b/ark-client/src/migration.rs
@@ -1,5 +1,4 @@
 use crate::error::ErrorContext;
-use crate::key_provider::KeyProvider;
 use crate::swap_storage::SwapStorage;
 use crate::utils::timeout_op;
 use crate::utils::unix_now;
@@ -321,12 +320,11 @@ pub struct DeprecatedSignerReport {
     pub next_sweep_eta: Option<i64>,
 }
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: KeyProvider,
 {
     /// Sweep VTXOs and boarding outputs minted under a *pre-cutoff* deprecated server signer to
     /// the current signer, then report what moved.

--- a/ark-client/src/migration.rs
+++ b/ark-client/src/migration.rs
@@ -360,7 +360,7 @@ where
         // classification closure, and the leg sizing must all see the same
         // `deprecated_signers`/`vtxo_max_amount`/`dust` even if a concurrent digest-driven
         // `refresh_server_info` swaps the snapshot mid-call.
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         if server_info.deprecated_signers.is_empty() {
             return Ok(DeprecatedSignerMigrationReport::nothing_migratable());
         }
@@ -473,7 +473,7 @@ where
     pub async fn deprecated_signer_status(&self) -> Result<Vec<DeprecatedSignerReport>, Error> {
         // Snapshot once (TOCTOU): the empty-check and every per-signer classification must see the
         // same `deprecated_signers`/`dust` even if a concurrent refresh swaps the snapshot.
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         if server_info.deprecated_signers.is_empty() {
             return Ok(Vec::new());
         }

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -193,7 +193,7 @@ where
         address: ark_core::ArkAddress,
         amount: Amount,
     ) -> Result<Txid, Error> {
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let receivers = vec![SendReceiver {
             address,
             amount,
@@ -243,7 +243,7 @@ where
             .context("failed to get spendable VTXOs")?;
 
         let now = crate::utils::unix_now()?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let spendable = vtxo_list
             .spendable_offchain_at(&server_info, now, |script| {
                 script_pubkey_to_vtxo_map
@@ -360,7 +360,7 @@ where
             .context("failed to get VTXO list")?;
 
         let now = crate::utils::unix_now()?;
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         let selected: Vec<_> = vtxo_list
             .spendable_offchain_at(&server_info, now, |script| {
                 script_pubkey_to_vtxo_map
@@ -517,7 +517,7 @@ where
         vtxo_inputs: Vec<VtxoInput>,
         receivers: Vec<SendReceiver>,
     ) -> Result<Txid, Error> {
-        let server_info = self.server_info()?;
+        let server_info = self.server_info().await?;
         Self::validate_selected_inputs_cover_receivers(&vtxo_inputs, &receivers, server_info.dust)?;
 
         let pending_tx = self
@@ -574,7 +574,7 @@ where
         receivers: Vec<SendReceiver>,
         server_info: &server::Info,
     ) -> Result<PendingTx, Error> {
-        let (change_address, change_address_vtxo) = self.get_offchain_address()?;
+        let (change_address, change_address_vtxo) = self.get_offchain_address().await?;
 
         let OffchainTransactions {
             ark_tx,
@@ -694,7 +694,7 @@ where
     async fn fetch_pending_offchain_txs(&self) -> Result<Vec<PendingTx>, Error> {
         const MAX_INPUTS_PER_INTENT: usize = 20;
 
-        let ark_addresses = self.get_offchain_addresses()?;
+        let ark_addresses = self.get_offchain_addresses().await?;
 
         let script_pubkey_to_vtxo_map: HashMap<_, _> = ark_addresses
             .iter()

--- a/ark-client/src/send_vtxo.rs
+++ b/ark-client/src/send_vtxo.rs
@@ -33,12 +33,11 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::Duration;
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     // Send public APIs
 

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -245,7 +245,7 @@ where
         to_address: Address,
         to_amount: Amount,
     ) -> Result<(Transaction, Vec<TxOut>), Error> {
-        let dust = self.server_info()?.dust;
+        let dust = self.server_info().await?.dust;
         if to_amount < dust {
             return Err(Error::ad_hoc(format!(
                 "invalid amount {to_amount}, must be greater than dust: {}",

--- a/ark-client/src/unilateral_exit.rs
+++ b/ark-client/src/unilateral_exit.rs
@@ -27,12 +27,11 @@ use std::collections::HashSet;
 
 // TODO: We should not _need_ to connect to the Ark server to perform unilateral exit. Currently we
 // do talk to the Ark server for simplicity.
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain,
     W: BoardingWallet + OnchainWallet,
     S: SwapStorage + 'static,
-    K: crate::KeyProvider,
 {
     /// Build the unilateral exit transaction tree for all spendable VTXOs.
     ///

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -6,7 +6,6 @@
 //! - On stream error: reconnect with exponential backoff
 
 use crate::error::ErrorContext;
-use crate::key_provider::KeyProvider;
 use crate::swap_storage::SwapStorage;
 use crate::wallet::BoardingWallet;
 use crate::wallet::OnchainWallet;
@@ -142,12 +141,11 @@ enum WatcherWork {
     },
 }
 
-impl<B, W, S, K> Client<B, W, S, K>
+impl<B, W, S> Client<B, W, S>
 where
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     /// Start a background task that watches for new VTXOs and:
     ///
@@ -180,8 +178,8 @@ where
 }
 
 /// Outer loop that reconnects on stream errors with exponential backoff.
-async fn run_watcher_loop<B, W, S, K>(
-    client: Arc<Client<B, W, S, K>>,
+async fn run_watcher_loop<B, W, S>(
+    client: Arc<Client<B, W, S>>,
     delegator: Arc<DelegatorClient>,
     config: VtxoWatcherConfig,
     mut stop_rx: watch::Receiver<bool>,
@@ -189,7 +187,6 @@ async fn run_watcher_loop<B, W, S, K>(
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     let mut backoff = INITIAL_BACKOFF;
 
@@ -434,14 +431,11 @@ async fn run_watcher_loop<B, W, S, K>(
 ///
 /// When [`Client::refresh_server_info`] updates the cached `deprecated_signers`, this arm picks up
 /// the freshly advertised deprecated signers on its next pass and migrates.
-async fn run_migration_arm<B, W, S, K>(
-    client: &Client<B, W, S, K>,
-    stop_rx: &mut watch::Receiver<bool>,
-) where
+async fn run_migration_arm<B, W, S>(client: &Client<B, W, S>, stop_rx: &mut watch::Receiver<bool>)
+where
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     // Consecutive-failure count drives the exponential cooldown; `0` means healthy (use the base
     // interval). Reset to `0` on any fully successful or no-op pass.
@@ -511,8 +505,8 @@ async fn wait_or_stop(stop_rx: &mut watch::Receiver<bool>, duration: Duration) -
 }
 
 /// Discover keys and add newly derived scripts to an existing subscription.
-async fn refresh_subscription_scripts<B, W, S, K>(
-    client: &Client<B, W, S, K>,
+async fn refresh_subscription_scripts<B, W, S>(
+    client: &Client<B, W, S>,
     subscription_id: &str,
     subscribed_addrs: &mut HashSet<ArkAddress>,
 ) -> Result<Option<Arc<ScriptMap>>, Error>
@@ -520,7 +514,6 @@ where
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     let _discovered = client.discover_keys(KEY_DISCOVERY_GAP_LIMIT).await?;
 
@@ -552,8 +545,8 @@ where
 /// Enumerate newly seen unspent delegate-eligible VTXOs from wallet state.
 ///
 /// This is a failsafe path to catch outputs that may have been missed by subscription timing.
-async fn collect_new_delegation_candidates<B, W, S, K>(
-    client: &Client<B, W, S, K>,
+async fn collect_new_delegation_candidates<B, W, S>(
+    client: &Client<B, W, S>,
     script_map: &ScriptMap,
     seen_unspent_outpoints: &mut HashSet<OutPoint>,
 ) -> Result<Vec<VirtualTxOutPoint>, Error>
@@ -561,7 +554,6 @@ where
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     let (vtxo_list, _) = client.list_vtxos().await?;
 
@@ -718,8 +710,8 @@ fn calculate_valid_at(group_vtxos: &[(&VirtualTxOutPoint, &Vtxo)], dust: Amount)
 ///
 /// The `script_map` provides VTXO metadata (tapscripts, spend info) without a network call.
 /// Only the affected addresses are queried for expiry data.
-async fn delegate_vtxos<B, W, S, K>(
-    client: &Arc<Client<B, W, S, K>>,
+async fn delegate_vtxos<B, W, S>(
+    client: &Arc<Client<B, W, S>>,
     delegator: &DelegatorClient,
     new_vtxos: &[VirtualTxOutPoint],
     script_map: &ScriptMap,
@@ -727,7 +719,6 @@ async fn delegate_vtxos<B, W, S, K>(
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     // Query only the addresses that appear in the event, not all wallet addresses.
     let affected_addresses = script_map.addresses_for(new_vtxos);
@@ -880,8 +871,8 @@ async fn delegate_vtxos<B, W, S, K>(
 }
 
 /// Prepare, sign, and submit a single delegation group.
-async fn delegate_group<B, W, S, K>(
-    client: &Client<B, W, S, K>,
+async fn delegate_group<B, W, S>(
+    client: &Client<B, W, S>,
     delegator: &DelegatorClient,
     vtxo_inputs: Vec<intent::Input>,
     outputs: Vec<intent::Output>,
@@ -893,7 +884,6 @@ async fn delegate_group<B, W, S, K>(
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     let input_count = vtxo_inputs.len();
 
@@ -941,12 +931,11 @@ const SELF_RENEW_REMAINING_FRACTION: f64 = 0.10;
 ///
 /// Only settles VTXOs whose remaining lifetime is less than [`SELF_RENEW_REMAINING_FRACTION`] of
 /// their total lifetime, leaving freshly-received VTXOs alone.
-async fn renew_expiring_vtxos<B, W, S, K>(client: &Client<B, W, S, K>)
+async fn renew_expiring_vtxos<B, W, S>(client: &Client<B, W, S>)
 where
     B: Blockchain + Send + Sync + 'static,
     W: BoardingWallet + OnchainWallet + Send + Sync + 'static,
     S: SwapStorage + 'static,
-    K: KeyProvider + Send + Sync + 'static,
 {
     let (vtxo_list, _) = match client.list_vtxos().await {
         Ok(v) => v,

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -199,7 +199,7 @@ async fn run_watcher_loop<B, W, S, K>(
         }
 
         // Build the script map and subscription from the same address set.
-        let addresses = match client.get_offchain_addresses() {
+        let addresses = match client.get_offchain_addresses().await {
             Ok(a) => a,
             Err(e) => {
                 tracing::error!("Failed to get offchain addresses: {e}");
@@ -524,7 +524,7 @@ where
 {
     let _discovered = client.discover_keys(KEY_DISCOVERY_GAP_LIMIT).await?;
 
-    let addrs = client.get_offchain_addresses()?;
+    let addrs = client.get_offchain_addresses().await?;
     let new_addrs: Vec<_> = addrs
         .iter()
         .map(|(addr, _)| *addr)
@@ -756,7 +756,7 @@ async fn delegate_vtxos<B, W, S, K>(
         .cloned()
         .collect();
 
-    let server_info = match client.server_info() {
+    let server_info = match client.server_info().await {
         Ok(server_info) => server_info,
         Err(e) => {
             tracing::error!("Failed to read server info for delegation: {e}");
@@ -778,7 +778,7 @@ async fn delegate_vtxos<B, W, S, K>(
         }
     };
 
-    let (to_address, _) = match client.get_offchain_address() {
+    let (to_address, _) = match client.get_offchain_address().await {
         Ok(v) => v,
         Err(e) => {
             tracing::error!("Failed to get offchain address for delegation: {e}");

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -121,6 +121,7 @@ pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
 
     match alice
         .server_info()
+        .await
         .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()

--- a/e2e-tests/tests/boltz_submarine.rs
+++ b/e2e-tests/tests/boltz_submarine.rs
@@ -40,7 +40,10 @@ pub async fn submarine_swap() {
     let alice_fund_amount = Amount::ONE_BTC;
 
     regtest
-        .faucet_fund(&alice.get_boarding_address().unwrap(), alice_fund_amount)
+        .faucet_fund(
+            &alice.get_boarding_address().await.unwrap(),
+            alice_fund_amount,
+        )
         .await;
 
     alice.settle(&mut rng).await.unwrap();

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -3,11 +3,11 @@
 use ark_bdk_wallet::Wallet;
 use ark_client::error::Error;
 use ark_client::wallet::Persistence;
-use ark_client::Bip32KeyProvider;
 use ark_client::Blockchain;
 use ark_client::Client;
 use ark_client::InMemorySwapStorage;
 use ark_client::OfflineClient;
+use ark_client::OfflineClientConfig;
 use ark_client::SpendStatus;
 use ark_client::TxStatus;
 use ark_core::BoardingOutput;
@@ -542,11 +542,11 @@ impl Persistence for InMemoryDb {
 
 #[allow(unused)]
 pub async fn set_up_client(
-    name: String,
+    _name: String,
     regtest: Arc<Regtest>,
     secp: Secp256k1<All>,
 ) -> (
-    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage, Bip32KeyProvider>,
+    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>,
     Arc<Wallet<InMemoryDb>>,
 ) {
     let mut rng = thread_rng();
@@ -563,19 +563,17 @@ pub async fn set_up_client(
     let seed: [u8; 32] = rng.r#gen();
     let xpriv = Xpriv::new_master(network, &seed).unwrap();
 
-    let client = OfflineClient::<_, _, _, Bip32KeyProvider>::new_with_bip32(
-        name,
+    let client = OfflineClient::with_bip32(
+        OfflineClientConfig {
+            ark_server_url: "http://localhost:7070".to_string(),
+            boltz_url: "http://localhost:9069".to_string(),
+            ..Default::default()
+        },
         xpriv,
         None,
         regtest,
         wallet.clone(),
-        "http://localhost:7070".to_string(),
         Arc::new(InMemorySwapStorage::default()),
-        "http://localhost:9069".to_string(),
-        None,
-        Duration::from_secs(30),
-        None,
-        vec![],
     )
     .connect_with_retries(5)
     .await
@@ -586,12 +584,12 @@ pub async fn set_up_client(
 
 #[allow(unused)]
 pub async fn set_up_client_with_delegator(
-    name: String,
+    _name: String,
     regtest: Arc<Regtest>,
     secp: Secp256k1<All>,
     delegator_pk: XOnlyPublicKey,
 ) -> (
-    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage, Bip32KeyProvider>,
+    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>,
     Arc<Wallet<InMemoryDb>>,
 ) {
     let mut rng = thread_rng();
@@ -608,19 +606,21 @@ pub async fn set_up_client_with_delegator(
     let seed: [u8; 32] = rng.r#gen();
     let xpriv = Xpriv::new_master(network, &seed).unwrap();
 
-    let client = OfflineClient::<_, _, _, Bip32KeyProvider>::new_with_bip32(
-        name,
+    let config = OfflineClientConfig {
+        ark_server_url: "http://localhost:7070".to_string(),
+        boltz_url: "http://localhost:9069".to_string(),
+        delegator_pk: Some(delegator_pk),
+        historical_delegator_pks: vec![delegator_pk],
+        ..Default::default()
+    };
+
+    let client = OfflineClient::with_bip32(
+        config,
         xpriv,
         None,
         regtest,
         wallet.clone(),
-        "http://localhost:7070".to_string(),
         Arc::new(InMemorySwapStorage::default()),
-        "http://localhost:9069".to_string(),
-        None,
-        Duration::from_secs(30),
-        Some(delegator_pk),
-        vec![delegator_pk],
     )
     .connect_with_retries(5)
     .await
@@ -699,12 +699,12 @@ pub(crate) use wait_until_balance;
 /// with the same keys.
 #[allow(unused)]
 pub async fn set_up_client_with_seed(
-    name: String,
+    _name: String,
     regtest: Arc<Regtest>,
     secp: Secp256k1<All>,
     seed: [u8; 32],
 ) -> (
-    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage, Bip32KeyProvider>,
+    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>,
     Arc<Wallet<InMemoryDb>>,
 ) {
     let mut rng = thread_rng();
@@ -720,19 +720,17 @@ pub async fn set_up_client_with_seed(
 
     let xpriv = Xpriv::new_master(network, &seed).unwrap();
 
-    let client = OfflineClient::<_, _, _, Bip32KeyProvider>::new_with_bip32(
-        name,
+    let client = OfflineClient::with_bip32(
+        OfflineClientConfig {
+            ark_server_url: "http://localhost:7070".to_string(),
+            boltz_url: "http://localhost:9069".to_string(),
+            ..Default::default()
+        },
         xpriv,
         None,
         regtest,
         wallet.clone(),
-        "http://localhost:7070".to_string(),
         Arc::new(InMemorySwapStorage::default()),
-        "http://localhost:9069".to_string(),
-        None,
-        Duration::from_secs(30),
-        None,
-        vec![],
     )
     .connect_with_retries(5)
     .await

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -699,10 +699,32 @@ pub(crate) use wait_until_balance;
 /// with the same keys.
 #[allow(unused)]
 pub async fn set_up_client_with_seed(
+    name: String,
+    regtest: Arc<Regtest>,
+    secp: Secp256k1<All>,
+    seed: [u8; 32],
+) -> (
+    Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>,
+    Arc<Wallet<InMemoryDb>>,
+) {
+    set_up_client_with_seed_and_server_info_ttl(
+        name,
+        regtest,
+        secp,
+        seed,
+        ark_client::DEFAULT_SERVER_INFO_TTL,
+    )
+    .await
+}
+
+/// Set up a client with a specific seed and server-info TTL.
+#[allow(unused)]
+pub async fn set_up_client_with_seed_and_server_info_ttl(
     _name: String,
     regtest: Arc<Regtest>,
     secp: Secp256k1<All>,
     seed: [u8; 32],
+    server_info_ttl: Duration,
 ) -> (
     Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>,
     Arc<Wallet<InMemoryDb>>,
@@ -724,6 +746,7 @@ pub async fn set_up_client_with_seed(
         OfflineClientConfig {
             ark_server_url: "http://localhost:7070".to_string(),
             boltz_url: "http://localhost:9069".to_string(),
+            server_info_ttl,
             ..Default::default()
         },
         xpriv,

--- a/e2e-tests/tests/e2e_arkade_script.rs
+++ b/e2e-tests/tests/e2e_arkade_script.rs
@@ -69,7 +69,7 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
     );
 
     let fund_amount = Amount::ONE_BTC;
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, fund_amount)
         .await;
@@ -81,8 +81,8 @@ pub async fn e2e_arkade_script_submit_tx_to_bob() {
     let custom_owner_pk = custom_owner_kp.public_key().x_only_public_key().0;
     let arkd_pk = server_info.signer_pk.x_only_public_key().0;
 
-    let (alice_offchain_address, _) = alice.get_offchain_address().unwrap();
-    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let (alice_offchain_address, _) = alice.get_offchain_address().await.unwrap();
+    let (bob_address, _) = bob.get_offchain_address().await.unwrap();
     let receiver_amount = Amount::from_sat(100_000);
     let expected_receiver_script = bob_address.to_p2tr_script_pubkey();
     let expected_receiver_program = &expected_receiver_script.as_bytes()[2..];

--- a/e2e-tests/tests/e2e_arknote.rs
+++ b/e2e-tests/tests/e2e_arknote.rs
@@ -88,7 +88,10 @@ pub async fn settle_arknote() {
     // Fund Charlie with a boarding output
     let boarding_amount = Amount::from_sat(200_000);
     regtest
-        .faucet_fund(&charlie.get_boarding_address().unwrap(), boarding_amount)
+        .faucet_fund(
+            &charlie.get_boarding_address().await.unwrap(),
+            boarding_amount,
+        )
         .await;
 
     // Create a note

--- a/e2e-tests/tests/e2e_assets.rs
+++ b/e2e-tests/tests/e2e_assets.rs
@@ -24,7 +24,7 @@ pub async fn e2e_assets() {
     let (bob, _) = set_up_client("bob".to_string(), regtest.clone(), secp).await;
 
     // Fund Alice with 1 BTC and settle.
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, Amount::ONE_BTC)
         .await;
@@ -85,7 +85,7 @@ pub async fn e2e_assets() {
         .find(|vtxo| !vtxo.assets.is_empty())
         .unwrap();
 
-    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_address, _) = bob.get_offchain_address().await.unwrap();
 
     let err = alice
         .send_selection(
@@ -133,7 +133,7 @@ pub async fn e2e_assets() {
     let send_txid = alice
         .send(vec![SendReceiver {
             address: bob_address,
-            amount: alice.dust().unwrap(),
+            amount: alice.dust().await.unwrap(),
             assets: vec![ark_core::server::Asset {
                 asset_id: issued_asset_id,
                 amount: send_amount,

--- a/e2e-tests/tests/e2e_concurrent_settlement.rs
+++ b/e2e-tests/tests/e2e_concurrent_settlement.rs
@@ -27,9 +27,9 @@ pub async fn concurrent_boarding() {
     let (bob, _) = set_up_client("bob".to_string(), regtest.clone(), secp.clone()).await;
     let (claire, _) = set_up_client("claire".to_string(), regtest.clone(), secp.clone()).await;
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
-    let bob_boarding_address = bob.get_boarding_address().unwrap();
-    let claire_boarding_address = claire.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
+    let bob_boarding_address = bob.get_boarding_address().await.unwrap();
+    let claire_boarding_address = claire.get_boarding_address().await.unwrap();
 
     let alice_offchain_balance = alice.offchain_balance().await.unwrap();
     let bob_offchain_balance = bob.offchain_balance().await.unwrap();
@@ -88,9 +88,9 @@ pub async fn concurrent_boarding() {
     wait_until_balance!(&bob, confirmed: bob_fund_amount, pre_confirmed: Amount::ZERO);
     wait_until_balance!(&claire, confirmed: claire_fund_amount, pre_confirmed: Amount::ZERO);
 
-    let (alice_offchain_address, _) = alice.get_offchain_address().unwrap();
-    let (bob_offchain_address, _) = bob.get_offchain_address().unwrap();
-    let (claire_offchain_address, _) = claire.get_offchain_address().unwrap();
+    let (alice_offchain_address, _) = alice.get_offchain_address().await.unwrap();
+    let (bob_offchain_address, _) = bob.get_offchain_address().await.unwrap();
+    let (claire_offchain_address, _) = claire.get_offchain_address().await.unwrap();
 
     let alice_to_bob_send_amount = Amount::from_sat(100_000);
     let bob_to_claire_send_amount = Amount::from_sat(50_000);

--- a/e2e-tests/tests/e2e_continue_pending_tx.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx.rs
@@ -30,7 +30,7 @@ pub async fn e2e_continue_pending_tx() {
 
     // Fund Alice via boarding.
     let alice_fund_amount = Amount::ONE_BTC;
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, alice_fund_amount)
         .await;
@@ -42,7 +42,7 @@ pub async fn e2e_continue_pending_tx() {
 
     // Build VTXO inputs for the offchain tx.
     let send_amount = Amount::from_sat(100_000);
-    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_address, _) = bob.get_offchain_address().await.unwrap();
 
     let (vtxo_list, script_pubkey_to_vtxo_map) = alice.list_vtxos().await.unwrap();
 
@@ -60,7 +60,7 @@ pub async fn e2e_continue_pending_tx() {
     let selected = select_vtxos(
         spendable,
         send_amount,
-        alice.server_info().unwrap().dust,
+        alice.server_info().await.unwrap().dust,
         true,
     )
     .unwrap();

--- a/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
+++ b/e2e-tests/tests/e2e_continue_pending_tx_multi_input.rs
@@ -41,7 +41,7 @@ pub async fn e2e_continue_pending_tx_multi_input() {
 
     // Step 1: Fund Alice via boarding and settle.
     let alice_fund_amount = Amount::ONE_BTC;
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, alice_fund_amount)
         .await;
@@ -53,7 +53,7 @@ pub async fn e2e_continue_pending_tx_multi_input() {
 
     // Step 2: Alice sends to Bob → Alice gets change VTXO.
     let send_to_bob = Amount::from_sat(40_000_000); // 0.4 BTC
-    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_address, _) = bob.get_offchain_address().await.unwrap();
     alice
         .send(vec![SendReceiver::bitcoin(bob_address, send_to_bob)])
         .await
@@ -67,7 +67,7 @@ pub async fn e2e_continue_pending_tx_multi_input() {
 
     // Step 3: Bob sends back to Alice → Alice now has 2 VTXOs.
     let send_back = Amount::from_sat(20_000_000); // 0.2 BTC
-    let (alice_address, _) = alice.get_offchain_address().unwrap();
+    let (alice_address, _) = alice.get_offchain_address().await.unwrap();
     bob.send(vec![SendReceiver::bitcoin(alice_address, send_back)])
         .await
         .unwrap();
@@ -97,7 +97,7 @@ pub async fn e2e_continue_pending_tx_multi_input() {
     // Step 4: Send an amount that requires BOTH VTXOs.
     // Alice has ~0.6 BTC + 0.2 BTC. Send 0.7 BTC to carol (needs both).
     let send_amount = Amount::from_sat(70_000_000); // 0.7 BTC
-    let (carol_address, _) = carol.get_offchain_address().unwrap();
+    let (carol_address, _) = carol.get_offchain_address().await.unwrap();
 
     let spendable_coins = vtxo_list
         .spendable_offchain()
@@ -113,7 +113,7 @@ pub async fn e2e_continue_pending_tx_multi_input() {
     let selected = select_vtxos(
         spendable_coins,
         send_amount,
-        alice.server_info().unwrap().dust,
+        alice.server_info().await.unwrap().dust,
         true,
     )
     .unwrap();

--- a/e2e-tests/tests/e2e_delegate.rs
+++ b/e2e-tests/tests/e2e_delegate.rs
@@ -29,7 +29,7 @@ pub async fn e2e_delegate() {
     let bob_delegate_cosigner_kp = Keypair::new(&secp, &mut rng);
     let bob_delegate_cosigner_pk = bob_delegate_cosigner_kp.public_key();
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     let alice_fund_amount = Amount::ONE_BTC;
 
     let alice_boarding_outpoint = regtest

--- a/e2e-tests/tests/e2e_finalize_pending_tx.rs
+++ b/e2e-tests/tests/e2e_finalize_pending_tx.rs
@@ -30,7 +30,7 @@ pub async fn e2e_finalize_pending_tx() {
 
     // Fund Alice via boarding.
     let alice_fund_amount = Amount::ONE_BTC;
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, alice_fund_amount)
         .await;
@@ -42,7 +42,7 @@ pub async fn e2e_finalize_pending_tx() {
 
     // Build VTXO inputs for the offchain tx.
     let send_amount = Amount::from_sat(100_000);
-    let (bob_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_address, _) = bob.get_offchain_address().await.unwrap();
 
     let (vtxo_list, script_pubkey_to_vtxo_map) = alice.list_vtxos().await.unwrap();
 
@@ -60,7 +60,7 @@ pub async fn e2e_finalize_pending_tx() {
     let selected = select_vtxos(
         spendable,
         send_amount,
-        alice.server_info().unwrap().dust,
+        alice.server_info().await.unwrap().dust,
         true,
     )
     .unwrap();

--- a/e2e-tests/tests/e2e_key_discovery.rs
+++ b/e2e-tests/tests/e2e_key_discovery.rs
@@ -44,7 +44,7 @@ pub async fn e2e_key_discovery() {
     tracing::info!(?initial_balance, "Initial balance is zero");
 
     // Get a boarding address and fund it
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     let fund_amount = Amount::ONE_BTC;
 
     tracing::info!(%boarding_address, %fund_amount, "Funding boarding output");

--- a/e2e-tests/tests/e2e_multisig_delegate.rs
+++ b/e2e-tests/tests/e2e_multisig_delegate.rs
@@ -40,7 +40,7 @@ pub async fn e2e_multisig_delegate() {
     let bob_delegate_cosigner_kp = Keypair::new(&secp, &mut rng);
     let bob_delegate_cosigner_pk = bob_delegate_cosigner_kp.public_key();
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     let alice_fund_amount = Amount::ONE_BTC;
 
     let alice_boarding_outpoint = regtest
@@ -80,10 +80,10 @@ pub async fn e2e_multisig_delegate() {
         MsigOutputTaprootOptions {
             alice_pk: alice_msig_output_pk.into(),
             bob_pk: bob_msig_output_pk.into(),
-            server_pk: alice.server_info().unwrap().signer_pk.into(),
-            unilateral_exit_delay: alice.server_info().unwrap().unilateral_exit_delay,
+            server_pk: alice.server_info().await.unwrap().signer_pk.into(),
+            unilateral_exit_delay: alice.server_info().await.unwrap().unilateral_exit_delay,
         },
-        alice.server_info().unwrap().network,
+        alice.server_info().await.unwrap().network,
     )
     .unwrap();
 
@@ -117,7 +117,7 @@ pub async fn e2e_multisig_delegate() {
         OutPoint { txid, vout: 0 },
         // TODO: This should be modelled in the output type. I think it's supposed to be the
         // highest sequence number of all leaves, but I'm not sure.
-        alice.server_info().unwrap().unilateral_exit_delay,
+        alice.server_info().await.unwrap().unilateral_exit_delay,
         None,
         TxOut {
             value: msig_output_amount,
@@ -138,8 +138,8 @@ pub async fn e2e_multisig_delegate() {
             script_pubkey: msig_output.script_pubkey(),
         })],
         bob_delegate_cosigner_pk,
-        &alice.server_info().unwrap().forfeit_address,
-        alice.server_info().unwrap().dust,
+        &alice.server_info().await.unwrap().forfeit_address,
+        alice.server_info().await.unwrap().dust,
     )
     .unwrap();
 
@@ -197,7 +197,10 @@ pub async fn e2e_multisig_delegate() {
         .await
         .unwrap();
 
-    let vtxo_list = VtxoList::new(alice.server_info().unwrap().dust, virtual_tx_outpoints);
+    let vtxo_list = VtxoList::new(
+        alice.server_info().await.unwrap().dust,
+        virtual_tx_outpoints,
+    );
 
     assert_eq!(vtxo_list.all_unspent().count(), 1);
     assert_eq!(vtxo_list.spent().count(), 1);
@@ -208,7 +211,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(settled_msig_outpoint.is_preconfirmed);
     assert!(!settled_msig_outpoint.is_swept);
     assert!(!settled_msig_outpoint.is_unrolled);
-    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
+    assert!(!settled_msig_outpoint.is_recoverable(alice.server_info().await.unwrap().dust));
     assert_eq!(settled_msig_outpoint.settled_by, Some(commitment_txid));
 
     let new_msig_outpoint = &vtxo_list.all_unspent().next().unwrap();
@@ -217,7 +220,7 @@ pub async fn e2e_multisig_delegate() {
     assert!(!new_msig_outpoint.is_preconfirmed);
     assert!(!new_msig_outpoint.is_swept);
     assert!(!new_msig_outpoint.is_unrolled);
-    assert!(!new_msig_outpoint.is_recoverable(alice.server_info().unwrap().dust));
+    assert!(!new_msig_outpoint.is_recoverable(alice.server_info().await.unwrap().dust));
     assert!(new_msig_outpoint
         .commitment_txids
         .contains(&commitment_txid));

--- a/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_boarding_output.rs
@@ -27,6 +27,7 @@ pub async fn send_onchain_boarding_output() {
     // `boarding_exit_delay`.
     match alice
         .server_info()
+        .await
         .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()
@@ -40,7 +41,7 @@ pub async fn send_onchain_boarding_output() {
         }
     };
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
 
     regtest
         .faucet_fund(&alice_boarding_address, Amount::ONE_BTC)

--- a/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
@@ -126,11 +126,9 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     let mut max_block_height_offset = 0;
     let mut max_blocktime_offset = 0;
+    let server_info = alice.server_info().await.unwrap();
 
-    match alice
-        .server_info()
-        .await
-        .unwrap()
+    match server_info
         .unilateral_exit_delay
         .to_relative_lock_time()
         .expect("unilateral VTXO exit delay should be relative")
@@ -143,10 +141,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
         }
     };
 
-    match alice
-        .server_info()
-        .await
-        .unwrap()
+    match server_info
         .boarding_exit_delay
         .to_relative_lock_time()
         .expect("boarding exit delay should be relative")

--- a/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
+++ b/e2e-tests/tests/e2e_send_onchain_vtxo_and_boarding_output.rs
@@ -34,7 +34,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     assert_eq!(offchain_balance.total(), Amount::ZERO);
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
 
     let fund_amount = Amount::ONE_BTC;
 
@@ -63,7 +63,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
     regtest.mine(1).await;
     alice_wallet.sync().await.unwrap();
 
-    let (alice_offchain_address, _) = alice.get_offchain_address().unwrap();
+    let (alice_offchain_address, _) = alice.get_offchain_address().await.unwrap();
 
     alice
         .send(vec![SendReceiver::bitcoin(
@@ -114,7 +114,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: Amount::ZERO);
 
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
     regtest
         .faucet_fund(&alice_boarding_address, Amount::ONE_BTC)
         .await;
@@ -129,6 +129,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     match alice
         .server_info()
+        .await
         .unwrap()
         .unilateral_exit_delay
         .to_relative_lock_time()
@@ -144,6 +145,7 @@ pub async fn send_onchain_vtxo_and_boarding_output() {
 
     match alice
         .server_info()
+        .await
         .unwrap()
         .boarding_exit_delay
         .to_relative_lock_time()

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -1,22 +1,28 @@
 #![allow(clippy::unwrap_used)]
 
+use ark_bdk_wallet::Wallet;
+use ark_client::Client;
 use ark_client::DeprecatedSignerStatus;
+use ark_client::InMemorySwapStorage;
+use ark_core::server;
 use bitcoin::key::Secp256k1;
 use bitcoin::Amount;
 use common::init_tracing;
 use common::set_up_client_with_seed;
+use common::set_up_client_with_seed_and_server_info_ttl;
 use common::wait_until_balance;
+use common::InMemoryDb;
 use common::Regtest;
 use rand::thread_rng;
 use rand::Rng;
 use std::sync::Arc;
+use std::time::Duration;
 
 mod common;
 
-/// Regime 1: VTXO created under current signer → rotate with future cutoff (still cooperative)
-/// → `migrate_deprecated_signer_vtxos` settles all pre-cutoff VTXOs to the new signer.
-///
-/// Verifies the cooperative rotation path for still-co-signable deprecated signer outputs.
+/// Funds a VTXO, rotates arkd to a new signer with a future cutoff, and verifies that
+/// the existing client refreshes server info through its zero TTL before migrating the
+/// VTXO to the new signer.
 #[tokio::test]
 #[ignore = "requires regtest"]
 pub async fn e2e_signer_rotation_sweep_migration() {
@@ -29,8 +35,7 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     let seed: [u8; 32] = rng.r#gen();
     let fund_amount = Amount::ONE_BTC;
 
-    let (client, _wallet) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    let (client, _wallet) = set_up_ttl_refresh_client(regtest.clone(), secp.clone(), seed).await;
 
     let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
@@ -42,58 +47,25 @@ pub async fn e2e_signer_rotation_sweep_migration() {
 
     let old_digest = client.server_info().await.unwrap().digest.clone();
 
-    // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1).
+    // Rotate with a future cutoff so the old signer is deprecated but still co-signs.
     regtest.rotate_signer("+86400");
     tracing::info!("Signer rotated with future cutoff (+86400)");
 
-    // A guarded Ark RPC with the stale digest should refresh cached server_info and return
-    // ServerInfoChanged. The failed estimate is not retried automatically. The first call after
-    // the arkd restart can still hit the old broken HTTP/2 connection, so retry until the
-    // re-dialed channel reaches arkd and gets the digest-mismatch response.
-    let mut refreshed_by_digest_mismatch = false;
-    let mut last_probe_error = None;
-    for _ in 0..30 {
-        let (estimate_address, _) = client.get_offchain_address().await.unwrap();
-        match client.estimate_batch_fees(&mut rng, estimate_address).await {
-            Ok(_) => panic!("digest refresh probe unexpectedly succeeded"),
-            Err(err) if err.is_server_info_changed() => {
-                refreshed_by_digest_mismatch = true;
-                break;
-            }
-            Err(err) => last_probe_error = Some(format!("{err:?}")),
-        }
-
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    }
-    assert!(
-        refreshed_by_digest_mismatch,
-        "expected digest mismatch / ServerInfoChanged, last probe error: {:?}",
-        last_probe_error
-    );
-
-    let client2 = client;
-    let refreshed_info = client2.server_info().await.unwrap();
+    let refreshed_info = wait_for_deprecated_signer(&client).await;
     assert_ne!(
         refreshed_info.digest, old_digest,
-        "digest refresh should update cached server_info"
-    );
-    assert!(
-        !refreshed_info.deprecated_signers.is_empty(),
-        "server_info should list the old signer as deprecated after rotation"
+        "TTL refresh should update cached server_info"
     );
 
-    let balance_before = client2.offchain_balance().await.unwrap();
-    tracing::info!(
-        ?balance_before,
-        "Balance seen by new client before migration"
-    );
+    let balance_before = client.offchain_balance().await.unwrap();
+    tracing::info!(?balance_before, "Balance before migration");
     assert_eq!(
         balance_before.total(),
         fund_amount,
         "Total balance must be preserved after rotation"
     );
 
-    let report = client2
+    let report = client
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();
@@ -107,11 +79,11 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     );
 
     // Wait for the new batch to confirm.
-    wait_until_balance!(&client2, confirmed: fund_amount);
+    wait_until_balance!(&client, confirmed: fund_amount);
 
     // If migration actually moved VTXOs to the new signer, there is nothing left
     // to migrate — a second call must rotate nothing.
-    let second = client2
+    let second = client
         .migrate_deprecated_signer_vtxos(&mut rng)
         .await
         .unwrap();
@@ -122,10 +94,67 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     tracing::info!("Sweep-migration test passed: all VTXOs settled under new signer");
 }
 
-/// Regime 2: VTXO created under current signer → rotate with past cutoff (operator will NOT
-/// co-sign the old key) → VTXO is stuck in `pending_recovery`, NOT in confirmed/pre_confirmed.
-///
-/// Verifies the held-back balance state for outputs whose deprecated signer no longer co-signs.
+/// Verifies that the digest-mismatch fast path still refreshes cached server info when a
+/// guarded Ark RPC observes a signer change before the configured server-info TTL expires.
+#[tokio::test]
+#[ignore = "requires regtest"]
+pub async fn e2e_signer_rotation_digest_mismatch_refreshes_server_info() {
+    init_tracing();
+
+    let regtest = Arc::new(Regtest::new());
+    let secp = Secp256k1::new();
+    let mut rng = thread_rng();
+
+    let seed: [u8; 32] = rng.r#gen();
+    let fund_amount = Amount::ONE_BTC;
+
+    let (client, _wallet) =
+        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+
+    let boarding_address = client.get_boarding_address().await.unwrap();
+    regtest.faucet_fund(&boarding_address, fund_amount).await;
+    client.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&client, confirmed: fund_amount);
+
+    let old_digest = client.server_info().await.unwrap().digest.clone();
+
+    regtest.rotate_signer("+86400");
+    tracing::info!("Signer rotated with future cutoff (+86400)");
+
+    let mut refreshed_by_digest_mismatch = false;
+    let mut last_probe_error = None;
+    for _ in 0..30 {
+        let (estimate_address, _) = client.get_offchain_address().await.unwrap();
+        match client.estimate_batch_fees(&mut rng, estimate_address).await {
+            Ok(_) => panic!("digest refresh probe unexpectedly succeeded"),
+            Err(err) if err.is_server_info_changed() => {
+                refreshed_by_digest_mismatch = true;
+                break;
+            }
+            Err(err) => last_probe_error = Some(format!("{err:?}")),
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(
+        refreshed_by_digest_mismatch,
+        "expected digest mismatch / ServerInfoChanged, last probe error: {:?}",
+        last_probe_error
+    );
+
+    let refreshed_info = client.server_info().await.unwrap();
+    assert_ne!(
+        refreshed_info.digest, old_digest,
+        "digest refresh should update cached server_info"
+    );
+    assert!(
+        !refreshed_info.deprecated_signers.is_empty(),
+        "server_info should list the old signer as deprecated after digest refresh"
+    );
+}
+
+/// Funds a VTXO, rotates arkd to a new signer with a past cutoff, and verifies that
+/// funds under the old signer are reported as pending recovery instead of spendable.
 #[tokio::test]
 #[ignore = "requires regtest"]
 pub async fn e2e_signer_rotation_past_cutoff_held_back() {
@@ -138,8 +167,7 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
     let seed: [u8; 32] = rng.r#gen();
     let fund_amount = Amount::ONE_BTC;
 
-    let (client, _wallet) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    let (client, _wallet) = set_up_ttl_refresh_client(regtest.clone(), secp.clone(), seed).await;
 
     let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
@@ -149,30 +177,16 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
     wait_until_balance!(&client, confirmed: fund_amount);
     tracing::info!("VTXO confirmed under current signer");
 
-    drop(client);
-
     // Rotate: past cutoff (-60 seconds) means the operator will NOT co-sign the old key.
     regtest.rotate_signer("-60");
     tracing::info!("Signer rotated with past cutoff (-60)");
 
-    // Reconnect to pick up updated server info.
-    let (client2, _wallet2) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
-
-    assert!(
-        !client2
-            .server_info()
-            .await
-            .unwrap()
-            .deprecated_signers
-            .is_empty(),
-        "server_info should list the old signer as deprecated after rotation"
-    );
+    wait_for_deprecated_signer(&client).await;
 
     // The VTXO is under a past-cutoff deprecated signer: not spendable offchain,
     // not yet expired → must appear in pending_recovery, not in confirmed.
     wait_until_balance!(
-        &client2,
+        &client,
         confirmed: Amount::ZERO,
         pre_confirmed: Amount::ZERO,
         pending_recovery: fund_amount,
@@ -181,13 +195,8 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
     tracing::info!("Past-cutoff held-back test passed: VTXO is in pending_recovery, not spendable");
 }
 
-/// Boarding-only migration: fund a boarding address but DO NOT settle it to a VTXO, then rotate
-/// with a future cutoff. After reconnecting with the same seed, the deprecated BOARDING input must
-/// migrate cooperatively through the report's boarding leg — WITHOUT any explicit
-/// `get_boarding_addresses()` call, because connect-time boarding persistence already watches the
-/// deprecated signer's boarding outputs.
-///
-/// Exercises the boarding-only migration leg, isolated from the VTXO path.
+/// Funds a boarding address without settling it, rotates arkd with a future cutoff, and
+/// verifies that migration spends the deprecated boarding input through the boarding leg.
 #[tokio::test]
 #[ignore = "requires regtest"]
 pub async fn e2e_signer_rotation_boarding_only_migration() {
@@ -200,46 +209,19 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     let seed: [u8; 32] = rng.r#gen();
     let fund_amount = Amount::ONE_BTC;
 
-    let (client, _wallet) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    let (client, _wallet) = set_up_ttl_refresh_client(regtest.clone(), secp.clone(), seed).await;
 
     // Fund a boarding output under the current signer but deliberately do NOT settle it: this
     // isolates the boarding-input migration path from the VTXO one.
     let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
 
-    // Rotate with a future cutoff: the old signer is deprecated but still co-signs (regime 1), so
-    // the boarding input is cooperatively migratable. We keep the SAME client and just refresh its
-    // cached server info to pick up the rotation — boarding outputs are owned by the wallet
-    // keypair, which this seed-only test harness does not re-derive across a reconnect (only the
-    // client's offchain keys are seed-derived, so VTXOs survive a reconnect but boarding outputs
-    // do not). Connect-time deprecated-boarding persistence is exercised on every connect; this
-    // test isolates the boarding migration *leg* itself.
+    // Rotate with a future cutoff so the boarding input can migrate cooperatively. The zero
+    // server-info TTL lets normal public APIs pick up the rotation without an explicit force
+    // refresh.
     regtest.rotate_signer("+86400");
 
-    // `rotate_signer` already blocks until arkd has restarted and re-advertises the deprecated
-    // signer, but the restart broke our existing gRPC connection, so the first refresh may hit a
-    // stale channel and need a re-dial. Retry until the refreshed snapshot shows the deprecated
-    // signer.
-    let mut rotated = false;
-    for _ in 0..30 {
-        if client.refresh_server_info().await.is_ok()
-            && !client
-                .server_info()
-                .await
-                .unwrap()
-                .deprecated_signers
-                .is_empty()
-        {
-            rotated = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    }
-    assert!(
-        rotated,
-        "server_info should list the old signer as deprecated after rotation"
-    );
+    wait_for_deprecated_signer(&client).await;
     tracing::info!(
         "Signer rotated with future cutoff (+86400); boarding UTXO now under deprecated signer"
     );
@@ -281,12 +263,8 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     tracing::info!("Boarding-only migration test passed");
 }
 
-/// Classification: a future cutoff (`+86400`) makes the deprecated signer `Migratable` with a
-/// positive `seconds_until_cutoff`, exposed via the read-only `deprecated_signer_status()`.
-///
-/// `rotate_signer("+86400")` resolves the cutoff to `now + 86400` (an absolute future Unix
-/// timestamp), so we assert `cutoff_date` is in the future and `seconds_until_cutoff > 0` rather
-/// than an exact offset.
+/// Funds a VTXO, rotates arkd with a future cutoff, and verifies that
+/// `deprecated_signer_status()` reports the old signer as migratable.
 #[tokio::test]
 #[ignore = "requires regtest"]
 pub async fn e2e_signer_rotation_status_migratable() {
@@ -299,15 +277,12 @@ pub async fn e2e_signer_rotation_status_migratable() {
     let seed: [u8; 32] = rng.r#gen();
     let fund_amount = Amount::ONE_BTC;
 
-    let (client, _wallet) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    let (client, _wallet) = set_up_ttl_refresh_client(regtest.clone(), secp.clone(), seed).await;
 
     let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
     client.settle(&mut rng).await.unwrap();
     wait_until_balance!(&client, confirmed: fund_amount);
-
-    drop(client);
 
     // Capture a lower bound on "now" before rotating so we can assert the cutoff is in the future.
     let before_rotate = std::time::SystemTime::now()
@@ -318,10 +293,9 @@ pub async fn e2e_signer_rotation_status_migratable() {
     regtest.rotate_signer("+86400");
     tracing::info!("Signer rotated with future cutoff (+86400)");
 
-    let (client2, _wallet2) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    wait_for_deprecated_signer(&client).await;
 
-    let status = client2.deprecated_signer_status().await.unwrap();
+    let status = client.deprecated_signer_status().await.unwrap();
     assert_eq!(
         status.len(),
         1,
@@ -331,7 +305,7 @@ pub async fn e2e_signer_rotation_status_migratable() {
     assert_eq!(
         row.status,
         DeprecatedSignerStatus::Migratable,
-        "a future cutoff classifies as Migratable"
+        "a future cutoff should report Migratable"
     );
     assert!(
         row.cutoff_date > before_rotate,
@@ -347,13 +321,11 @@ pub async fn e2e_signer_rotation_status_migratable() {
         row.vtxo_count >= 1,
         "the funded VTXO should be counted under the deprecated signer"
     );
-    tracing::info!(?row, "Migratable classification test passed");
+    tracing::info!(?row, "Migratable status test passed");
 }
 
-/// Classification: a zero cutoff (`"0"`) makes the deprecated signer `DueNow` with
-/// `cutoff_date == 0` and no `seconds_until_cutoff`, exposed via `deprecated_signer_status()`.
-///
-/// `rotate_signer("0")` advertises cutoff `0` ("rotate immediately", still co-signable).
+/// Funds a VTXO, rotates arkd with cutoff `0`, and verifies that
+/// `deprecated_signer_status()` reports the old signer as due now.
 #[tokio::test]
 #[ignore = "requires regtest"]
 pub async fn e2e_signer_rotation_status_due_now() {
@@ -366,25 +338,20 @@ pub async fn e2e_signer_rotation_status_due_now() {
     let seed: [u8; 32] = rng.r#gen();
     let fund_amount = Amount::ONE_BTC;
 
-    let (client, _wallet) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    let (client, _wallet) = set_up_ttl_refresh_client(regtest.clone(), secp.clone(), seed).await;
 
     let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
     client.settle(&mut rng).await.unwrap();
     wait_until_balance!(&client, confirmed: fund_amount);
 
-    drop(client);
-
-    // Cutoff "0" => "rotate immediately" (DUE_NOW): deprecated, no cutoff advertised, still
-    // co-signable.
+    // Cutoff "0" means rotate immediately: deprecated, no cutoff advertised, still co-signable.
     regtest.rotate_signer("0");
     tracing::info!("Signer rotated with zero cutoff (DueNow)");
 
-    let (client2, _wallet2) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    wait_for_deprecated_signer(&client).await;
 
-    let status = client2.deprecated_signer_status().await.unwrap();
+    let status = client.deprecated_signer_status().await.unwrap();
     assert_eq!(
         status.len(),
         1,
@@ -394,7 +361,7 @@ pub async fn e2e_signer_rotation_status_due_now() {
     assert_eq!(
         row.status,
         DeprecatedSignerStatus::DueNow,
-        "a zero cutoff classifies as DueNow"
+        "a zero cutoff should report DueNow"
     );
     assert_eq!(
         row.cutoff_date, 0,
@@ -404,5 +371,40 @@ pub async fn e2e_signer_rotation_status_due_now() {
         row.seconds_until_cutoff, None,
         "DueNow signer has no seconds_until_cutoff"
     );
-    tracing::info!(?row, "DueNow classification test passed");
+    tracing::info!(?row, "DueNow status test passed");
+}
+
+type TestClient = Client<Regtest, Wallet<InMemoryDb>, InMemorySwapStorage>;
+
+async fn wait_for_deprecated_signer(client: &TestClient) -> server::Info {
+    let mut last_error = None;
+    for _ in 0..30 {
+        match client.server_info().await {
+            Ok(info) if !info.deprecated_signers.is_empty() => return info,
+            Ok(_) => {}
+            Err(err) => last_error = Some(format!("{err:?}")),
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    panic!(
+        "server_info should list the old signer as deprecated after rotation, last error: {:?}",
+        last_error
+    );
+}
+
+async fn set_up_ttl_refresh_client(
+    regtest: Arc<Regtest>,
+    secp: Secp256k1<bitcoin::secp256k1::All>,
+    seed: [u8; 32],
+) -> (TestClient, Arc<Wallet<InMemoryDb>>) {
+    set_up_client_with_seed_and_server_info_ttl(
+        "alice".to_string(),
+        regtest,
+        secp,
+        seed,
+        Duration::ZERO,
+    )
+    .await
 }

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -40,18 +40,45 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     wait_until_balance!(&client, confirmed: fund_amount);
     tracing::info!("VTXO confirmed under current signer");
 
-    drop(client);
+    let old_digest = client.server_info().unwrap().digest.clone();
 
     // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1).
     regtest.rotate_signer("+86400");
     tracing::info!("Signer rotated with future cutoff (+86400)");
 
-    // Reconnect to pick up updated server info (deprecated_signers now populated).
-    let (client2, _wallet2) =
-        set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
+    // A guarded Ark RPC with the stale digest should refresh cached server_info and return
+    // ServerInfoChanged. The failed estimate is not retried automatically. The first call after
+    // the arkd restart can still hit the old broken HTTP/2 connection, so retry until the
+    // re-dialed channel reaches arkd and gets the digest-mismatch response.
+    let mut refreshed_by_digest_mismatch = false;
+    let mut last_probe_error = None;
+    for _ in 0..30 {
+        let (estimate_address, _) = client.get_offchain_address().unwrap();
+        match client.estimate_batch_fees(&mut rng, estimate_address).await {
+            Ok(_) => panic!("digest refresh probe unexpectedly succeeded"),
+            Err(err) if err.is_server_info_changed() => {
+                refreshed_by_digest_mismatch = true;
+                break;
+            }
+            Err(err) => last_probe_error = Some(format!("{err:?}")),
+        }
 
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
     assert!(
-        !client2.server_info().unwrap().deprecated_signers.is_empty(),
+        refreshed_by_digest_mismatch,
+        "expected digest mismatch / ServerInfoChanged, last probe error: {:?}",
+        last_probe_error
+    );
+
+    let client2 = client;
+    let refreshed_info = client2.server_info().unwrap();
+    assert_ne!(
+        refreshed_info.digest, old_digest,
+        "digest refresh should update cached server_info"
+    );
+    assert!(
+        !refreshed_info.deprecated_signers.is_empty(),
         "server_info should list the old signer as deprecated after rotation"
     );
 

--- a/e2e-tests/tests/e2e_signer_rotation.rs
+++ b/e2e-tests/tests/e2e_signer_rotation.rs
@@ -32,7 +32,7 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     let (client, _wallet) =
         set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
 
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
 
     client.settle(&mut rng).await.unwrap();
@@ -40,7 +40,7 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     wait_until_balance!(&client, confirmed: fund_amount);
     tracing::info!("VTXO confirmed under current signer");
 
-    let old_digest = client.server_info().unwrap().digest.clone();
+    let old_digest = client.server_info().await.unwrap().digest.clone();
 
     // Rotate: future cutoff means the old signer is deprecated but still co-signs (regime 1).
     regtest.rotate_signer("+86400");
@@ -53,7 +53,7 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     let mut refreshed_by_digest_mismatch = false;
     let mut last_probe_error = None;
     for _ in 0..30 {
-        let (estimate_address, _) = client.get_offchain_address().unwrap();
+        let (estimate_address, _) = client.get_offchain_address().await.unwrap();
         match client.estimate_batch_fees(&mut rng, estimate_address).await {
             Ok(_) => panic!("digest refresh probe unexpectedly succeeded"),
             Err(err) if err.is_server_info_changed() => {
@@ -72,7 +72,7 @@ pub async fn e2e_signer_rotation_sweep_migration() {
     );
 
     let client2 = client;
-    let refreshed_info = client2.server_info().unwrap();
+    let refreshed_info = client2.server_info().await.unwrap();
     assert_ne!(
         refreshed_info.digest, old_digest,
         "digest refresh should update cached server_info"
@@ -141,7 +141,7 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
     let (client, _wallet) =
         set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
 
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
 
     client.settle(&mut rng).await.unwrap();
@@ -160,7 +160,12 @@ pub async fn e2e_signer_rotation_past_cutoff_held_back() {
         set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
 
     assert!(
-        !client2.server_info().unwrap().deprecated_signers.is_empty(),
+        !client2
+            .server_info()
+            .await
+            .unwrap()
+            .deprecated_signers
+            .is_empty(),
         "server_info should list the old signer as deprecated after rotation"
     );
 
@@ -200,7 +205,7 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
 
     // Fund a boarding output under the current signer but deliberately do NOT settle it: this
     // isolates the boarding-input migration path from the VTXO one.
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
 
     // Rotate with a future cutoff: the old signer is deprecated but still co-signs (regime 1), so
@@ -219,7 +224,12 @@ pub async fn e2e_signer_rotation_boarding_only_migration() {
     let mut rotated = false;
     for _ in 0..30 {
         if client.refresh_server_info().await.is_ok()
-            && !client.server_info().unwrap().deprecated_signers.is_empty()
+            && !client
+                .server_info()
+                .await
+                .unwrap()
+                .deprecated_signers
+                .is_empty()
         {
             rotated = true;
             break;
@@ -292,7 +302,7 @@ pub async fn e2e_signer_rotation_status_migratable() {
     let (client, _wallet) =
         set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
 
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
     client.settle(&mut rng).await.unwrap();
     wait_until_balance!(&client, confirmed: fund_amount);
@@ -359,7 +369,7 @@ pub async fn e2e_signer_rotation_status_due_now() {
     let (client, _wallet) =
         set_up_client_with_seed("alice".to_string(), regtest.clone(), secp.clone(), seed).await;
 
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     regtest.faucet_fund(&boarding_address, fund_amount).await;
     client.settle(&mut rng).await.unwrap();
     wait_until_balance!(&client, confirmed: fund_amount);

--- a/e2e-tests/tests/e2e_sub_dust.rs
+++ b/e2e-tests/tests/e2e_sub_dust.rs
@@ -28,7 +28,10 @@ pub async fn send_subdust_amount() {
     let alice_fund_amount = Amount::ONE_BTC;
 
     regtest
-        .faucet_fund(&alice.get_boarding_address().unwrap(), alice_fund_amount)
+        .faucet_fund(
+            &alice.get_boarding_address().await.unwrap(),
+            alice_fund_amount,
+        )
         .await;
 
     alice.settle(&mut rng).await.unwrap();
@@ -39,7 +42,7 @@ pub async fn send_subdust_amount() {
 
     // Send Bob a sub-dust amount.
     let sub_dust_amount = Amount::ONE_SAT;
-    let (bob_offchain_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_offchain_address, _) = bob.get_offchain_address().await.unwrap();
 
     alice
         .send(vec![SendReceiver::bitcoin(
@@ -52,7 +55,7 @@ pub async fn send_subdust_amount() {
     wait_until_balance!(&alice, confirmed: Amount::ZERO, pre_confirmed: alice_fund_amount - sub_dust_amount);
     wait_until_balance!(&bob, confirmed: Amount::ZERO, pre_confirmed: Amount::ZERO, recoverable: sub_dust_amount);
 
-    let (alice_offchain_address, _) = alice.get_offchain_address().unwrap();
+    let (alice_offchain_address, _) = alice.get_offchain_address().await.unwrap();
 
     bob.send(vec![SendReceiver::bitcoin(
         alice_offchain_address,

--- a/e2e-tests/tests/e2e_two_party.rs
+++ b/e2e-tests/tests/e2e_two_party.rs
@@ -27,7 +27,7 @@ pub async fn e2e() {
 
     let alice_offchain_balance = alice.offchain_balance().await.unwrap();
     let bob_offchain_balance = bob.offchain_balance().await.unwrap();
-    let alice_boarding_address = alice.get_boarding_address().unwrap();
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
 
     tracing::info!(
         ?alice_boarding_address,
@@ -75,7 +75,7 @@ pub async fn e2e() {
     assert_eq!(bob_offchain_balance.total(), Amount::ZERO);
 
     let send_to_bob_vtxo_amount = Amount::from_sat(100_000);
-    let (bob_offchain_address, _) = bob.get_offchain_address().unwrap();
+    let (bob_offchain_address, _) = bob.get_offchain_address().await.unwrap();
 
     tracing::info!(
         %send_to_bob_vtxo_amount,

--- a/e2e-tests/tests/fulmine_delegator_smoke.rs
+++ b/e2e-tests/tests/fulmine_delegator_smoke.rs
@@ -38,7 +38,7 @@ async fn fulmine_delegator_smoke() {
     let client = Arc::new(client);
 
     // Sanity: configured client returns delegated (3-leaf) addresses.
-    let (_, next_vtxo) = client.get_offchain_address().unwrap();
+    let (_, next_vtxo) = client.get_offchain_address().await.unwrap();
     assert_eq!(next_vtxo.delegator_pk(), Some(delegator_pk));
 
     // Start watcher and keep handle alive for the test duration.
@@ -47,7 +47,7 @@ async fn fulmine_delegator_smoke() {
         ark_client::vtxo_watcher::VtxoWatcherConfig::default(),
     );
 
-    let boarding_address = client.get_boarding_address().unwrap();
+    let boarding_address = client.get_boarding_address().await.unwrap();
     let fund_amount = Amount::from_sat(100_000);
     let _outpoint = regtest.faucet_fund(&boarding_address, fund_amount).await;
 


### PR DESCRIPTION
It turns out that solely relying on running into digest mismatch errors to refresh the server info is insufficient, because most calls do not check the digest header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TTL-based caching for server information, with serialized refresh to ensure consistent network data usage.
  * Improved offline client configuration for deterministic key setup and more reliable startup/address discovery.
* **Bug Fixes**
  * Updated on-chain/off-chain flows to await fresh server info, including fee estimation, swaps, sends, settlement, dust handling, and recovery/migration paths.
* **Tests**
  * Updated e2e tests to use the new async address/server-info behavior and added coverage for server-info refresh behavior.
* **Chores**
  * Updated regtest Docker image tags used for local testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->