### PR TITLE
feat(client): cache vtxos and sync them incrementally

### DIFF
--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1819,27 +1819,46 @@ where
         // don't refetch what they just returned.
         let refresh_outpoints = cache.unspent_outpoints_for(&scripts).await?;
 
-        if !unknown_scripts.is_empty() {
+        let delta_after = (cache.last_sync_ms().await? - vtxo_cache::SYNC_MARGIN_MS).max(1) as u64;
+
+        // The three fetches are independent, so they run concurrently.
+        let unknown_fut = async {
+            if unknown_scripts.is_empty() {
+                return Ok(Vec::new());
+            }
+
             let request = GetVtxosRequest::new_for_scripts(unknown_scripts.clone());
-            let vtxos = self.fetch_all_vtxos(request).await?;
-            cache.upsert(vtxos).await?;
-        }
+            self.fetch_all_vtxos(request).await
+        };
 
         // The delta must cover _all_ synced scripts, not just the requested ones, because the
         // watermark below is global: anything the delta skips now would be skipped forever.
-        if !synced_scripts.is_empty() {
-            let after = (cache.last_sync_ms().await? - vtxo_cache::SYNC_MARGIN_MS).max(1) as u64;
-            let request = GetVtxosRequest::new_for_scripts(synced_scripts.into_iter().collect())
-                .with_after(after);
-            let vtxos = self.fetch_all_vtxos(request).await?;
-            cache.upsert(vtxos).await?;
-        }
+        let delta_fut = async {
+            if synced_scripts.is_empty() {
+                return Ok(Vec::new());
+            }
 
-        if !refresh_outpoints.is_empty() {
+            let request =
+                GetVtxosRequest::new_for_scripts(synced_scripts.iter().cloned().collect())
+                    .with_after(delta_after);
+            self.fetch_all_vtxos(request).await
+        };
+
+        let refresh_fut = async {
+            if refresh_outpoints.is_empty() {
+                return Ok(Vec::new());
+            }
+
             let request = GetVtxosRequest::new_for_outpoints(&refresh_outpoints);
-            let vtxos = self.fetch_all_vtxos(request).await?;
-            cache.upsert(vtxos).await?;
-        }
+            self.fetch_all_vtxos(request).await
+        };
+
+        let (unknown_vtxos, delta_vtxos, refresh_vtxos) =
+            futures::try_join!(unknown_fut, delta_fut, refresh_fut)?;
+
+        cache.upsert(unknown_vtxos).await?;
+        cache.upsert(delta_vtxos).await?;
+        cache.upsert(refresh_vtxos).await?;
 
         cache.mark_synced(unknown_scripts).await?;
         cache.set_last_sync_ms(now_ms).await?;

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -2119,7 +2119,11 @@ where
 
         let mut all_vtxos = Vec::new();
         let mut cursor = 0;
