### PR TITLE
feat: add ark-frost-sample showcasing FROST external signer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "ark-introspector-client",
   "e2e-tests",
   "ark-client-sample",
+  "ark-frost-sample",
   "ark-rs",
 ]
 

--- a/ark-frost-sample/.gitignore
+++ b/ark-frost-sample/.gitignore
@@ -1,0 +1,3 @@
+*/frost_key_package.hex
+*/frost_pubkey_package.hex
+*/swap_storage.sqlite*

--- a/ark-frost-sample/Cargo.toml
+++ b/ark-frost-sample/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ark-frost-sample"
+version = "0.10.1"
+edition = { workspace = true }
+publish = false
+repository = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+ark-bdk-wallet = { path = "../ark-bdk-wallet" }
+ark-client = { path = "../ark-client", features = ["default", "sqlite"] }
+ark-core = { path = "../ark-core" }
+base64 = "0.22"
+bitcoin = { version = "0.32.7" }
+clap = { version = "4", features = ["derive"] }
+esplora-client = { version = "0.10", features = ["async-https"] }
+frost-secp256k1-tr = "2.2"
+rand = "0.8"
+rustls = { version = "0.23", features = ["ring"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+toml = "0.7"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter"] }

--- a/ark-frost-sample/README.md
+++ b/ark-frost-sample/README.md
@@ -1,0 +1,87 @@
+# ark-frost-sample
+
+An Ark Lightning client whose wallet key is a **FROST 2-of-3 threshold multisig** ([RFC 9591](https://www.rfc-editor.org/rfc/rfc9591), via [`frost-secp256k1-tr`](https://crates.io/crates/frost-secp256k1-tr)).
+
+Three actors — **alice**, **bob** and **clair** — each hold a share of a single group key created with distributed key generation: no party ever knows the full secret key, at any point. The Arkade address is derived from the x-only group public key, so to the Ark server (and on chain) the wallet is indistinguishable from a single-key wallet.
+
+Every signature needs 2 of the 3 actors. Coordination happens by **copy-pasting base64 blobs between terminals**: the coordinator prints a signing request, one other actor answers it with `sign`, and the coordinator aggregates the shares into a plain BIP340 signature.
+
+The sample plugs into `ark-client` through the `Signer` trait, which routes all Schnorr script-path signing through the FROST ceremony instead of a local keypair.
+
+## Supported flows
+
+- **Receive via Lightning** (`invoice`): Boltz reverse submarine swap; claiming the VHTLC requires one signing ceremony.
+- **Send via Lightning** (`pay`): Boltz submarine swap; funding the VHTLC requires signing ceremonies (Ark tx + checkpoint tx).
+- `balance`, `offchain-address`, `group-info`.
+
+The library supports all flows through the `Signer` trait, including settlement, boarding and chain swaps. Note that settlement runs against server-timed batch rounds, so the copy-paste signing ceremony of this sample may be too slow for it in practice; the Lightning flows above are the ones exercised by this walkthrough.
+
+## Walkthrough (regtest)
+
+Start the regtest stack (Ark server on `:7070`, esplora on `:3000`, Boltz on `:9001`), then open **three terminals** in this directory.
+
+### 1. Key generation (all three terminals at once)
+
+```sh
+# terminal 1            # terminal 2            # terminal 3
+cargo run -p ark-frost-sample -- --actor alice keygen
+cargo run -p ark-frost-sample -- --actor bob   keygen
+cargo run -p ark-frost-sample -- --actor clair keygen
+```
+
+Each terminal prints a **round 1 blob** — paste it into _both_ other terminals. Each terminal then prints two **round 2 blobs**, one addressed to each peer — paste each into the terminal it is addressed to. When done, each actor has its key share in `<actor>/frost_key_package.hex` and all three print the same group public key.
+
+### 2. Receive over Lightning
+
+In alice's terminal (any actor can coordinate):
+
+```sh
+cargo run -p ark-frost-sample -- --actor alice invoice 50000
+```
+
+Pay the printed BOLT11 invoice from any Lightning wallet. Once Boltz funds the VHTLC, alice prints a **signing request blob**. Hand it to bob (or clair):
+
+```sh
+cargo run -p ark-frost-sample -- --actor bob sign <blob>
+```
+
+Paste bob's response back into alice's terminal — the claim is signed 2-of-3 and the funds land at the multisig Ark address.
+
+### 3. Send over Lightning
+
+```sh
+cargo run -p ark-frost-sample -- --actor alice pay <bolt11-invoice>
+```
+
+Funding the swap triggers signing ceremonies (one per transaction being signed: the Ark tx and its checkpoint tx). For each printed request, run `sign` as any other actor and paste the response back.
+
+### Testing the ceremony without a server
+
+`sign-test` runs a full signing ceremony over an arbitrary 32-byte message — useful to verify the keygen output before touching real funds:
+
+```sh
+cargo run -p ark-frost-sample -- --actor alice sign-test $(printf '07%.0s' {1..32})
+# then answer the printed request from another terminal:
+cargo run -p ark-frost-sample -- --actor clair sign <blob>
+```
+
+### 4. Balance
+
+```sh
+cargo run -p ark-frost-sample -- --actor alice balance
+```
+
+## How the ceremony fits in one round trip
+
+FROST signing normally takes two rounds (commit, then sign). With exactly two participants the responder can do both at once: the coordinator's commitments are in the request, so the responder's commitment set is already complete and it returns its commitments _and_ its signature share in a single reply. One paste each way per signature.
+
+The signing request contains the raw 32-byte sighash. The responder prints it before signing — in a real deployment each co-signer would independently reconstruct and verify the transaction before signing, rather than trusting the coordinator.
+
+## Files per actor
+
+| File                       | Contents                                                 |
+| -------------------------- | -------------------------------------------------------- |
+| `ark.config.toml`          | Ark server / esplora / Boltz URLs                        |
+| `frost_key_package.hex`    | this actor's secret key share (never leaves the machine) |
+| `frost_pubkey_package.hex` | group public key package (same for everyone)             |
+| `swap_storage.sqlite`      | Boltz swap state                                         |

--- a/ark-frost-sample/alice/ark.config.toml
+++ b/ark-frost-sample/alice/ark.config.toml
@@ -1,0 +1,4 @@
+ark_server_url = "http://localhost:7070"
+esplora_url = "http://localhost:3000/api"
+boltz_url = "http://localhost:9001"
+# network = "regtest"

--- a/ark-frost-sample/bob/ark.config.toml
+++ b/ark-frost-sample/bob/ark.config.toml
@@ -1,0 +1,4 @@
+ark_server_url = "http://localhost:7070"
+esplora_url = "http://localhost:3000/api"
+boltz_url = "http://localhost:9001"
+# network = "regtest"

--- a/ark-frost-sample/clair/ark.config.toml
+++ b/ark-frost-sample/clair/ark.config.toml
@@ -1,0 +1,4 @@
+ark_server_url = "http://localhost:7070"
+esplora_url = "http://localhost:3000/api"
+boltz_url = "http://localhost:9001"
+# network = "regtest"

--- a/ark-frost-sample/justfile
+++ b/ark-frost-sample/justfile
@@ -1,0 +1,34 @@
+# FROST multisig sample commands
+#
+# Run all three `keygen` recipes at the same time in separate terminals.
+
+default:
+    @just --list
+
+# Run the interactive 2-of-3 DKG for an actor (run for alice, bob AND clair concurrently)
+keygen actor:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} keygen
+
+# Show the FROST group public key
+group-info actor:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} group-info
+
+# Show the Ark address of the multisig wallet
+offchain-address actor:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} offchain-address
+
+# Show the multisig wallet balance
+balance actor:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} balance
+
+# Receive sats over Lightning (prints a BOLT11 invoice, then coordinates the claim)
+invoice actor amount:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} invoice {{ amount }}
+
+# Pay a BOLT11 invoice over Lightning
+pay actor invoice:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} pay {{ invoice }}
+
+# Respond to a signing request blob from another actor
+sign actor blob:
+    cargo run -p ark-frost-sample -- --actor {{ actor }} sign {{ blob }}

