### PR TITLE
chore: prepare 0.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ Use the convenience crate if you want a single SDK dependency:
 
 ```toml
 [dependencies]
-ark-rs = "0.9.3"
+ark-rs = "0.10.0"
 ```
 
 Or depend on the crates you need directly:
 
 ```toml
 [dependencies]
-ark-core = "0.9.3"
-ark-client = "0.9.3"
-ark-bdk-wallet = "0.9.3"
+ark-core = "0.10.0"
+ark-client = "0.10.0"
+ark-bdk-wallet = "0.10.0"
 ```
 
 Optional `ark-rs` features:

--- a/ark-bdk-wallet/Cargo.toml
+++ b/ark-bdk-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-bdk-wallet"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -14,8 +14,8 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
-ark-client = { path = "../ark-client", version = "0.9.3", default-features = false }
-ark-core = { path = "../ark-core", version = "0.9.3" }
+ark-client = { path = "../ark-client", version = "0.10.0", default-features = false }
+ark-core = { path = "../ark-core", version = "0.10.0" }
 async-stream = "0.3"
 bdk_wallet = "1.0.0"
 bitcoin = { version = "0.32.7", features = ["rand"] }

--- a/ark-bdk-wallet/README.md
+++ b/ark-bdk-wallet/README.md
@@ -8,7 +8,7 @@ This crate implements `ark-client` on-chain wallet traits using [`bdk_wallet`](h
 
 ```toml
 [dependencies]
-ark-bdk-wallet = "0.9.3"
+ark-bdk-wallet = "0.10.0"
 ```
 
 ## Documentation

--- a/ark-client-sample/Cargo.toml
+++ b/ark-client-sample/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-client-sample"
-version = "0.9.3"
+version = "0.10.0"
 edition = { workspace = true }
 publish = false
 repository = { workspace = true }

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-client"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -13,9 +13,9 @@ description = "Main client library for interacting with Ark servers"
 workspace = true
 
 [dependencies]
-ark-core = { path = "../ark-core", version = "0.9.3" }
-ark-delegator = { path = "../ark-delegator", version = "0.9.3" }
-ark-fees = { path = "../ark-fees", version = "0.9.3" }
+ark-core = { path = "../ark-core", version = "0.10.0" }
+ark-delegator = { path = "../ark-delegator", version = "0.10.0" }
+ark-fees = { path = "../ark-fees", version = "0.10.0" }
 async-stream = "0.3"
 async-trait = "0.1"
 base64 = "0.22.1"
@@ -38,7 +38,7 @@ tokio = { version = "1.41.0", features = ["sync", "rt-multi-thread"] }
 tracing = "0.1.37"
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
-ark-grpc = { path = "../ark-grpc", version = "0.9.3", default-features = false }
+ark-grpc = { path = "../ark-grpc", version = "0.10.0", default-features = false }
 backon = { version = "1", features = ["tokio-sleep"] }
 tonic = "0.14"
 
@@ -59,7 +59,7 @@ wasm-bindgen-futures = { version = "0.4" }
 tonic-build = { version = "0.14" }
 
 [dev-dependencies]
-ark-grpc = { path = "../ark-grpc", version = "0.9.3", default-features = false, features = ["test-utils"] }
+ark-grpc = { path = "../ark-grpc", version = "0.10.0", default-features = false, features = ["test-utils"] }
 rustls = { version = "0.23", features = ["ring"] }
 tempfile = "3.8"
 tokio = { version = "1.41.0", features = ["macros", "net", "rt-multi-thread", "sync"] }

--- a/ark-client/README.md
+++ b/ark-client/README.md
@@ -8,13 +8,13 @@ High-level client library for interacting with Arkade servers.
 
 ```toml
 [dependencies]
-ark-client = "0.9.3"
+ark-client = "0.10.0"
 ```
 
 Enable optional SQLite storage support with:
 
 ```toml
-ark-client = { version = "0.9.3", features = ["sqlite"] }
+ark-client = { version = "0.10.0", features = ["sqlite"] }
 ```
 
 ## Documentation

--- a/ark-core/Cargo.toml
+++ b/ark-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-core"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }

--- a/ark-core/README.md
+++ b/ark-core/README.md
@@ -8,7 +8,7 @@ This crate contains the shared data structures and protocol primitives used by t
 
 ```toml
 [dependencies]
-ark-core = "0.9.3"
+ark-core = "0.10.0"
 ```
 
 ## Documentation

--- a/ark-delegator/Cargo.toml
+++ b/ark-delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-delegator"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -13,7 +13,7 @@ description = "REST client for Ark delegator services"
 workspace = true
 
 [dependencies]
-ark-core = { path = "../ark-core", version = "0.9.3" }
+ark-core = { path = "../ark-core", version = "0.10.0" }
 bitcoin = { version = "0.32.7", features = ["base64"] }
 reqwest = { version = "^0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/ark-delegator/README.md
+++ b/ark-delegator/README.md
@@ -8,7 +8,7 @@ This crate provides typed request/response helpers for interacting with Arkade d
 
 ```toml
 [dependencies]
-ark-delegator = "0.9.3"
+ark-delegator = "0.10.0"
 ```
 
 ## Documentation

--- a/ark-fees/Cargo.toml
+++ b/ark-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-fees"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }

--- a/ark-fees/README.md
+++ b/ark-fees/README.md
@@ -6,7 +6,7 @@ Fee estimation library using CEL (Common Expression Language) for calculating Ar
 
 ```toml
 [dependencies]
-ark-fees = "0.9.3"
+ark-fees = "0.10.0"
 ```
 
 > **Note:** This is a Rust port of the Go implementation at

--- a/ark-grpc/Cargo.toml
+++ b/ark-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-grpc"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -13,7 +13,7 @@ description = "gRPC client for Ark server communication"
 workspace = true
 
 [dependencies]
-ark-core = { path = "../ark-core", version = "0.9.3" }
+ark-core = { path = "../ark-core", version = "0.10.0" }
 async-stream = { version = "0.3", default-features = false }
 base64 = { version = "0.22", default-features = false }
 bitcoin = { version = "0.32.7", default-features = false }

--- a/ark-grpc/README.md
+++ b/ark-grpc/README.md
@@ -8,7 +8,7 @@ This crate contains the generated Arkade gRPC types plus a Rust client wrapper u
 
 ```toml
 [dependencies]
-ark-grpc = "0.9.3"
+ark-grpc = "0.10.0"
 ```
 
 TLS root options are available through the `tls-native-roots` and `tls-webpki-roots` features.

--- a/ark-introspector-client/Cargo.toml
+++ b/ark-introspector-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-introspector-client"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }

--- a/ark-introspector-client/README.md
+++ b/ark-introspector-client/README.md
@@ -8,7 +8,7 @@ This crate provides typed helpers for querying Arkade introspector APIs used in 
 
 ```toml
 [dependencies]
-ark-introspector-client = "0.9.3"
+ark-introspector-client = "0.10.0"
 ```
 
 ## Documentation

--- a/ark-rest/Cargo.toml
+++ b/ark-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-rest"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -13,7 +13,7 @@ description = "REST client for Ark server communication"
 workspace = true
 
 [dependencies]
-ark-core = { path = "../ark-core", version = "0.9.3" }
+ark-core = { path = "../ark-core", version = "0.10.0" }
 base64 = "0.22.1"
 bitcoin = { version = "0.32.7", default-features = false }
 futures = { version = "0.3" }

--- a/ark-rest/README.md
+++ b/ark-rest/README.md
@@ -8,7 +8,7 @@ This crate contains generated REST API bindings plus a Rust client wrapper for A
 
 ```toml
 [dependencies]
-ark-rest = "0.9.3"
+ark-rest = "0.10.0"
 ```
 
 ## Notes

--- a/ark-rs/Cargo.toml
+++ b/ark-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-rs"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }
@@ -13,9 +13,9 @@ description = "Collection of Rust crates designed to simplify building Bitcoin w
 workspace = true
 
 [dependencies]
-ark-client = { path = "../ark-client", version = "0.9.3", optional = true, default-features = false }
-ark-core = { path = "../ark-core", version = "0.9.3" }
-ark-grpc = { path = "../ark-grpc", version = "0.9.3", optional = true, default-features = false }
+ark-client = { path = "../ark-client", version = "0.10.0", optional = true, default-features = false }
+ark-core = { path = "../ark-core", version = "0.10.0" }
+ark-grpc = { path = "../ark-grpc", version = "0.10.0", optional = true, default-features = false }
 
 [features]
 default = ["tls-native-roots"]

--- a/ark-rs/README.md
+++ b/ark-rs/README.md
@@ -8,7 +8,7 @@ Convenience crate for the Arkade Rust SDK.
 
 ```toml
 [dependencies]
-ark-rs = "0.9.3"
+ark-rs = "0.10.0"
 ```
 
 By default this includes `ark-core` and enables native TLS roots for optional transport/client crates.

--- a/ark-script/Cargo.toml
+++ b/ark-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-script"
-version = "0.9.3"
+version = "0.10.0"
 categories = { workspace = true }
 edition = { workspace = true }
 keywords = { workspace = true }

--- a/ark-script/README.md
+++ b/ark-script/README.md
@@ -8,7 +8,7 @@ This crate contains script-building utilities for Arkade-specific opcodes, key t
 
 ```toml
 [dependencies]
-ark-script = "0.9.3"
+ark-script = "0.10.0"
 ```
 
 ## Documentation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project and crate versions from `0.9.3` to `0.10.0` across the workspace.
  * Updated related dependency versions so the packages stay aligned.
* **Documentation**
  * Refreshed installation examples in multiple READMEs to show `0.10.0` instead of `0.9.3`.
  * Kept the example dependency snippets in sync with the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->