-        const PAGE_SIZE: i32 = 100;
+        // The server honors the requested page size (its per-endpoint "max" is only the default
+        // for requests that don't set one), and every page request re-runs the full vtxo query
+        // server-side before paginating in memory — so fewer, larger pages are strictly cheaper
+        // on both ends. 2000 vtxos fit comfortably within tonic's 4 MiB response limit.
+        const PAGE_SIZE: i32 = 2000;
 
         loop {
             let paged_request = request.clone().with_page(PAGE_SIZE, cursor);

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -590,6 +590,62 @@ pub struct OffChainBalance {
 }
 
 impl OffChainBalance {
+    /// Compute the offchain balance from an already-fetched VTXO list, e.g. one returned by
+    /// [`Client::list_vtxos`].
+    ///
+    /// Use this when you need both the balance and the VTXO list, so a single VTXO sync serves
+    /// both instead of fetching the list twice.
+    pub fn from_vtxo_list(
+        vtxo_list: &AnnotatedVtxoList,
+        server_info: &server::Info,
+        now: i64,
+    ) -> Result<Self, Error> {
+        let spendable_outpoints: HashSet<OutPoint> = vtxo_list
+            .spendable_offchain_at(server_info, now)
+            .map(|entry| entry.vtxo().outpoint)
+            .collect();
+
+        let pre_confirmed = vtxo_list
+            .pre_confirmed()
+            .filter(|entry| spendable_outpoints.contains(&entry.vtxo().outpoint))
+            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
+
+        let confirmed = vtxo_list
+            .confirmed()
+            .filter(|entry| spendable_outpoints.contains(&entry.vtxo().outpoint))
+            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
+
+        let recoverable = vtxo_list
+            .recoverable()
+            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
+
+        let pending_recovery = vtxo_list
+            .pending_recovery_due_to_signer_at(server_info, now)
+            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
+
+        // Aggregate asset balances from currently offchain-spendable VTXOs only.
+        let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
+        for entry in vtxo_list.spendable_offchain_at(server_info, now) {
+            for asset in &entry.vtxo().assets {
+                let total = asset_balances
+                    .get(&asset.asset_id)
+                    .copied()
+                    .unwrap_or(0)
+                    .checked_add(asset.amount)
+                    .ok_or_else(|| Error::ad_hoc("asset balance overflow"))?;
+                asset_balances.insert(asset.asset_id, total);
+            }
+        }
+
+        Ok(OffChainBalance {
+            pre_confirmed,
+            confirmed,
+            recoverable,
+            pending_recovery,
+            asset_balances,
+        })
+    }
+
     pub fn pre_confirmed(&self) -> Amount {
         self.pre_confirmed
     }
@@ -1868,54 +1924,27 @@ where
     }
 
     pub async fn offchain_balance(&self) -> Result<OffChainBalance, Error> {
-        let vtxo_list = self.list_vtxos().await.context("failed to list VTXOs")?;
-        let now = unix_now()?;
+        let (_, balance) = self.offchain_balance_with_vtxos().await?;
+        Ok(balance)
+    }
+
+    /// Get the offchain balance together with the VTXO list it was computed from.
+    ///
+    /// Prefer this over calling [`Client::offchain_balance`] and [`Client::list_vtxos`]
+    /// back-to-back: a single VTXO sync serves both.
+    pub async fn offchain_balance_with_vtxos(
+        &self,
+    ) -> Result<(AnnotatedVtxoList, OffChainBalance), Error> {
         let server_info = self.server_info().await?;
+        let vtxo_list = self
+            .list_vtxos_with_server_info(&server_info)
+            .await
+            .context("failed to list VTXOs")?;
+        let now = unix_now()?;
 
-        let spendable_outpoints: HashSet<OutPoint> = vtxo_list
-            .spendable_offchain_at(&server_info, now)
-            .map(|entry| entry.vtxo().outpoint)
-            .collect();
+        let balance = OffChainBalance::from_vtxo_list(&vtxo_list, &server_info, now)?;
 
-        let pre_confirmed = vtxo_list
-            .pre_confirmed()
-            .filter(|entry| spendable_outpoints.contains(&entry.vtxo().outpoint))
-            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
-
-        let confirmed = vtxo_list
-            .confirmed()
-            .filter(|entry| spendable_outpoints.contains(&entry.vtxo().outpoint))
-            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
-
-        let recoverable = vtxo_list
-            .recoverable()
-            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
-
-        let pending_recovery = vtxo_list
-            .pending_recovery_due_to_signer_at(&server_info, now)
-            .fold(Amount::ZERO, |acc, entry| acc + entry.vtxo().amount);
-
-        // Aggregate asset balances from currently offchain-spendable VTXOs only.
-        let mut asset_balances: HashMap<AssetId, u64> = HashMap::new();
-        for entry in vtxo_list.spendable_offchain_at(&server_info, now) {
-            for asset in &entry.vtxo().assets {
-                let total = asset_balances
-                    .get(&asset.asset_id)
-                    .copied()
-                    .unwrap_or(0)
-                    .checked_add(asset.amount)
-                    .ok_or_else(|| Error::ad_hoc("asset balance overflow"))?;
-                asset_balances.insert(asset.asset_id, total);
-            }
-        }
-
-        Ok(OffChainBalance {
-            pre_confirmed,
-            confirmed,
-            recoverable,
-            pending_recovery,
-            asset_balances,
-        })
+        Ok((vtxo_list, balance))
     }
 
     /// Get information about an asset by its ID.

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -1821,19 +1821,21 @@ where
 
         let delta_after = (cache.last_sync_ms().await? - vtxo_cache::SYNC_MARGIN_MS).max(1) as u64;
 
-        // The three fetches are independent, so they run concurrently.
-        let unknown_fut = async {
+        // The three fetches are independent, so they run concurrently. Each future is boxed:
+        // inlining three copies of the fetch future into this one makes it large enough to
+        // overflow the stack in debug builds.
+        let unknown_fut = Box::pin(async {
             if unknown_scripts.is_empty() {
                 return Ok(Vec::new());
             }
 
             let request = GetVtxosRequest::new_for_scripts(unknown_scripts.clone());
             self.fetch_all_vtxos(request).await
-        };
+        });
 
         // The delta must cover _all_ synced scripts, not just the requested ones, because the
         // watermark below is global: anything the delta skips now would be skipped forever.
-        let delta_fut = async {
+        let delta_fut = Box::pin(async {
             if synced_scripts.is_empty() {
                 return Ok(Vec::new());
             }
@@ -1842,16 +1844,16 @@ where
                 GetVtxosRequest::new_for_scripts(synced_scripts.iter().cloned().collect())
                     .with_after(delta_after);
             self.fetch_all_vtxos(request).await
-        };
+        });
 
-        let refresh_fut = async {
+        let refresh_fut = Box::pin(async {
             if refresh_outpoints.is_empty() {
                 return Ok(Vec::new());
             }
 
             let request = GetVtxosRequest::new_for_outpoints(&refresh_outpoints);
             self.fetch_all_vtxos(request).await
-        };
+        });
 
         let (unknown_vtxos, delta_vtxos, refresh_vtxos) =
             futures::try_join!(unknown_fut, delta_fut, refresh_fut)?;

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -3,6 +3,9 @@ use crate::key_provider::KeypairIndex;
 use crate::utils::sleep;
 use crate::utils::timeout_op;
 use crate::utils::unix_now;
+use crate::utils::unix_now_millis;
+use crate::vtxo_cache::InMemoryVtxoCache;
+use crate::vtxo_cache::VtxoCacheStore;
 use crate::wallet::OnchainWallet;
 use ark_core::asset::AssetId;
 use ark_core::build_anchor_tx;
@@ -73,6 +76,7 @@ mod migration;
 mod send_vtxo;
 mod unilateral_exit;
 mod utils;
+pub mod vtxo_cache;
 
 pub use ark_core::server::DeprecatedSignerStatus;
 pub use ark_core::server::ServerSignerStatus;
@@ -455,6 +459,7 @@ pub struct OfflineClient<B, W, S> {
     contract_store: Arc<Mutex<Option<Box<dyn ContractStore>>>>,
     delegator_pk: Option<XOnlyPublicKey>,
     historical_delegator_pks: Vec<XOnlyPublicKey>,
+    vtxo_cache: Arc<dyn VtxoCacheStore>,
 }
 
 /// A client to interact with Ark server
@@ -464,6 +469,7 @@ pub struct Client<B, W, S> {
     inner: OfflineClient<B, W, S>,
     state: Arc<RwLock<ServerState>>,
     server_info_refresh_lock: Arc<tokio::sync::Mutex<()>>,
+    vtxo_sync_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 struct ServerState {
@@ -722,12 +728,20 @@ where
             swap_storage,
             boltz_url: config.boltz_url.trim_end_matches('/').to_string(),
             boltz_referral_id,
+            vtxo_cache: Arc::new(InMemoryVtxoCache::new()),
             timeout: config.timeout,
             server_info_ttl: config.server_info_ttl,
             contract_store: Arc::new(Mutex::new(None)),
             delegator_pk: config.delegator_pk,
             historical_delegator_pks,
         }
+    }
+
+    /// Use a custom [`VtxoCacheStore`] implementation instead of the default
+    /// [`InMemoryVtxoCache`], e.g. to share a persistent VTXO cache between processes.
+    pub fn with_vtxo_cache(mut self, vtxo_cache: Arc<dyn VtxoCacheStore>) -> Self {
+        self.vtxo_cache = vtxo_cache;
+        self
     }
 
     /// Create a new offline client with a static keypair.
@@ -865,6 +879,7 @@ where
             inner: self,
             state,
             server_info_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+            vtxo_sync_lock: Arc::new(tokio::sync::Mutex::new(())),
         };
 
         client.hydrate_persisted_contract_keys()?;
