### PR TITLE
Add Bip86 wallet descriptor

### DIFF
--- a/ark-bdk-wallet/src/lib.rs
+++ b/ark-bdk-wallet/src/lib.rs
@@ -47,8 +47,8 @@ impl Wallet {
     /// derived from an existing Xpriv. Use this when you already have an Xpriv (e.g. from a
     /// BIP39 mnemonic).
     pub fn new_from_xpriv(xprv: Xpriv, network: Network, esplora_url: &str) -> Result<Self> {
-        let external = bdk_wallet::template::Bip84(xprv, KeychainKind::External);
-        let change = bdk_wallet::template::Bip84(xprv, KeychainKind::Internal);
+        let external = bdk_wallet::template::Bip86(xprv, KeychainKind::External);
+        let change = bdk_wallet::template::Bip86(xprv, KeychainKind::Internal);
         let wallet = BdkWallet::create(external, change)
             .network(network)
             .create_wallet_no_persist()?;


### PR DESCRIPTION
Closes #223. Switches the BDK on-chain wallet descriptor from Segwit to Taproot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallets created from an extended private key now use Taproot-style address derivation for both external and internal addresses.
  * This changes the address format and key derivation scheme produced by new wallets, while keeping the public interface unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->