--- a/ark-frost-sample/src/frost.rs
+++ b/ark-frost-sample/src/frost.rs
@@ -1,0 +1,787 @@
+//! FROST 2-of-3 key generation and signing for the sample.
+//!
+//! Every multi-party exchange happens by copy-pasting base64 blobs between the three actor
+//! terminals. The protocol itself is implemented as pure blob-in/blob-out steps ([`dkg_start`],
+//! [`DkgRound1`], [`DkgRound2`], [`FrostActor::start_signing`], [`FrostActor::respond`],
+//! [`FrostActor::finalize_signing`]); the interactive prompts are thin wrappers around them, and
+//! the end-to-end test drives the same steps in a single process.
+//!
+//! Secrets (DKG round secrets, signing nonces) only ever live in memory of a single command
+//! invocation; the produced key share and group key are persisted per actor.
+
+use anyhow::anyhow;
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Result;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use bitcoin::hex::DisplayHex;
+use bitcoin::hex::FromHex;
+use bitcoin::key::Secp256k1;
+use bitcoin::secp256k1;
+use bitcoin::secp256k1::schnorr;
+use bitcoin::XOnlyPublicKey;
+use frost_secp256k1_tr as frost;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::io::BufRead;
+use std::io::Write;
+use std::path::Path;
+
+pub const ACTORS: [&str; 3] = ["alice", "bob", "clair"];
+
+const MIN_SIGNERS: u16 = 2;
+const MAX_SIGNERS: u16 = 3;
+
+const KEY_PACKAGE_FILE: &str = "frost_key_package.hex";
+const PUBKEY_PACKAGE_FILE: &str = "frost_pubkey_package.hex";
+
+pub fn actor_identifier(actor: &str) -> Result<frost::Identifier> {
+    let index = ACTORS
+        .iter()
+        .position(|a| *a == actor)
+        .ok_or_else(|| anyhow!("unknown actor '{actor}', expected one of {ACTORS:?}"))?;
+
+    frost::Identifier::try_from(index as u16 + 1).map_err(|e| anyhow!("invalid identifier: {e}"))
+}
+
+fn actor_by_identifier(identifier: &frost::Identifier) -> Result<&'static str> {
+    for actor in ACTORS {
+        if actor_identifier(actor)? == *identifier {
+            return Ok(actor);
+        }
+    }
+    bail!("no actor for identifier");
+}
+
+fn others(actor: &str) -> Vec<&'static str> {
+    ACTORS.iter().copied().filter(|a| *a != actor).collect()
+}
+
+/// A message passed between actor terminals, as a single-line base64 blob.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Payload {
+    DkgRound1 {
+        from: String,
+        package: String,
+    },
+    DkgRound2 {
+        from: String,
+        to: String,
+        package: String,
+    },
+    SignRequest {
+        from: String,
+        msg: String,
+        commitments: String,
+    },
+    SignResponse {
+        from: String,
+        commitments: String,
+        sig_share: String,
+    },
+}
+
+fn encode(payload: &Payload) -> Result<String> {
+    Ok(BASE64.encode(serde_json::to_vec(payload)?))
+}
+
+fn decode(blob: &str) -> Result<Payload> {
+    let bytes = BASE64
+        .decode(blob.trim())
+        .context("blob is not valid base64")?;
+    serde_json::from_slice(&bytes).context("blob does not contain a valid payload")
+}
+
+fn prompt(text: &str) -> Result<String> {
+    eprint!("{text}");
+    std::io::stderr().flush()?;
+    let mut line = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .context("failed to read from stdin")?;
+    let line = line.trim().to_string();
+    if line.is_empty() {
+        bail!("empty input");
+    }
+    Ok(line)
+}
+
+// === Distributed key generation ===
+
+/// DKG state after producing this actor's round 1 package.
+pub struct DkgRound1 {
+    actor: String,
+    secret: frost::keys::dkg::round1::SecretPackage,
+    blob: String,
+}
+
+/// Start the 2-of-3 DKG for `actor`, producing the round 1 blob to broadcast to both peers.
+pub fn dkg_start(actor: &str) -> Result<DkgRound1> {
+    let identifier = actor_identifier(actor)?;
+    let mut rng = rand::thread_rng();
+
+    let (secret, package) = frost::keys::dkg::part1(identifier, MAX_SIGNERS, MIN_SIGNERS, &mut rng)
+        .map_err(|e| anyhow!("DKG part 1 failed: {e}"))?;
+
+    let blob = encode(&Payload::DkgRound1 {
+        from: actor.to_string(),
+        package: package
+            .serialize()
+            .map_err(|e| anyhow!("{e}"))?
+            .to_lower_hex_string(),
+    })?;
+
+    Ok(DkgRound1 {
+        actor: actor.to_string(),
+        secret,
+        blob,
+    })
+}
+
+impl DkgRound1 {
+    /// The round 1 blob to send to BOTH other actors.
+    pub fn blob(&self) -> &str {
+        &self.blob
+    }
+
+    /// Consume the round 1 blobs of both peers (any order) and produce the per-peer round 2
+    /// blobs.
+    pub fn receive_round1(self, blobs: &[&str]) -> Result<DkgRound2> {
+        let mut round1_packages = BTreeMap::new();
+        for blob in blobs {
+            let Payload::DkgRound1 { from, package } = decode(blob)? else {
+                bail!("expected a round 1 blob");
+            };
+            if from == self.actor {
+                bail!("received my own round 1 blob back");
+            }
+            let package = frost::keys::dkg::round1::Package::deserialize(&Vec::from_hex(&package)?)
+                .map_err(|e| anyhow!("invalid round 1 package: {e}"))?;
+            if round1_packages
+                .insert(actor_identifier(&from)?, package)
+                .is_some()
+            {
+                bail!("received two round 1 blobs from '{from}'");
+            }
+        }
+        if round1_packages.len() != others(&self.actor).len() {
+            bail!("expected round 1 blobs from {:?}", others(&self.actor));
+        }
+
+        let (secret, round2_packages) = frost::keys::dkg::part2(self.secret, &round1_packages)
+            .map_err(|e| anyhow!("DKG part 2 failed: {e}"))?;
+
+        let mut outgoing = Vec::new();
+        for (peer_identifier, package) in round2_packages {
+            let peer = actor_by_identifier(&peer_identifier)?;
+            let blob = encode(&Payload::DkgRound2 {
+                from: self.actor.clone(),
+                to: peer.to_string(),
+                package: package
+                    .serialize()
+                    .map_err(|e| anyhow!("{e}"))?
+                    .to_lower_hex_string(),
+            })?;
+            outgoing.push((peer.to_string(), blob));
+        }
+
+        Ok(DkgRound2 {
+            actor: self.actor,
+            round1_packages,
+            secret,
+            outgoing,
+        })
+    }
+}
+
+/// DKG state after producing the per-peer round 2 packages.
+pub struct DkgRound2 {
+    actor: String,
+    round1_packages: BTreeMap<frost::Identifier, frost::keys::dkg::round1::Package>,
+    secret: frost::keys::dkg::round2::SecretPackage,
+    outgoing: Vec<(String, String)>,
+}
+
+impl DkgRound2 {
+    /// The round 2 blobs, as `(recipient, blob)` pairs. Each blob must go to exactly the named
+    /// recipient (and nobody else).
+    pub fn outgoing(&self) -> &[(String, String)] {
+        &self.outgoing
+    }
+
+    /// Consume the round 2 blobs both peers addressed to this actor (any order) and derive the
+    /// key share and group key.
+    pub fn receive_round2(self, blobs: &[&str]) -> Result<FrostActor> {
+        let mut round2_packages = BTreeMap::new();
+        for blob in blobs {
+            let Payload::DkgRound2 { from, to, package } = decode(blob)? else {
+                bail!("expected a round 2 blob");
+            };
+            if from == self.actor {
+                bail!("received my own round 2 blob back");
+            }
+            if to != self.actor {
+                bail!(
+                    "this round 2 blob is addressed to '{to}', not to '{}'",
+                    self.actor
+                );
+            }
+            let package = frost::keys::dkg::round2::Package::deserialize(&Vec::from_hex(&package)?)
+                .map_err(|e| anyhow!("invalid round 2 package: {e}"))?;
+            if round2_packages
+                .insert(actor_identifier(&from)?, package)
+                .is_some()
+            {
+                bail!("received two round 2 blobs from '{from}'");
+            }
+        }
+        if round2_packages.len() != others(&self.actor).len() {
+            bail!("expected round 2 blobs from {:?}", others(&self.actor));
+        }
+
+        let (key_package, pubkey_package) =
+            frost::keys::dkg::part3(&self.secret, &self.round1_packages, &round2_packages)
+                .map_err(|e| anyhow!("DKG part 3 failed: {e}"))?;
+
+        FrostActor::new(&self.actor, key_package, pubkey_package)
+    }
+}
+
+/// Run the interactive 2-of-3 distributed key generation for `actor`.
+///
+/// All three actors must run this concurrently in separate terminals and exchange the printed
+/// blobs. On success the actor's key share and the group public key package are written to `dir`.
+pub fn run_dkg(actor: &str, dir: &Path) -> Result<XOnlyPublicKey> {
+    eprintln!("Running FROST 2-of-3 DKG as '{actor}'.");
+    eprintln!("All three actors must run `keygen` at the same time.\n");
+
+    let round1 = dkg_start(actor)?;
+
+    eprintln!("Send this round 1 blob to BOTH other actors:\n");
+    println!("{}\n", round1.blob());
+
+    let mut round1_blobs = Vec::new();
+    for other in others(actor) {
+        round1_blobs.push(prompt(&format!("Paste {other}'s round 1 blob: "))?);
+    }
+    let round2 =
+        round1.receive_round1(&round1_blobs.iter().map(String::as_str).collect::<Vec<_>>())?;
+
+    eprintln!();
+    for (peer, blob) in round2.outgoing() {
+        eprintln!("Send this round 2 blob to {peer} (and ONLY {peer}):\n");
+        println!("{blob}\n");
+    }
+
+    let mut round2_blobs = Vec::new();
+    for other in others(actor) {
+        round2_blobs.push(prompt(&format!(
+            "Paste the round 2 blob {other} made for you: "
+        ))?);
+    }
+    let frost_actor =
+        round2.receive_round2(&round2_blobs.iter().map(String::as_str).collect::<Vec<_>>())?;
+
+    frost_actor.save(dir)?;
+
+    let group_pk = frost_actor.group_pk();
+    eprintln!("\nDKG complete. Group public key (x-only): {group_pk}");
+    eprintln!(
+        "Key share written to {}",
+        dir.join(KEY_PACKAGE_FILE).display()
+    );
+
+    Ok(group_pk)
+}
+
+fn group_x_only_pk(pubkey_package: &frost::keys::PublicKeyPackage) -> Result<XOnlyPublicKey> {
+    let bytes = pubkey_package
+        .verifying_key()
+        .serialize()
+        .map_err(|e| anyhow!("{e}"))?;
+    // 33-byte compressed SEC1 encoding; BIP340 uses the 32-byte x coordinate.
+    XOnlyPublicKey::from_slice(&bytes[1..]).context("invalid group public key")
+}
+
+/// An actor's share of the FROST group key.
+pub struct FrostActor {
+    actor: String,
+    key_package: frost::keys::KeyPackage,
+    pubkey_package: frost::keys::PublicKeyPackage,
+    group_pk: XOnlyPublicKey,
+}
+
+/// An in-flight signing ceremony on the coordinator side.
+///
+/// Holds the coordinator's secret nonces; consumed by [`FrostActor::finalize_signing`] so nonces
+/// cannot be reused.
+pub struct SigningSession {
+    nonces: frost::round1::SigningNonces,
+    commitments: frost::round1::SigningCommitments,
+    msg: [u8; 32],
+    request_blob: String,
+}
+
+impl SigningSession {
+    /// The signing request blob to send to ONE other actor.
+    pub fn request_blob(&self) -> &str {
+        &self.request_blob
+    }
+}
+
+/// A participant's answer to a signing request.
+pub struct SignResponse {
+    /// The actor who started the ceremony.
+    pub coordinator: String,
+    /// The 32-byte message (sighash) being signed.
+    pub msg: [u8; 32],
+    /// The response blob to paste back into the coordinator's terminal.
+    pub blob: String,
+}
+
+impl FrostActor {
+    fn new(
+        actor: &str,
+        key_package: frost::keys::KeyPackage,
+        pubkey_package: frost::keys::PublicKeyPackage,
+    ) -> Result<Self> {
+        let group_pk = group_x_only_pk(&pubkey_package)?;
+
+        Ok(Self {
+            actor: actor.to_string(),
+            key_package,
+            pubkey_package,
+            group_pk,
+        })
+    }
+
+    pub fn save(&self, dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(dir)?;
+        std::fs::write(
+            dir.join(KEY_PACKAGE_FILE),
+            self.key_package
+                .serialize()
+                .map_err(|e| anyhow!("{e}"))?
+                .to_lower_hex_string(),
+        )?;
+        std::fs::write(
+            dir.join(PUBKEY_PACKAGE_FILE),
+            self.pubkey_package
+                .serialize()
+                .map_err(|e| anyhow!("{e}"))?
+                .to_lower_hex_string(),
+        )?;
+        Ok(())
+    }
+
+    pub fn load(actor: &str, dir: &Path) -> Result<Self> {
+        let read_hex = |file: &str| -> Result<Vec<u8>> {
+            let path = dir.join(file);
+            let hex = std::fs::read_to_string(&path).with_context(|| {
+                format!(
+                    "failed to read {}; run `keygen` for '{actor}' first",
+                    path.display()
+                )
+            })?;
+            Ok(Vec::from_hex(hex.trim())?)
+        };
+
+        let key_package = frost::keys::KeyPackage::deserialize(&read_hex(KEY_PACKAGE_FILE)?)
+            .map_err(|e| anyhow!("invalid key package: {e}"))?;
+        let pubkey_package =
+            frost::keys::PublicKeyPackage::deserialize(&read_hex(PUBKEY_PACKAGE_FILE)?)
+                .map_err(|e| anyhow!("invalid public key package: {e}"))?;
+
+        Self::new(actor, key_package, pubkey_package)
+    }
+
+    pub fn group_pk(&self) -> XOnlyPublicKey {
+        self.group_pk
+    }
+
+    /// Start a signing ceremony over a 32-byte message, producing the request blob for one other
+    /// actor.
+    pub fn start_signing(&self, msg: &[u8; 32]) -> Result<SigningSession> {
+        let mut rng = rand::thread_rng();
+
+        let (nonces, commitments) =
+            frost::round1::commit(self.key_package.signing_share(), &mut rng);
+
+        let request_blob = encode(&Payload::SignRequest {
+            from: self.actor.clone(),
+            msg: msg.to_lower_hex_string(),
+            commitments: commitments
+                .serialize()
+                .map_err(|e| anyhow!("{e}"))?
+                .to_lower_hex_string(),
+        })?;
+
+        Ok(SigningSession {
+            nonces,
+            commitments,
+            msg: *msg,
+            request_blob,
+        })
+    }
+
+    /// Answer a signing request from another actor.
+    ///
+    /// Commitment and signature share are produced in one step: with two participants, the
+    /// coordinator's commitments in the request complete the commitment set.
+    pub fn respond(&self, request_blob: &str) -> Result<SignResponse> {
+        let my_identifier = actor_identifier(&self.actor)?;
+        let mut rng = rand::thread_rng();
+
+        let Payload::SignRequest {
+            from,
+            msg,
+            commitments: coordinator_commitments,
+        } = decode(request_blob)?
+        else {
+            bail!("expected a signing request blob");
+        };
+        if from == self.actor {
+            bail!("cannot respond to my own signing request");
+        }
+        let coordinator_identifier = actor_identifier(&from)?;
+        let coordinator_commitments = frost::round1::SigningCommitments::deserialize(
+            &Vec::from_hex(&coordinator_commitments)?,
+        )
+        .map_err(|e| anyhow!("invalid commitments: {e}"))?;
+
+        let msg: [u8; 32] = <[u8; 32]>::from_hex(&msg).context("message must be 32 bytes")?;
+
+        let (nonces, my_commitments) =
+            frost::round1::commit(self.key_package.signing_share(), &mut rng);
+
+        let mut commitments_map = BTreeMap::new();
+        commitments_map.insert(coordinator_identifier, coordinator_commitments);
+        commitments_map.insert(my_identifier, my_commitments);
+
+        let signing_package = frost::SigningPackage::new(commitments_map, &msg);
+
+        let share = frost::round2::sign(&signing_package, &nonces, &self.key_package)
+            .map_err(|e| anyhow!("failed to produce signature share: {e}"))?;
+
+        let blob = encode(&Payload::SignResponse {
+            from: self.actor.clone(),
+            commitments: my_commitments
+                .serialize()
+                .map_err(|e| anyhow!("{e}"))?
+                .to_lower_hex_string(),
+            sig_share: share.serialize().to_lower_hex_string(),
+        })?;
+
+        Ok(SignResponse {
+            coordinator: from,
+            msg,
+            blob,
+        })
+    }
+
+    /// Combine the participant's response with the coordinator's own share into a BIP340
+    /// signature for the group key.
+    pub fn finalize_signing(
+        &self,
+        session: SigningSession,
+        response_blob: &str,
+    ) -> Result<schnorr::Signature> {
+        let my_identifier = actor_identifier(&self.actor)?;
+
+        let Payload::SignResponse {
+            from,
+            commitments: their_commitments,
+            sig_share,
+        } = decode(response_blob)?
+        else {
+            bail!("expected a signing response blob");
+        };
+        if from == self.actor {
+            bail!("the response must come from a different actor");
+        }
+        let their_identifier = actor_identifier(&from)?;
+        let their_commitments =
+            frost::round1::SigningCommitments::deserialize(&Vec::from_hex(&their_commitments)?)
+                .map_err(|e| anyhow!("invalid commitments: {e}"))?;
+        let their_share = frost::round2::SignatureShare::deserialize(&Vec::from_hex(&sig_share)?)
+            .map_err(|e| anyhow!("invalid signature share: {e}"))?;
+
+        let mut commitments_map = BTreeMap::new();
+        commitments_map.insert(my_identifier, session.commitments);
+        commitments_map.insert(their_identifier, their_commitments);
+
+        let signing_package = frost::SigningPackage::new(commitments_map, &session.msg);
+
+        let my_share = frost::round2::sign(&signing_package, &session.nonces, &self.key_package)
+            .map_err(|e| anyhow!("failed to produce signature share: {e}"))?;
+
+        let mut shares = BTreeMap::new();
+        shares.insert(my_identifier, my_share);
+        shares.insert(their_identifier, their_share);
+
+        let signature = frost::aggregate(&signing_package, &shares, &self.pubkey_package)
+            .map_err(|e| anyhow!("failed to aggregate signature shares: {e}"))?;
+
+        let signature = to_bip340_signature(&signature)?;
+
+        // Sanity check against the group key before handing the signature to the client.
+        let secp = Secp256k1::new();
+        secp.verify_schnorr(
+            &signature,
+            &secp256k1::Message::from_digest(session.msg),
+            &self.group_pk,
+        )
+        .context("aggregated FROST signature failed BIP340 verification")?;
+
+        Ok(signature)
+    }
+
+    /// Coordinate a 2-of-3 signing ceremony for a 32-byte message, interactively.
+    ///
+    /// Prints a signing request blob, waits for one other actor to respond via `sign`, and
+    /// aggregates both signature shares into a BIP340 signature for the group key.
+    pub fn coordinate_signature(&self, msg: &[u8; 32]) -> Result<schnorr::Signature> {
+        let session = self.start_signing(msg)?;
+
+        eprintln!("\nA signature from the FROST group key is required.");
+        eprintln!("Send this signing request to ONE other actor, who must run `sign <blob>`:\n");
+        println!("{}\n", session.request_blob());
+
+        let response_blob = prompt("Paste their response: ")?;
+        let signature = self.finalize_signing(session, &response_blob)?;
+
+        eprintln!("Signature aggregated and verified against the group key.\n");
+
+        Ok(signature)
+    }
+
+    /// Participate in a signing ceremony started by another actor, interactively.
+    ///
+    /// Consumes a signing request blob and prints the response blob to paste back into the
+    /// coordinator's terminal.
+    pub fn respond_to_signing_request(&self, blob: &str) -> Result<()> {
+        let response = self.respond(blob)?;
+
+        eprintln!("Signing request from '{}'.", response.coordinator);
+        eprintln!("Message (sighash): {}", response.msg.to_lower_hex_string());
+        eprintln!("\nPaste this response into the coordinator's terminal:\n");
+        println!("{}", response.blob);
+
+        Ok(())
+    }
+}
+
+fn to_bip340_signature(signature: &frost::Signature) -> Result<schnorr::Signature> {
+    let bytes = signature.serialize().map_err(|e| anyhow!("{e}"))?;
+    // The taproot ciphersuite serializes signatures in 64-byte BIP340 form (R.x || s).
+    schnorr::Signature::from_slice(&bytes)
+        .context("FROST signature is not a valid BIP340 signature")
+}
+
+/// [`ark_client::Signer`] backed by an interactive FROST signing ceremony.
+pub struct FrostSigner {
+    actor: FrostActor,
+}
+
+impl FrostSigner {
+    pub fn new(actor: FrostActor) -> Self {
+        Self { actor }
+    }
+
+    pub fn group_pk(&self) -> XOnlyPublicKey {
+        self.actor.group_pk()
+    }
+}
+
+impl ark_client::Signer for FrostSigner {
+    fn signing_pks(&self) -> Result<Vec<XOnlyPublicKey>, ark_client::Error> {
+        Ok(vec![self.actor.group_pk()])
+    }
+
+    fn sign_schnorr(
+        &self,
+        pk: &XOnlyPublicKey,
+        msg: &secp256k1::Message,
+    ) -> Result<schnorr::Signature, ark_client::Error> {
+        if *pk != self.actor.group_pk() {
+            return Err(ark_client::Error::consumer(anyhow!(
+                "cannot sign for {pk}: FROST group key is {}",
+                self.actor.group_pk()
+            )));
+        }
+
+        let mut msg32 = [0u8; 32];
+        msg32.copy_from_slice(msg.as_ref());
+
+        self.actor
+            .coordinate_signature(&msg32)
+            .map_err(ark_client::Error::consumer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::thread_rng;
+    use std::collections::HashMap;
+
+    /// Run the full 2-of-3 DKG through the same blob exchange the three terminals would do,
+    /// entirely in one process.
+    fn run_dkg_via_blobs() -> HashMap<&'static str, FrostActor> {
+        // Round 1: every actor broadcasts one blob to both peers.
+        let round1: HashMap<&str, DkgRound1> = ACTORS
+            .iter()
+            .map(|actor| (*actor, dkg_start(actor).expect("dkg start")))
+            .collect();
+        let round1_blobs: HashMap<&str, String> = round1
+            .iter()
+            .map(|(actor, state)| (*actor, state.blob().to_string()))
+            .collect();
+
+        // Round 2: every actor consumes the peers' round 1 blobs and produces one blob per peer.
+        let mut round2 = HashMap::new();
+        let mut inboxes: HashMap<&str, Vec<String>> = HashMap::new();
+        for (actor, state) in round1 {
+            let peer_blobs: Vec<&str> = others(actor)
+                .iter()
+                .map(|peer| round1_blobs[peer].as_str())
+                .collect();
+            let state = state.receive_round1(&peer_blobs).expect("dkg round 1");
+
+            for (recipient, blob) in state.outgoing() {
+                inboxes
+                    .entry(
+                        ACTORS
+                            .iter()
+                            .find(|a| *a == recipient)
+                            .expect("known actor"),
+                    )
+                    .or_default()
+                    .push(blob.clone());
+            }
+            round2.insert(actor, state);
+        }
+
+        // Round 3: every actor consumes the round 2 blobs addressed to it.
+        round2
+            .into_iter()
+            .map(|(actor, state)| {
+                let inbox: Vec<&str> = inboxes[actor].iter().map(String::as_str).collect();
+                (actor, state.receive_round2(&inbox).expect("dkg round 2"))
+            })
+            .collect()
+    }
+
+    /// One-process end-to-end test of the whole sample protocol: DKG between alice, bob and
+    /// clair via blobs, then a signing ceremony for every coordinator/responder pair, checking
+    /// each aggregated signature is valid BIP340 for the x-only group key (what the Arkade VTXO
+    /// script paths verify).
+    #[test]
+    fn dkg_and_signing_end_to_end_via_blobs() {
+        let actors = run_dkg_via_blobs();
+
+        // All actors must agree on the group key.
+        let group_pk = actors["alice"].group_pk();
+        for actor in ACTORS {
+            assert_eq!(actors[actor].group_pk(), group_pk);
+        }
+
+        let secp = Secp256k1::new();
+        let msg = [7u8; 32];
+
+        // Any actor can coordinate with any other actor responding.
+        for coordinator in ACTORS {
+            for responder in others(coordinator) {
+                let session = actors[coordinator]
+                    .start_signing(&msg)
+                    .expect("start signing");
+
+                let response = actors[responder]
+                    .respond(session.request_blob())
+                    .expect("respond");
+                assert_eq!(response.coordinator, coordinator);
+                assert_eq!(response.msg, msg);
+
+                let signature = actors[coordinator]
+                    .finalize_signing(session, &response.blob)
+                    .expect("finalize");
+
+                secp.verify_schnorr(&signature, &secp256k1::Message::from_digest(msg), &group_pk)
+                    .expect("valid BIP340 signature for the x-only group key");
+            }
+        }
+    }
+
+    #[test]
+    fn responding_to_own_request_fails() {
+        let actors = run_dkg_via_blobs();
+
+        let session = actors["alice"]
+            .start_signing(&[1u8; 32])
+            .expect("start signing");
+
+        assert!(actors["alice"].respond(session.request_blob()).is_err());
+    }
+
+    /// A 2-of-3 FROST signature must verify as a plain BIP340 signature for the x-only group
+    /// key, which is what the Arkade VTXO script paths check.
+    #[test]
+    fn frost_signature_is_valid_bip340() {
+        let mut rng = thread_rng();
+
+        let (shares, pubkey_package) = frost::keys::generate_with_dealer(
+            MAX_SIGNERS,
+            MIN_SIGNERS,
+            frost::keys::IdentifierList::Default,
+            &mut rng,
+        )
+        .expect("dealer keygen");
+
+        let key_packages: BTreeMap<_, _> = shares
+            .into_iter()
+            .map(|(identifier, share)| {
+                (
+                    identifier,
+                    frost::keys::KeyPackage::try_from(share).expect("key package"),
+                )
+            })
+            .collect();
+
+        let msg = [42u8; 32];
+
+        // Any two of the three participants sign.
+        let signers: Vec<_> = key_packages.iter().take(2).collect();
+
+        let mut nonces_map = BTreeMap::new();
+        let mut commitments_map = BTreeMap::new();
+        for (identifier, key_package) in &signers {
+            let (nonces, commitments) =
+                frost::round1::commit(key_package.signing_share(), &mut rng);
+            nonces_map.insert(**identifier, nonces);
+            commitments_map.insert(**identifier, commitments);
+        }
+
+        let signing_package = frost::SigningPackage::new(commitments_map, &msg);
+
+        let mut shares_map = BTreeMap::new();
+        for (identifier, key_package) in &signers {
+            let share = frost::round2::sign(&signing_package, &nonces_map[identifier], key_package)
+                .expect("signature share");
+            shares_map.insert(**identifier, share);
+        }
+
+        let signature =
+            frost::aggregate(&signing_package, &shares_map, &pubkey_package).expect("aggregate");
+
+        let signature = to_bip340_signature(&signature).expect("BIP340 signature");
+        let group_pk = group_x_only_pk(&pubkey_package).expect("group pk");
+
+        Secp256k1::new()
+            .verify_schnorr(&signature, &secp256k1::Message::from_digest(msg), &group_pk)
+            .expect("valid BIP340 signature for the x-only group key");
+    }
+}

--- a/ark-frost-sample/src/main.rs
+++ b/ark-frost-sample/src/main.rs
@@ -1,0 +1,448 @@
+#![allow(clippy::print_stdout)]
+// The copy-paste coordination between actor terminals is driven by stderr prompts.
+#![allow(clippy::print_stderr)]
+
+//! An Ark Lightning client whose wallet key is a FROST 2-of-3 multisig.
+//!
+//! Three actors — alice, bob and clair — each hold a share of a single group key generated with
+//! distributed key generation (no party ever knows the full secret key). The Arkade address is
+//! derived from the x-only group public key, so on-chain and to the Ark server it is
+//! indistinguishable from a single-key wallet.
+//!
+//! Every signature requires 2 of the 3 actors: the coordinator prints a signing request blob and
+//! one other actor answers it with `sign` in their own terminal. See the README for a full
+//! three-terminal walkthrough of receiving and sending over Lightning.
+
+mod frost;
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use ark_bdk_wallet::Wallet;
+use ark_client::lightning_invoice::Bolt11Invoice;
+use ark_client::Blockchain;
+use ark_client::Error;
+use ark_client::OfflineClient;
+use ark_client::OfflineClientConfig;
+use ark_client::SpendStatus;
+use ark_client::SqliteSwapStorage;
+use ark_client::SwapAmount;
+use ark_client::TxStatus;
+use ark_core::ExplorerUtxo;
+use bitcoin::key::Secp256k1;
+use bitcoin::Address;
+use bitcoin::Amount;
+use bitcoin::Network;
+use bitcoin::OutPoint;
+use bitcoin::Transaction;
+use bitcoin::Txid;
+use clap::Parser;
+use clap::Subcommand;
+use frost::FrostActor;
+use frost::FrostSigner;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+#[derive(Parser)]
+#[command(name = "ark-frost-sample")]
+#[command(about = "An Ark Lightning client backed by a FROST 2-of-3 multisig")]
+struct Cli {
+    /// Which actor this terminal represents.
+    #[arg(short, long, value_parser = ["alice", "bob", "clair"])]
+    actor: String,
+
+    /// Data directory for this actor (key share, config, swap storage).
+    /// Defaults to ./<actor>.
+    #[arg(short, long)]
+    dir: Option<PathBuf>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run the interactive 2-of-3 distributed key generation.
+    ///
+    /// All three actors must run this at the same time in separate terminals and exchange the
+    /// printed blobs.
+    Keygen,
+    /// Show the FROST group public key.
+    GroupInfo,
+    /// Show the Ark address of the FROST multisig wallet.
+    OffchainAddress,
+    /// Show the balance of the FROST multisig wallet.
+    Balance,
+    /// Generate a BOLT11 invoice to receive via Lightning (Boltz reverse submarine swap).
+    ///
+    /// Waits for the invoice to be paid and claims the funds; claiming requires a signing
+    /// ceremony with one other actor.
+    Invoice {
+        /// How many sats to receive.
+        amount: u64,
+    },
+    /// Pay a BOLT11 invoice via a Boltz submarine swap.
+    ///
+    /// Funding the swap requires signing ceremonies with one other actor.
+    Pay {
+        /// A BOLT11 invoice.
+        invoice: String,
+    },
+    /// Participate in a signing ceremony started by another actor.
+    Sign {
+        /// The signing request blob printed by the coordinator.
+        blob: String,
+    },
+    /// Run a signing ceremony over an arbitrary 32-byte message, without an Ark server.
+    ///
+    /// Useful to verify the keygen output and the copy-paste signing flow end to end.
+    SignTest {
+        /// The 32-byte message to sign, hex-encoded.
+        msg: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct Config {
+    ark_server_url: String,
+    esplora_url: String,
+    boltz_url: String,
+    swap_storage_path: Option<String>,
+    network: Option<String>,
+}
+
+impl Config {
+    fn load(dir: &Path) -> Result<Self> {
+        let path = dir.join("ark.config.toml");
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read config at {}", path.display()))?;
+        toml::from_str(&content).context("invalid config")
+    }
+
+    fn network(&self) -> Result<Network> {
+        match self.network.as_deref() {
+            None | Some("regtest") => Ok(Network::Regtest),
+            Some(other) => Network::from_str(other).context("invalid network"),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|_| anyhow!("failed to install crypto providers"))?;
+
+    let cli = Cli::parse();
+    let dir = cli
+        .dir
+        .unwrap_or_else(|| PathBuf::from(format!("./{}", cli.actor)));
+
+    match cli.command {
+        Commands::Keygen => {
+            frost::run_dkg(&cli.actor, &dir)?;
+        }
+        Commands::GroupInfo => {
+            let actor = FrostActor::load(&cli.actor, &dir)?;
+            println!(
+                "{}",
+                serde_json::json!({ "group_pk": actor.group_pk().to_string() })
+            );
+        }
+        Commands::Sign { blob } => {
+            let actor = FrostActor::load(&cli.actor, &dir)?;
+            actor.respond_to_signing_request(&blob)?;
+        }
+        Commands::SignTest { msg } => {
+            let actor = FrostActor::load(&cli.actor, &dir)?;
+            let msg: [u8; 32] =
+                bitcoin::hex::FromHex::from_hex(&msg).context("message must be 32 bytes of hex")?;
+            let signature = actor.coordinate_signature(&msg)?;
+            println!(
+                "{}",
+                serde_json::json!({ "signature": signature.to_string() })
+            );
+        }
+        Commands::OffchainAddress => {
+            let client = connect(&cli.actor, &dir).await?;
+            let (address, _) = client
+                .get_offchain_address()
+                .await
+                .map_err(|e| anyhow!(e))?;
+            println!("{}", serde_json::json!({ "address": address.encode() }));
+        }
+        Commands::Balance => {
+            let client = connect(&cli.actor, &dir).await?;
+            let balance = client.offchain_balance().await.map_err(|e| anyhow!(e))?;
+            println!(
+                "{}",
+                serde_json::json!({
+                    "offchain_confirmed": balance.confirmed(),
+                    "offchain_pre_confirmed": balance.pre_confirmed(),
+                    "recoverable": balance.recoverable(),
+                })
+            );
+        }
+        Commands::Invoice { amount } => {
+            let client = connect(&cli.actor, &dir).await?;
+
+            let res = client
+                .get_ln_invoice(SwapAmount::invoice(Amount::from_sat(amount)), None, None)
+                .await
+                .map_err(|e| anyhow!(e))?;
+
+            let invoice = res.invoice.to_string();
+            let swap_id = res.swap_id;
+
+            tracing::info!(swap_id, "Generated Lightning invoice");
+            println!(
+                "{}",
+                serde_json::json!({ "invoice": invoice, "swap_id": swap_id })
+            );
+
+            eprintln!("\nWaiting for the invoice to be paid...");
+            eprintln!("Claiming the funds will require a signing ceremony with one other actor.");
+
+            client
+                .wait_for_vhtlc(&swap_id)
+                .await
+                .map_err(|e| anyhow!(e))?;
+
+            tracing::info!(
+                swap_id,
+                "Lightning invoice paid and claimed by the multisig"
+            );
+        }
+        Commands::Pay { invoice } => {
+            let client = connect(&cli.actor, &dir).await?;
+
+            let invoice = Bolt11Invoice::from_str(&invoice)
+                .map_err(|e| anyhow!("failed to parse BOLT11 invoice: {e}"))?;
+
+            let result = client
+                .pay_ln_invoice(invoice)
+                .await
+                .map_err(|e| anyhow!(e))?;
+            let swap_id = result.swap_id;
+
+            tracing::info!(swap_id, "Payment sent, waiting for finalization");
+
+            client
+                .wait_for_invoice_paid(swap_id.as_str())
+                .await
+                .map_err(|e| anyhow!(e))?;
+
+            tracing::info!(swap_id, "Payment made");
+        }
+    }
+
+    Ok(())
+}
+
+async fn connect(
+    actor: &str,
+    dir: &Path,
+) -> Result<ark_client::Client<EsploraClient, Wallet, SqliteSwapStorage>> {
+    let config = Config::load(dir)?;
+    let network = config.network()?;
+
+    let frost_actor = FrostActor::load(actor, dir)?;
+    let signer = Arc::new(FrostSigner::new(frost_actor));
+    tracing::info!(group_pk = %signer.group_pk(), "Loaded FROST key share");
+
+    let esplora_client = Arc::new(EsploraClient::new(&config.esplora_url)?);
+
+    // The on-chain wallet is required by the client but unused in the Lightning-only flows; give
+    // it a throwaway key.
+    let secp = Secp256k1::new();
+    let onchain_kp = bitcoin::key::Keypair::new(&secp, &mut rand::thread_rng());
+    let wallet = Arc::new(Wallet::new(
+        onchain_kp,
+        network,
+        config.esplora_url.as_str(),
+    )?);
+
+    let swap_storage_path = config.swap_storage_path.clone().unwrap_or_else(|| {
+        dir.join("swap_storage.sqlite")
+            .to_string_lossy()
+            .into_owned()
+    });
+    let storage = Arc::new(
+        SqliteSwapStorage::new(&swap_storage_path)
+            .await
+            .map_err(|e| anyhow!(e))?,
+    );
+
+    let client_config = OfflineClientConfig {
+        ark_server_url: config.ark_server_url.clone(),
+        boltz_url: config.boltz_url.clone(),
+        ..Default::default()
+    };
+
+    let offline_client =
+        OfflineClient::with_signer(client_config, signer, esplora_client, wallet, storage);
+
+    offline_client.connect().await.map_err(|e| anyhow!(e))
+}
+
+pub struct EsploraClient {
+    esplora_client: esplora_client::AsyncClient,
+}
+
+impl EsploraClient {
+    pub fn new(url: &str) -> Result<Self> {
+        let builder = esplora_client::Builder::new(url);
+        let esplora_client = builder.build_async()?;
+
+        Ok(Self { esplora_client })
+    }
+}
+
+impl Blockchain for EsploraClient {
+    async fn find_outpoints(&self, address: &Address) -> Result<Vec<ExplorerUtxo>, Error> {
+        let current_block_height = self
+            .esplora_client
+            .get_height()
+            .await
+            .map_err(Error::consumer)?;
+
+        let script_pubkey = address.script_pubkey();
+        let txs = self
+            .esplora_client
+            .scripthash_txs(&script_pubkey, None)
+            .await
+            .map_err(Error::consumer)?;
+
+        let spent_outpoints: HashSet<OutPoint> = txs
+            .iter()
+            .flat_map(|tx| {
+                tx.vin
+                    .iter()
+                    .filter(|input| {
+                        input
+                            .prevout
+                            .as_ref()
+                            .is_some_and(|prevout| prevout.scriptpubkey == script_pubkey)
+                    })
+                    .map(|input| OutPoint {
+                        txid: input.txid,
+                        vout: input.vout,
+                    })
+            })
+            .collect();
+
+        let utxos = txs
+            .into_iter()
+            .flat_map(|tx| {
+                let txid = tx.txid;
+                tx.vout
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, v)| v.scriptpubkey == script_pubkey)
+                    .map(|(i, v)| {
+                        let outpoint = OutPoint {
+                            txid,
+                            vout: i as u32,
+                        };
+                        let confirmations = match tx.status.block_height {
+                            Some(confirmation_block_height) => {
+                                match current_block_height.checked_sub(confirmation_block_height) {
+                                    Some(x) => x + 1,
+                                    None => 0,
+                                }
+                            }
+                            None => 0,
+                        };
+
+                        ExplorerUtxo {
+                            outpoint,
+                            amount: Amount::from_sat(v.value),
+                            confirmation_blocktime: tx.status.block_time,
+                            confirmations: confirmations as u64,
+                            is_spent: spent_outpoints.contains(&outpoint),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        Ok(utxos)
+    }
+
+    async fn find_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
+        let option = self
+            .esplora_client
+            .get_tx(txid)
+            .await
+            .map_err(Error::consumer)?;
+        Ok(option)
+    }
+
+    async fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus, Error> {
+        let info = self
+            .esplora_client
+            .get_tx_info(txid)
+            .await
+            .map_err(Error::consumer)?;
+
+        Ok(TxStatus {
+            confirmed_at: info.and_then(|s| s.status.block_time.map(|t| t as i64)),
+        })
+    }
+
+    async fn get_output_status(&self, txid: &Txid, vout: u32) -> Result<SpendStatus, Error> {
+        let status = self
+            .esplora_client
+            .get_output_status(txid, vout as u64)
+            .await
+            .map_err(Error::consumer)?;
+
+        Ok(SpendStatus {
+            spend_txid: status.as_ref().and_then(|s| s.txid),
+        })
+    }
+
+    async fn broadcast(&self, tx: &Transaction) -> Result<(), Error> {
+        self.esplora_client
+            .broadcast(tx)
+            .await
+            .map_err(Error::consumer)?;
+        Ok(())
+    }
+
+    async fn get_fee_rate(&self) -> Result<f64, Error> {
+        Ok(1.0)
+    }
+
+    async fn broadcast_package(&self, _txs: &[&Transaction]) -> Result<(), Error> {
+        unimplemented!("Not implemented yet");
+    }
+}
+
+fn init_tracing() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                "info,\
+                 tower=info,\
+                 hyper_util=info,\
+                 hyper=info,\
+                 h2=warn,\
+                 reqwest=info,\
+                 ark_core=info,\
+                 rustls=info,\
+                 sqlx::query=warn"
+                    .into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init()
+}

--- a/justfile
+++ b/justfile
@@ -4,15 +4,19 @@ set dotenv-load := true
 # is provided by the `regtest` git submodule (arkade-regtest) and driven by its
 # zero-dependency Node CLI (`regtest.mjs`). `.env.regtest` holds this repo's arkd
 # image + config overrides (exit delays, zeroed intent fees).
+
 regtest_dir := "regtest"
 regtest_env := ".env.regtest"
+
 # Profiles the e2e suite needs: `emulator` transitively pulls in `base` + `ark`
 # (arkd) plus the arkade-script emulator used by the introspector tests. boltz /
 # delegate / solver are not exercised by the `e2e_*` suite.
+
 regtest_profiles := "emulator"
 
 mod ark-rest
 mod nix
+mod ark-frost-sample
 
 ## ------------------------
 ## Code quality functions


### PR DESCRIPTION
## Summary

Sample CLI demonstrating the new `ExternalSigner` trait (stacked on `feat/external-signer`): an Ark wallet whose key is a **FROST 2-of-3 threshold multisig** ([RFC 9591](https://www.rfc-editor.org/rfc/rfc9591), via [`frost-secp256k1-tr`](https://crates.io/crates/frost-secp256k1-tr)).

Three actors — alice, bob and clair — run distributed key generation so no party ever holds the full secret key. The Arkade address is derived from the x-only group public key, so to the Ark server the wallet is indistinguishable from a single-key wallet. Signing ceremonies are coordinated by copy-pasting base64 blobs between terminals; the aggregated result is a plain BIP340 signature.

## Supported flows

- **Receive via Lightning** (`invoice`): Boltz reverse submarine swap; claiming the VHTLC requires one signing ceremony.
- **Send via Lightning** (`pay`): Boltz submarine swap; signing ceremonies for the Ark tx + checkpoint tx.
- `balance`, `offchain-address`, `group-info`, and `sign-test` (ceremony dry-run without a server).

The library supports all flows through the `Signer` trait; this walkthrough exercises the Lightning flows (settlement is impractical with a copy-paste ceremony due to server-timed batch rounds).

See `ark-frost-sample/README.md` for a full regtest walkthrough.

## Notes

- `publish = false`; key shares / pubkey packages / swap storage are gitignored.
- Base branch is `feat/external-signer` — this PR only adds the sample crate (+ workspace member and justfile module).