@@ -1707,12 +1722,79 @@ where
         manager.annotated_boarding_outputs_for_exit_delays(&candidate_delays)
     }
 
+    /// Get the VTXOs for the given addresses, using the configured [`VtxoCacheStore`] to avoid
+    /// refetching the full VTXO history on every call.
+    ///
+    /// Scripts seen for the first time are fetched in full. For known scripts we only fetch the
+    /// delta since the last sync (the server filters by the VTXO's `updated_at` timestamp, which
+    /// is bumped on creation, spend, settlement and unroll), plus a targeted refresh by outpoint
+    /// of the cached unspent VTXOs, whose swept/expiry state can change server-side without
+    /// bumping `updated_at`. Spent VTXOs are terminal and are never refetched.
+    ///
+    /// Use [`Client::clear_vtxo_cache`] to force a full refetch.
     pub async fn get_virtual_tx_outpoints(
         &self,
         addresses: impl Iterator<Item = ArkAddress>,
     ) -> Result<Vec<VirtualTxOutPoint>, Error> {
-        let request = GetVtxosRequest::new_for_addresses(addresses);
-        self.fetch_all_vtxos(request).await
+        let scripts: HashSet<ScriptBuf> = addresses
+            .map(|address| address.to_p2tr_script_pubkey())
+            .collect();
+
+        if scripts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Holding the lock for the whole sync serializes concurrent callers, so the same delta is
+        // not fetched twice.
+        let _sync_guard = self.vtxo_sync_lock.lock().await;
+
+        let cache = &self.inner.vtxo_cache;
+
+        let now_ms = unix_now_millis()?;
+
+        let synced_scripts = cache.synced_scripts().await?;
+        let unknown_scripts = scripts
+            .iter()
+            .filter(|script| !synced_scripts.contains(*script))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        // Cached unspent VTXOs to refresh by outpoint, collected before the fetches below so we
+        // don't refetch what they just returned.
+        let refresh_outpoints = cache.unspent_outpoints_for(&scripts).await?;
+
+        if !unknown_scripts.is_empty() {
+            let request = GetVtxosRequest::new_for_scripts(unknown_scripts.clone());
+            let vtxos = self.fetch_all_vtxos(request).await?;
+            cache.upsert(vtxos).await?;
+        }
+
+        // The delta must cover _all_ synced scripts, not just the requested ones, because the
+        // watermark below is global: anything the delta skips now would be skipped forever.
+        if !synced_scripts.is_empty() {
+            let after = (cache.last_sync_ms().await? - vtxo_cache::SYNC_MARGIN_MS).max(1) as u64;
+            let request = GetVtxosRequest::new_for_scripts(synced_scripts.into_iter().collect())
+                .with_after(after);
+            let vtxos = self.fetch_all_vtxos(request).await?;
+            cache.upsert(vtxos).await?;
+        }
+
+        if !refresh_outpoints.is_empty() {
+            let request = GetVtxosRequest::new_for_outpoints(&refresh_outpoints);
+            let vtxos = self.fetch_all_vtxos(request).await?;
+            cache.upsert(vtxos).await?;
+        }
+
+        cache.mark_synced(unknown_scripts).await?;
+        cache.set_last_sync_ms(now_ms).await?;
+
+        cache.vtxos_for(&scripts).await
+    }
+
+    /// Clear the VTXO cache, forcing the next VTXO query to fetch everything from the server
+    /// again.
+    pub async fn clear_vtxo_cache(&self) -> Result<(), Error> {
+        self.inner.vtxo_cache.clear().await
     }
 
     pub async fn list_vtxos(&self) -> Result<AnnotatedVtxoList, Error> {

--- a/ark-client/src/utils.rs
+++ b/ark-client/src/utils.rs
@@ -19,6 +19,24 @@ pub(crate) fn unix_now() -> Result<i64, Error> {
     }
 }
 
+/// Current time as Unix milliseconds. Uses `js_sys::Date` on wasm32, `std::time` elsewhere.
+pub(crate) fn unix_now_millis() -> Result<i64, Error> {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    {
+        let millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| Error::ad_hoc(format!("system clock before UNIX_EPOCH: {e}")))?
+            .as_millis();
+
+        i64::try_from(millis).map_err(|_| Error::ad_hoc("unix timestamp overflow"))
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    {
+        Ok(js_sys::Date::now() as i64)
+    }
+}
+
 pub(crate) async fn sleep(duration: Duration) {
     #[cfg(target_arch = "wasm32")]
     {

--- a/ark-client/src/vtxo_cache.rs
+++ b/ark-client/src/vtxo_cache.rs
@@ -1,0 +1,281 @@
+//! # VTXO cache
+//!
+//! The Ark client caches VTXOs and syncs them incrementally, instead of crawling the entire
+//! (ever-growing) VTXO history on every query.
+//!
+//! The Ark server filters `GetVtxos` by the VTXO's `updated_at` timestamp (milliseconds), which
+//! is bumped whenever a VTXO is created, spent, settled or unrolled. This lets us fetch the full
+//! VTXO set once per script and afterwards only ask for the delta since the last sync.
+//!
+//! Two state transitions do _not_ bump `updated_at` on the server: sweeps (swept-ness is derived
+//! from separate marker tables) and expiry updates. Both only matter for _unspent_ VTXOs, so the
+//! sync additionally refreshes all cached unspent VTXOs by outpoint. Spent VTXOs are terminal and
+//! are never refetched.
+//!
+//! The cache storage is pluggable via [`VtxoCacheStore`], allowing e.g. a Redis- or
+//! database-backed cache shared between processes. [`InMemoryVtxoCache`] is the default.
+
+use crate::Error;
+use ark_core::server::VirtualTxOutPoint;
+use async_trait::async_trait;
+use bitcoin::OutPoint;
+use bitcoin::ScriptBuf;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+/// Subtracted from the sync watermark to compensate for clock skew between this machine and the
+/// server, since the watermark is taken from the local clock but compared against server-side
+/// `updated_at` timestamps.
+pub(crate) const SYNC_MARGIN_MS: i64 = 5 * 60 * 1_000;
+
+/// Storage backend for the VTXO cache.
+///
+/// The sync algorithm lives in the client; implementations only need to provide storage. All
+/// implementations must uphold: a VTXO is keyed by its outpoint, and an upsert replaces the
+/// previous entry for the same outpoint.
+///
+/// Implementations must be safe for concurrent use. The client serializes cache _syncs_
+/// internally, but reads may happen concurrently.
+#[async_trait]
+pub trait VtxoCacheStore: Send + Sync {
+    /// All cached VTXOs (including spent ones) belonging to any of the given scripts, most
+    /// recently created first.
+    async fn vtxos_for(
+        &self,
+        scripts: &HashSet<ScriptBuf>,
+    ) -> Result<Vec<VirtualTxOutPoint>, Error>;
+
+    /// Outpoints of cached _unspent_ VTXOs belonging to any of the given scripts. These are the
+    /// VTXOs whose state can still change without bumping `updated_at` on the server.
+    async fn unspent_outpoints_for(
+        &self,
+        scripts: &HashSet<ScriptBuf>,
+    ) -> Result<Vec<OutPoint>, Error>;
+
+    /// Insert or replace VTXOs, keyed by outpoint.
+    async fn upsert(&self, vtxos: Vec<VirtualTxOutPoint>) -> Result<(), Error>;
+
+    /// The scripts which have been fully synced at least once.
+    async fn synced_scripts(&self) -> Result<HashSet<ScriptBuf>, Error>;
+
+    /// Record that the given scripts have been fully synced.
+    async fn mark_synced(&self, scripts: Vec<ScriptBuf>) -> Result<(), Error>;
+
+    /// Local timestamp (in Unix milliseconds) at which the last sync _started_. Zero if never
+    /// synced.
+    async fn last_sync_ms(&self) -> Result<i64, Error>;
+
+    /// Store the timestamp at which the current sync started.
+    async fn set_last_sync_ms(&self, last_sync_ms: i64) -> Result<(), Error>;
+
+    /// Drop all cached state, forcing the next sync to fetch everything again.
+    async fn clear(&self) -> Result<(), Error>;
+}
+
+/// Default [`VtxoCacheStore`] implementation, keeping everything in memory.
+#[derive(Default)]
+pub struct InMemoryVtxoCache {
+    state: Mutex<CacheState>,
+}
+
+impl InMemoryVtxoCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn state<T>(&self, f: impl FnOnce(&mut CacheState) -> T) -> Result<T, Error> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| Error::ad_hoc("VTXO cache lock poisoned"))?;
+        Ok(f(&mut state))
+    }
+}
+
+#[async_trait]
+impl VtxoCacheStore for InMemoryVtxoCache {
+    async fn vtxos_for(
+        &self,
+        scripts: &HashSet<ScriptBuf>,
+    ) -> Result<Vec<VirtualTxOutPoint>, Error> {
+        self.state(|state| state.vtxos_for(scripts))
+    }
+
+    async fn unspent_outpoints_for(
+        &self,
+        scripts: &HashSet<ScriptBuf>,
+    ) -> Result<Vec<OutPoint>, Error> {
+        self.state(|state| state.unspent_outpoints_for(scripts))
+    }
+
+    async fn upsert(&self, vtxos: Vec<VirtualTxOutPoint>) -> Result<(), Error> {
+        self.state(|state| state.upsert(vtxos))
+    }
+
+    async fn synced_scripts(&self) -> Result<HashSet<ScriptBuf>, Error> {
+        self.state(|state| state.synced_scripts.clone())
+    }
+
+    async fn mark_synced(&self, scripts: Vec<ScriptBuf>) -> Result<(), Error> {
+        self.state(|state| state.synced_scripts.extend(scripts))
+    }
+
+    async fn last_sync_ms(&self) -> Result<i64, Error> {
+        self.state(|state| state.last_sync_ms)
+    }
+
+    async fn set_last_sync_ms(&self, last_sync_ms: i64) -> Result<(), Error> {
+        self.state(|state| state.last_sync_ms = last_sync_ms)
+    }
+
+    async fn clear(&self) -> Result<(), Error> {
+        self.state(|state| *state = CacheState::default())
+    }
+}
+
+#[derive(Default)]
+struct CacheState {
+    vtxos: HashMap<OutPoint, VirtualTxOutPoint>,
+    synced_scripts: HashSet<ScriptBuf>,
+    last_sync_ms: i64,
+}
+
+impl CacheState {
+    fn upsert(&mut self, vtxos: impl IntoIterator<Item = VirtualTxOutPoint>) {
+        for vtxo in vtxos {
+            self.vtxos.insert(vtxo.outpoint, vtxo);
+        }
+    }
+
+    fn unspent_outpoints_for(&self, scripts: &HashSet<ScriptBuf>) -> Vec<OutPoint> {
+        self.vtxos
+            .values()
+            .filter(|vtxo| !vtxo.is_spent && scripts.contains(&vtxo.script))
+            .map(|vtxo| vtxo.outpoint)
+            .collect()
+    }
+
+    fn vtxos_for(&self, scripts: &HashSet<ScriptBuf>) -> Vec<VirtualTxOutPoint> {
+        let mut vtxos = self
+            .vtxos
+            .values()
+            .filter(|vtxo| scripts.contains(&vtxo.script))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        vtxos.sort_by(|a, b| {
+            b.created_at
+                .cmp(&a.created_at)
+                .then_with(|| a.outpoint.cmp(&b.outpoint))
+        });
+
+        vtxos
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::Amount;
+
+    fn vtxo(
+        txid_byte: u8,
+        script: &ScriptBuf,
+        created_at: i64,
+        is_spent: bool,
+    ) -> VirtualTxOutPoint {
+        VirtualTxOutPoint {
+            outpoint: OutPoint {
+                txid: bitcoin::hashes::Hash::from_byte_array([txid_byte; 32]),
+                vout: 0,
+            },
+            created_at,
+            expires_at: created_at + 1_000,
+            amount: Amount::from_sat(1_000),
+            script: script.clone(),
+            is_preconfirmed: false,
+            is_swept: false,
+            is_unrolled: false,
+            is_spent,
+            spent_by: None,
+            commitment_txids: Vec::new(),
+            settled_by: None,
+            ark_txid: None,
+            assets: Vec::new(),
+            depth: 0,
+        }
+    }
+
+    fn script(byte: u8) -> ScriptBuf {
+        ScriptBuf::from_bytes(vec![byte; 3])
+    }
+
+    #[test]
+    fn upsert_replaces_by_outpoint() {
+        let mut state = CacheState::default();
+        let s = script(1);
+
+        state.upsert([vtxo(1, &s, 100, false)]);
+        state.upsert([vtxo(1, &s, 100, true)]);
+
+        let vtxos = state.vtxos_for(&HashSet::from([s]));
+        assert_eq!(vtxos.len(), 1);
+        assert!(vtxos[0].is_spent);
+    }
+
+    #[test]
+    fn vtxos_for_filters_by_script_and_sorts_by_created_at_desc() {
+        let mut state = CacheState::default();
+        let s1 = script(1);
+        let s2 = script(2);
+
+        state.upsert([
+            vtxo(1, &s1, 100, false),
+            vtxo(2, &s1, 300, true),
+            vtxo(3, &s2, 200, false),
+        ]);
+
+        let vtxos = state.vtxos_for(&HashSet::from([s1]));
+        assert_eq!(vtxos.len(), 2);
+        assert_eq!(vtxos[0].created_at, 300);
+        assert_eq!(vtxos[1].created_at, 100);
+    }
+
+    #[test]
+    fn unspent_outpoints_exclude_spent_and_foreign_scripts() {
+        let mut state = CacheState::default();
+        let s1 = script(1);
+        let s2 = script(2);
+
+        let unspent = vtxo(1, &s1, 100, false);
+        state.upsert([
+            unspent.clone(),
+            vtxo(2, &s1, 200, true),
+            vtxo(3, &s2, 300, false),
+        ]);
+
+        let outpoints = state.unspent_outpoints_for(&HashSet::from([s1]));
+        assert_eq!(outpoints, vec![unspent.outpoint]);
+    }
+
+    #[tokio::test]
+    async fn clear_resets_everything() {
+        let cache = InMemoryVtxoCache::new();
+        let s = script(1);
+
+        cache.upsert(vec![vtxo(1, &s, 100, false)]).await.unwrap();
+        cache.mark_synced(vec![s.clone()]).await.unwrap();
+        cache.set_last_sync_ms(42).await.unwrap();
+
+        cache.clear().await.unwrap();
+
+        assert!(cache
+            .vtxos_for(&HashSet::from([s.clone()]))
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(!cache.synced_scripts().await.unwrap().contains(&s));
+        assert_eq!(cache.last_sync_ms().await.unwrap(), 0);
+    }
+}

--- a/ark-core/src/server.rs
+++ b/ark-core/src/server.rs
@@ -263,6 +263,16 @@ impl GetVtxosRequest {
         }
     }
 
+    pub fn new_for_scripts(scripts: Vec<ScriptBuf>) -> Self {
+        Self {
+            reference: GetVtxosRequestReference::Scripts(scripts),
+            filter: None,
+            page: None,
+            before: None,
+            after: None,
+        }
+    }
+
     pub fn new_for_outpoints(outpoints: &[OutPoint]) -> Self {
         Self {
             reference: GetVtxosRequestReference::OutPoints(outpoints.to_vec()),


### PR DESCRIPTION
Instead of crawling the entire (ever-growing) vtxo history on every query, the client now caches vtxos and only fetches the delta since the last sync. The server filters GetVtxos by the vtxo's updated_at timestamp (milliseconds), which is bumped on creation, spend, settlement and unroll, so one delta request catches new vtxos and state changes to known ones.

Sweeps and expiry updates do not bump updated_at server-side, so the sync additionally refreshes the cached unspent vtxos by outpoint. Spent vtxos are terminal and are never refetched. The watermark is taken from the local clock with a five minute margin to absorb clock skew.

The storage is pluggable via the VtxoCacheStore trait so integrators can back the cache with e.g. Redis; InMemoryVtxoCache is the default. Client::clear_vtxo_cache forces a full refetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable VTXO caching layer with an in-memory default and support for custom cache stores (including cache injection for offline clients).
  * Added script-based VTXO retrieval support and improved offchain balance computation from a single VTXO listing.
* **Performance**
  * Virtual outpoint retrieval is now cache-backed with serialized sync, incremental fetching, and faster server pagination.
* **Bug Fixes**
  * Cache clearing now resets cached VTXOs and sync markers.
* **Tests**
  * Added unit tests covering cache replacement, filtering, unspent-outpoint behavior, and clear/reset semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->