### PR TITLE
fix: split settlements that exceed the server's max proof weight

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Security reports are greatly appreciated and we will publicly thank you for it.
 
 The following keys may be used to communicate sensitive information to developers:
 
-| Name | PGP Public Key URL | Fingerprint |
-|------|-------------|-------------|
-| Marco Argentieri | [https://github.com/tiero.gpg](https://github.com/tiero.gpg) | 0F6586CE8DA12FB1 |
+| Name               | PGP Public Key URL                                               | Fingerprint      |
+| ------------------ | ---------------------------------------------------------------- | ---------------- |
+| Marco Argentieri   | [https://github.com/tiero.gpg](https://github.com/tiero.gpg)     | 0F6586CE8DA12FB1 |
 | Pietralberto Mazza | [https://github.com/altafan.gpg](https://github.com/altafan.gpg) | 6C7639DEA147673B |
-| Andrew Camilleri | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg) | F918A46E23064E28 |
+| Andrew Camilleri   | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg)     | F918A46E23064E28 |
 
 You can import a key by running the following command in your terminal and verify the fingerprint matches the one above:
 

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -2178,6 +2178,9 @@ impl SettlementInput {
 /// Returns an error if a single input on its own already exceeds the limit, or if the chunks
 /// cannot be balanced to clear the dust threshold. Errors surface before any batch is joined, so
 /// a settlement never fails halfway through its chunks.
+const SINGLE_INPUT_TOO_LARGE_CONTEXT: &str =
+    "a single input's proof alone exceeds the weight limit; it cannot be batch-settled";
+
 fn chunk_settlement_inputs(
     onchain_inputs: Vec<batch::OnChainInput>,
     vtxo_inputs: Vec<intent::Input>,
@@ -2205,7 +2208,8 @@ fn chunk_settlement_inputs(
 
             if current.is_empty() {
                 // A single input already busts the limit; splitting cannot help.
-                return Err(Error::intent_proof_too_large(weight, max_weight));
+                return Err(Error::intent_proof_too_large(weight, max_weight)
+                    .context(SINGLE_INPUT_TOO_LARGE_CONTEXT));
             }
 
             chunks.push(std::mem::replace(&mut current, SettlementChunk::new()));
@@ -2214,7 +2218,8 @@ fn chunk_settlement_inputs(
 
             let weight = current.estimate_proof_weight(to_address)?;
             if weight > max_weight {
-                return Err(Error::intent_proof_too_large(weight, max_weight));
+                return Err(Error::intent_proof_too_large(weight, max_weight)
+                    .context(SINGLE_INPUT_TOO_LARGE_CONTEXT));
             }
         }
     }

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -2086,6 +2086,7 @@ fn estimate_settlement_proof_weight(
 }
 
 /// A subset of settlement inputs whose intent proof fits under the proof weight limit.
+#[derive(Debug)]
 struct SettlementChunk {
     onchain_inputs: Vec<batch::OnChainInput>,
     vtxo_inputs: Vec<intent::Input>,
@@ -2347,4 +2348,207 @@ pub(crate) struct PreparedIntent {
     pub onchain_inputs: Vec<batch::OnChainInput>,
     /// The original VTXO inputs (needed for forfeit signing).
     pub vtxo_inputs: Vec<intent::Input>,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use ark_core::script::multisig_script;
+    use bitcoin::hashes::Hash;
+    use bitcoin::taproot::LeafVersion;
+    use bitcoin::taproot::TaprootBuilder;
+    use bitcoin::Network;
+    use bitcoin::Sequence;
+
+    fn test_address_and_spend_info() -> (
+        ArkAddress,
+        bitcoin::ScriptBuf,
+        bitcoin::taproot::ControlBlock,
+    ) {
+        let secp = Secp256k1::new();
+
+        let server_pk: PublicKey =
+            "0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+                .parse()
+                .unwrap();
+        let owner_pk: PublicKey =
+            "03dff1d77f2a671c5f36183726db2341be58f8be17d2a3d1d2cd47b7b0f5f2d624"
+                .parse()
+                .unwrap();
+
+        let server_xonly = server_pk.x_only_public_key().0;
+        let owner_xonly = owner_pk.x_only_public_key().0;
+
+        let spend_script = multisig_script(server_xonly, owner_xonly);
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, spend_script.clone())
+            .unwrap()
+            .finalize(&secp, server_xonly)
+            .unwrap();
+        let control_block = spend_info
+            .control_block(&(spend_script.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let address = ArkAddress::new(Network::Regtest, server_xonly, spend_info.output_key());
+
+        (address, spend_script, control_block)
+    }
+
+    fn vtxo_input(outpoint_tag: u8, amount: Amount) -> intent::Input {
+        let (address, spend_script, control_block) = test_address_and_spend_info();
+
+        intent::Input::new(
+            OutPoint::new(Txid::from_byte_array([outpoint_tag; 32]), 0),
+            Sequence::MAX,
+            None,
+            TxOut {
+                value: amount,
+                script_pubkey: address.to_p2tr_script_pubkey(),
+            },
+            vec![spend_script.clone()],
+            (spend_script, control_block),
+            false,
+            false,
+            Vec::new(),
+        )
+    }
+
+    fn vtxo_inputs(amounts: &[u64]) -> Vec<intent::Input> {
+        amounts
+            .iter()
+            .enumerate()
+            .map(|(i, amount)| vtxo_input(i as u8 + 1, Amount::from_sat(*amount)))
+            .collect()
+    }
+
+    /// The estimated proof weight for settling `n` identical test inputs.
+    fn weight_of(n: usize) -> u64 {
+        let (address, _, _) = test_address_and_spend_info();
+        let inputs = vtxo_inputs(&vec![10_000; n]);
+        estimate_settlement_proof_weight(&[], &inputs, &address).unwrap()
+    }
+
+    fn chunk_outpoints(chunks: &[SettlementChunk]) -> Vec<OutPoint> {
+        chunks
+            .iter()
+            .flat_map(|chunk| chunk.vtxo_inputs.iter().map(|input| input.outpoint()))
+            .collect()
+    }
+
+    const DUST: Amount = Amount::from_sat(330);
+
+    #[test]
+    fn estimated_proof_weight_grows_per_input() {
+        let w1 = weight_of(1);
+        let w2 = weight_of(2);
+        let w3 = weight_of(3);
+
+        assert!(w1 < w2);
+        assert!(w2 < w3);
+
+        // Each identical input adds the same weight: input base (outpoint, script length,
+        // sequence) plus its witness (two 64-byte signatures, leaf script, control block).
+        assert_eq!(w2 - w1, w3 - w2);
+        let per_input = w2 - w1;
+        assert!(
+            (300..600).contains(&per_input),
+            "unexpected per-input weight: {per_input}"
+        );
+    }
+
+    #[test]
+    fn one_chunk_when_everything_fits() {
+        let (address, _, _) = test_address_and_spend_info();
+        let inputs = vtxo_inputs(&[10_000; 10]);
+
+        let chunks =
+            chunk_settlement_inputs(Vec::new(), inputs.clone(), &address, weight_of(10), DUST)
+                .unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].total_amount, Amount::from_sat(100_000));
+        assert_eq!(
+            chunk_outpoints(&chunks),
+            inputs.iter().map(|i| i.outpoint()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn splits_into_weight_bounded_chunks_preserving_order() {
+        let (address, _, _) = test_address_and_spend_info();
+        let inputs = vtxo_inputs(&[10_000; 10]);
+        let max_weight = weight_of(3);
+
+        let chunks =
+            chunk_settlement_inputs(Vec::new(), inputs.clone(), &address, max_weight, DUST)
+                .unwrap();
+
+        assert_eq!(chunks.len(), 4); // 3 + 3 + 3 + 1.
+
+        for chunk in chunks.iter() {
+            assert!(chunk.estimate_proof_weight(&address).unwrap() <= max_weight);
+            assert!(chunk.total_amount >= DUST);
+        }
+
+        assert_eq!(
+            chunk_outpoints(&chunks),
+            inputs.iter().map(|i| i.outpoint()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn errors_when_a_single_input_exceeds_the_limit() {
+        let (address, _, _) = test_address_and_spend_info();
+        let inputs = vtxo_inputs(&[10_000; 3]);
+
+        let err = chunk_settlement_inputs(Vec::new(), inputs, &address, weight_of(1) - 1, DUST)
+            .unwrap_err();
+
+        assert!(err.is_intent_proof_too_large());
+        assert!(err.to_string().contains("cannot be batch-settled"));
+    }
+
+    #[test]
+    fn rebalances_sub_dust_trailing_chunk() {
+        let (address, _, _) = test_address_and_spend_info();
+        // Six healthy inputs and one sub-dust input which ends up alone in the trailing chunk.
+        let inputs = vtxo_inputs(&[10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 100]);
+        let max_weight = weight_of(3);
+
+        let chunks =
+            chunk_settlement_inputs(Vec::new(), inputs.clone(), &address, max_weight, DUST)
+                .unwrap();
+
+        for chunk in chunks.iter() {
+            assert!(chunk.estimate_proof_weight(&address).unwrap() <= max_weight);
+            assert!(chunk.total_amount >= DUST);
+        }
+
+        // No input was lost or duplicated.
+        let mut outpoints = chunk_outpoints(&chunks);
+        outpoints.sort();
+        let mut expected = inputs.iter().map(|i| i.outpoint()).collect::<Vec<_>>();
+        expected.sort();
+        assert_eq!(outpoints, expected);
+
+        let total = chunks
+            .iter()
+            .fold(Amount::ZERO, |acc, chunk| acc + chunk.total_amount);
+        assert_eq!(total, Amount::from_sat(60_100));
+    }
+
+    #[test]
+    fn errors_when_sub_dust_chunks_cannot_be_balanced() {
+        let (address, _, _) = test_address_and_spend_info();
+        // Two sub-dust inputs which cannot share a chunk: the proof weight limit only fits one
+        // input per chunk.
+        let inputs = vtxo_inputs(&[100, 100]);
+
+        let err =
+            chunk_settlement_inputs(Vec::new(), inputs, &address, weight_of(1), DUST).unwrap_err();
+
+        assert!(err.to_string().contains("cannot balance settlement chunks"));
+    }
 }

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -78,7 +78,7 @@ where
         // Get off-chain address and send all funds to this address, no change output 🦄
         let (to_address, _) = self.get_offchain_address_with_server_info(&server_info)?;
 
-        let (boarding_inputs, vtxo_inputs, total_amount) = self
+        let (boarding_inputs, vtxo_inputs, _) = self
             .fetch_commitment_transaction_inputs(&server_info, now)
             .await?;
 
@@ -94,30 +94,9 @@ where
             return Ok(None);
         }
 
-        let join_next_batch = || async {
-            self.join_next_batch(
-                &mut rng.clone(),
-                &server_info,
-                boarding_inputs.clone(),
-                vtxo_inputs.clone(),
-                BatchOutputType::Board {
-                    to_address,
-                    to_amount: total_amount,
-                },
-            )
-            .await
-        };
-
-        // Joining a batch can fail depending on the timing, so we try a few times.
-        let commitment_txid = join_next_batch
-            .retry(ExponentialBuilder::default().with_max_times(0))
-            .sleep(sleep)
-            .when(|err| !err.is_server_info_changed())
-            .notify(|err: &Error, dur: std::time::Duration| {
-                tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}",);
-            })
-            .await
-            .context("Failed to join batch")?;
+        let commitment_txid = self
+            .join_batches_chunked(rng, &server_info, boarding_inputs, vtxo_inputs, to_address)
+            .await?;
 
         tracing::info!(%commitment_txid, "Settlement success");
 
@@ -218,29 +197,15 @@ where
             return Ok(None);
         }
 
-        let join_next_batch = || async {
-            self.join_next_batch(
-                &mut rng.clone(),
+        let commitment_txid = self
+            .join_batches_chunked(
+                rng,
                 &server_info,
-                boarding_inputs.clone(),
-                all_vtxo_inputs.clone(),
-                BatchOutputType::Board {
-                    to_address,
-                    to_amount: total_amount,
-                },
+                boarding_inputs,
+                all_vtxo_inputs,
+                to_address,
             )
-            .await
-        };
-
-        let commitment_txid = join_next_batch
-            .retry(ExponentialBuilder::default().with_max_times(0))
-            .sleep(sleep)
-            .when(|err| !err.is_server_info_changed())
-            .notify(|err: &Error, dur: std::time::Duration| {
-                tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
-            })
-            .await
-            .context("Failed to join batch")?;
+            .await?;
 
         tracing::info!(%commitment_txid, num_notes = notes.len(), "Settlement with notes success");
 
@@ -315,34 +280,96 @@ where
             return Ok(None);
         }
 
-        let join_next_batch = || async {
-            self.join_next_batch(
-                &mut rng.clone(),
-                server_info,
-                boarding_inputs.clone(),
-                vtxo_inputs.clone(),
-                BatchOutputType::Board {
-                    to_address,
-                    to_amount: total_amount,
-                },
-            )
-            .await
-        };
-
-        // Joining a batch can fail depending on the timing, so we try a few times.
-        let commitment_txid = join_next_batch
-            .retry(ExponentialBuilder::default().with_max_times(0))
-            .sleep(sleep)
-            .when(|err| !err.is_server_info_changed())
-            .notify(|err: &Error, dur: std::time::Duration| {
-                tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}",);
-            })
-            .await
-            .context("Failed to join batch")?;
+        let commitment_txid = self
+            .join_batches_chunked(rng, server_info, boarding_inputs, vtxo_inputs, to_address)
+            .await?;
 
         tracing::info!(%commitment_txid, "Settlement of specific VTXOs success");
 
         Ok(Some(commitment_txid))
+    }
+
+    /// Settle the given inputs into `to_address`, splitting them across multiple sequential
+    /// batches if a single intent proof would exceed the proof weight limit.
+    ///
+    /// Returns the commitment transaction ID of the last batch joined.
+    async fn join_batches_chunked<R>(
+        &self,
+        rng: &mut R,
+        server_info: &server::Info,
+        boarding_inputs: Vec<batch::OnChainInput>,
+        vtxo_inputs: Vec<intent::Input>,
+        to_address: ArkAddress,
+    ) -> Result<Txid, Error>
+    where
+        R: Rng + CryptoRng + Clone,
+    {
+        let chunks = match self.max_intent_proof_weight(server_info) {
+            Some(max_weight) => {
+                chunk_settlement_inputs(boarding_inputs, vtxo_inputs, &to_address, max_weight)?
+            }
+            None => {
+                let mut chunk = SettlementChunk::new();
+                for input in boarding_inputs {
+                    chunk.push(SettlementInput::Onchain(input));
+                }
+                for input in vtxo_inputs {
+                    chunk.push(SettlementInput::Vtxo(input));
+                }
+                vec![chunk]
+            }
+        };
+
+        let n_chunks = chunks.len();
+        if n_chunks > 1 {
+            tracing::info!(
+                n_chunks,
+                "Settlement inputs exceed the intent proof weight limit; \
+                 splitting settlement across multiple batches"
+            );
+        }
+
+        let mut commitment_txid = None;
+
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            let join_next_batch = || async {
+                self.join_next_batch(
+                    &mut rng.clone(),
+                    server_info,
+                    chunk.onchain_inputs.clone(),
+                    chunk.vtxo_inputs.clone(),
+                    BatchOutputType::Board {
+                        to_address,
+                        to_amount: chunk.total_amount,
+                    },
+                )
+                .await
+            };
+
+            // Joining a batch can fail depending on the timing, so we try a few times.
+            let txid = join_next_batch
+                .retry(ExponentialBuilder::default().with_max_times(0))
+                .sleep(sleep)
+                .when(|err| !err.is_server_info_changed() && !err.is_intent_proof_too_large())
+                .notify(|err: &Error, dur: std::time::Duration| {
+                    tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}",);
+                })
+                .await
+                .context("Failed to join batch")?;
+
+            if n_chunks > 1 {
+                tracing::info!(
+                    commitment_txid = %txid,
+                    chunk = i + 1,
+                    n_chunks,
+                    "Settled batch chunk"
+                );
+            }
+
+            commitment_txid = Some(txid);
+        }
+
+        commitment_txid.ok_or_else(|| Error::ad_hoc("no settlement chunks to join"))
     }
 
     /// Settle _some_ prior VTXOs and boarding outputs into the next batch, generating UTXOs as
@@ -409,7 +436,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(3))
             .sleep(sleep)
-            .when(|err| !err.is_server_info_changed())
+            .when(|err| !err.is_server_info_changed() && !err.is_intent_proof_too_large())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
             })
@@ -494,7 +521,7 @@ where
         let commitment_txid = join_next_batch
             .retry(ExponentialBuilder::default().with_max_times(3))
             .sleep(sleep)
-            .when(|err| !err.is_server_info_changed())
+            .when(|err| !err.is_server_info_changed() && !err.is_intent_proof_too_large())
             .notify(|err: &Error, dur: std::time::Duration| {
                 tracing::warn!("Retrying joining next batch after {dur:?}. Error: {err}");
             })
@@ -1257,28 +1284,7 @@ where
 
         let vtxo_input_outpoints = vtxo_inputs.iter().map(|i| i.outpoint()).collect::<Vec<_>>();
 
-        let inputs = {
-            let boarding_inputs = onchain_inputs.clone().into_iter().map(|o| {
-                intent::Input::new(
-                    o.outpoint(),
-                    o.sequence(),
-                    None,
-                    TxOut {
-                        value: o.amount(),
-                        script_pubkey: o.script_pubkey().clone(),
-                    },
-                    o.tapscripts().to_vec(),
-                    o.spend_info().clone(),
-                    true,
-                    false,
-                    Vec::new(),
-                )
-            });
-
-            boarding_inputs
-                .chain(vtxo_inputs.clone())
-                .collect::<Vec<_>>()
-        };
+        let inputs = combined_intent_inputs(&onchain_inputs, &vtxo_inputs);
 
         let mut outputs = vec![];
 
@@ -1434,6 +1440,20 @@ where
         })
     }
 
+    /// The effective upper bound for the weight of an intent proof, if any: the server's
+    /// advertised `max_tx_weight`, further capped by the configured `max_intent_proof_weight`.
+    fn max_intent_proof_weight(&self, server_info: &server::Info) -> Option<u64> {
+        let server_max = u64::try_from(server_info.max_tx_weight)
+            .ok()
+            .filter(|w| *w > 0);
+
+        match (server_max, self.inner.max_intent_proof_weight) {
+            (Some(server), Some(config)) => Some(server.min(config)),
+            (Some(server), None) => Some(server),
+            (None, config) => config,
+        }
+    }
+
     pub(crate) async fn join_next_batch<R>(
         &self,
         rng: &mut R,
@@ -1462,6 +1482,17 @@ where
             onchain_inputs,
             vtxo_inputs,
         } = prepared;
+
+        // Fail fast if the server would reject the intent proof for being too heavy: retrying
+        // with the same inputs can never succeed.
+        if let Some(max_weight) = self.max_intent_proof_weight(server_info) {
+            let inputs = combined_intent_inputs(&onchain_inputs, &vtxo_inputs);
+            let weight = intent::estimate_proof_weight(&inputs, &outputs)?.to_wu();
+
+            if weight > max_weight {
+                return Err(Error::intent_proof_too_large(weight, max_weight));
+            }
+        }
 
         let onchain_input_outpoints = onchain_inputs
             .iter()
@@ -1980,6 +2011,177 @@ pub(crate) enum BatchOutputType {
         change_address: ArkAddress,
         change_amount: Amount,
     },
+}
+
+/// Combine boarding outputs and VTXOs into the flat input list used to build an intent proof,
+/// mirroring the conversion done when registering the intent.
+fn combined_intent_inputs(
+    onchain_inputs: &[batch::OnChainInput],
+    vtxo_inputs: &[intent::Input],
+) -> Vec<intent::Input> {
+    onchain_inputs
+        .iter()
+        .map(|o| {
+            intent::Input::new(
+                o.outpoint(),
+                o.sequence(),
+                None,
+                TxOut {
+                    value: o.amount(),
+                    script_pubkey: o.script_pubkey().clone(),
+                },
+                o.tapscripts().to_vec(),
+                o.spend_info().clone(),
+                true,
+                false,
+                Vec::new(),
+            )
+        })
+        .chain(vtxo_inputs.iter().cloned())
+        .collect()
+}
+
+/// Estimate the weight of the intent proof for settling the given inputs into a single offchain
+/// VTXO at `to_address`.
+fn estimate_settlement_proof_weight(
+    onchain_inputs: &[batch::OnChainInput],
+    vtxo_inputs: &[intent::Input],
+    to_address: &ArkAddress,
+) -> Result<u64, Error> {
+    let inputs = combined_intent_inputs(onchain_inputs, vtxo_inputs);
+
+    let total_amount = inputs
+        .iter()
+        .fold(Amount::ZERO, |acc, input| acc + input.amount());
+
+    let mut outputs = vec![intent::Output::Offchain(TxOut {
+        value: total_amount,
+        script_pubkey: to_address.to_p2tr_script_pubkey(),
+    })];
+
+    if let Some(packet) = create_asset_preservation_packet(&inputs, &outputs)? {
+        outputs.push(intent::Output::AssetPacket(packet.to_txout()));
+    }
+
+    let weight = intent::estimate_proof_weight(&inputs, &outputs)?;
+
+    Ok(weight.to_wu())
+}
+
+/// A subset of settlement inputs whose intent proof fits under the proof weight limit.
+struct SettlementChunk {
+    onchain_inputs: Vec<batch::OnChainInput>,
+    vtxo_inputs: Vec<intent::Input>,
+    total_amount: Amount,
+}
+
+impl SettlementChunk {
+    fn new() -> Self {
+        Self {
+            onchain_inputs: Vec::new(),
+            vtxo_inputs: Vec::new(),
+            total_amount: Amount::ZERO,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.onchain_inputs.is_empty() && self.vtxo_inputs.is_empty()
+    }
+
+    fn push(&mut self, input: SettlementInput) {
+        match input {
+            SettlementInput::Onchain(input) => {
+                self.total_amount += input.amount();
+                self.onchain_inputs.push(input);
+            }
+            SettlementInput::Vtxo(input) => {
+                self.total_amount += input.amount();
+                self.vtxo_inputs.push(input);
+            }
+        }
+    }
+
+    fn pop(&mut self, input_was_onchain: bool) -> SettlementInput {
+        if input_was_onchain {
+            let input = self.onchain_inputs.pop().expect("just pushed");
+            self.total_amount -= input.amount();
+            SettlementInput::Onchain(input)
+        } else {
+            let input = self.vtxo_inputs.pop().expect("just pushed");
+            self.total_amount -= input.amount();
+            SettlementInput::Vtxo(input)
+        }
+    }
+}
+
+enum SettlementInput {
+    Onchain(batch::OnChainInput),
+    Vtxo(intent::Input),
+}
+
+impl SettlementInput {
+    fn is_onchain(&self) -> bool {
+        matches!(self, SettlementInput::Onchain(_))
+    }
+}
+
+/// Split settlement inputs into chunks whose intent proofs each fit under `max_weight` weight
+/// units, preserving input order (boarding outputs first, then VTXOs).
+///
+/// Returns an error if a single input on its own already exceeds the limit.
+fn chunk_settlement_inputs(
+    onchain_inputs: Vec<batch::OnChainInput>,
+    vtxo_inputs: Vec<intent::Input>,
+    to_address: &ArkAddress,
+    max_weight: u64,
+) -> Result<Vec<SettlementChunk>, Error> {
+    let inputs = onchain_inputs
+        .into_iter()
+        .map(SettlementInput::Onchain)
+        .chain(vtxo_inputs.into_iter().map(SettlementInput::Vtxo));
+
+    let mut chunks = Vec::new();
+    let mut current = SettlementChunk::new();
+
+    for input in inputs {
+        let is_onchain = input.is_onchain();
+
+        current.push(input);
+
+        let weight = estimate_settlement_proof_weight(
+            &current.onchain_inputs,
+            &current.vtxo_inputs,
+            to_address,
+        )?;
+
+        if weight > max_weight {
+            let input = current.pop(is_onchain);
+
+            if current.is_empty() {
+                // A single input already busts the limit; splitting cannot help.
+                return Err(Error::intent_proof_too_large(weight, max_weight));
+            }
+
+            chunks.push(std::mem::replace(&mut current, SettlementChunk::new()));
+
+            current.push(input);
+
+            let weight = estimate_settlement_proof_weight(
+                &current.onchain_inputs,
+                &current.vtxo_inputs,
+                to_address,
+            )?;
+            if weight > max_weight {
+                return Err(Error::intent_proof_too_large(weight, max_weight));
+            }
+        }
+    }
+
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+
+    Ok(chunks)
 }
 
 /// Prepared intent data ready for batch registration.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -642,6 +642,16 @@ where
             outputs.push(intent::Output::AssetPacket(packet.to_txout()));
         }
 
+        // A delegate is a single pre-signed intent, so it cannot be chunked at settlement time.
+        // Reject an oversized intent now, while the owner can still act on it.
+        if let Some(max_weight) = self.max_intent_proof_weight(&server_info) {
+            let weight = intent::estimate_proof_weight(&vtxo_inputs, &outputs)?.to_wu();
+
+            if weight > max_weight {
+                return Err(Error::intent_proof_too_large(weight, max_weight));
+            }
+        }
+
         let delegate = batch::prepare_delegate_psbts(
             vtxo_inputs,
             outputs,
@@ -691,6 +701,9 @@ where
     ///
     /// This method allows Bob to settle Alice's VTXOs using the pre-signed intent and forfeit
     /// transactions from the [`Delegate`] struct.
+    ///
+    /// NOTE: the intent is pre-signed, so its proof weight cannot be checked or chunked here; it
+    /// is validated against the server's proof weight limit in [`Self::generate_delegate`].
     ///
     /// # Arguments
     ///

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -305,9 +305,13 @@ where
         R: Rng + CryptoRng + Clone,
     {
         let chunks = match self.max_intent_proof_weight(server_info) {
-            Some(max_weight) => {
-                chunk_settlement_inputs(boarding_inputs, vtxo_inputs, &to_address, max_weight)?
-            }
+            Some(max_weight) => chunk_settlement_inputs(
+                boarding_inputs,
+                vtxo_inputs,
+                &to_address,
+                max_weight,
+                server_info.dust,
+            )?,
             None => {
                 let mut chunk = SettlementChunk::new();
                 for input in boarding_inputs {
@@ -2112,6 +2116,45 @@ impl SettlementChunk {
             SettlementInput::Vtxo(input)
         }
     }
+
+    /// All inputs in this chunk as `(is_onchain, index, amount)`.
+    fn input_amounts(&self) -> Vec<(bool, usize, Amount)> {
+        self.onchain_inputs
+            .iter()
+            .enumerate()
+            .map(|(i, input)| (true, i, input.amount()))
+            .chain(
+                self.vtxo_inputs
+                    .iter()
+                    .enumerate()
+                    .map(|(i, input)| (false, i, input.amount())),
+            )
+            .collect()
+    }
+
+    fn remove(&mut self, is_onchain: bool, index: usize) -> SettlementInput {
+        if is_onchain {
+            let input = self.onchain_inputs.remove(index);
+            self.total_amount -= input.amount();
+            SettlementInput::Onchain(input)
+        } else {
+            let input = self.vtxo_inputs.remove(index);
+            self.total_amount -= input.amount();
+            SettlementInput::Vtxo(input)
+        }
+    }
+
+    fn clone_input(&self, is_onchain: bool, index: usize) -> SettlementInput {
+        if is_onchain {
+            SettlementInput::Onchain(self.onchain_inputs[index].clone())
+        } else {
+            SettlementInput::Vtxo(self.vtxo_inputs[index].clone())
+        }
+    }
+
+    fn estimate_proof_weight(&self, to_address: &ArkAddress) -> Result<u64, Error> {
+        estimate_settlement_proof_weight(&self.onchain_inputs, &self.vtxo_inputs, to_address)
+    }
 }
 
 enum SettlementInput {
@@ -2128,12 +2171,19 @@ impl SettlementInput {
 /// Split settlement inputs into chunks whose intent proofs each fit under `max_weight` weight
 /// units, preserving input order (boarding outputs first, then VTXOs).
 ///
-/// Returns an error if a single input on its own already exceeds the limit.
+/// Every chunk settles into its own offchain VTXO of the chunk's total amount, so each chunk
+/// must also clear the `dust` threshold; chunks that fall short are topped up by moving inputs
+/// over from other chunks.
+///
+/// Returns an error if a single input on its own already exceeds the limit, or if the chunks
+/// cannot be balanced to clear the dust threshold. Errors surface before any batch is joined, so
+/// a settlement never fails halfway through its chunks.
 fn chunk_settlement_inputs(
     onchain_inputs: Vec<batch::OnChainInput>,
     vtxo_inputs: Vec<intent::Input>,
     to_address: &ArkAddress,
     max_weight: u64,
+    dust: Amount,
 ) -> Result<Vec<SettlementChunk>, Error> {
     let inputs = onchain_inputs
         .into_iter()
@@ -2148,11 +2198,7 @@ fn chunk_settlement_inputs(
 
         current.push(input);
 
-        let weight = estimate_settlement_proof_weight(
-            &current.onchain_inputs,
-            &current.vtxo_inputs,
-            to_address,
-        )?;
+        let weight = current.estimate_proof_weight(to_address)?;
 
         if weight > max_weight {
             let input = current.pop(is_onchain);
@@ -2166,11 +2212,7 @@ fn chunk_settlement_inputs(
 
             current.push(input);
 
-            let weight = estimate_settlement_proof_weight(
-                &current.onchain_inputs,
-                &current.vtxo_inputs,
-                to_address,
-            )?;
+            let weight = current.estimate_proof_weight(to_address)?;
             if weight > max_weight {
                 return Err(Error::intent_proof_too_large(weight, max_weight));
             }
@@ -2181,7 +2223,96 @@ fn chunk_settlement_inputs(
         chunks.push(current);
     }
 
+    rebalance_sub_dust_chunks(&mut chunks, to_address, max_weight, dust)?;
+
     Ok(chunks)
+}
+
+/// Top up chunks whose total amount is below the dust threshold by moving inputs over from
+/// other chunks, without pushing any chunk's intent proof over `max_weight`.
+///
+/// Before chunking existed, small recoverable VTXOs were always carried by larger inputs into a
+/// single above-dust output; this preserves that behavior across chunk boundaries.
+///
+/// A lone chunk is left untouched: its sub-dust failure mode predates chunking and is reported
+/// by `prepare_intent` ("cannot settle into sub-dust VTXO").
+fn rebalance_sub_dust_chunks(
+    chunks: &mut Vec<SettlementChunk>,
+    to_address: &ArkAddress,
+    max_weight: u64,
+    dust: Amount,
+) -> Result<(), Error> {
+    if chunks.len() <= 1 {
+        return Ok(());
+    }
+
+    for receiver in 0..chunks.len() {
+        while !chunks[receiver].is_empty() && chunks[receiver].total_amount < dust {
+            if !move_input_into_chunk(chunks, receiver, to_address, max_weight, dust)? {
+                let amount = chunks[receiver].total_amount;
+                return Err(Error::ad_hoc(format!(
+                    "cannot balance settlement chunks: chunk amount {amount} is below the dust \
+                     threshold {dust} and no input can be moved into it without exceeding the \
+                     proof weight limit {max_weight}"
+                )));
+            }
+        }
+    }
+
+    // Donors may have been drained empty; drop them.
+    chunks.retain(|chunk| !chunk.is_empty());
+
+    Ok(())
+}
+
+/// Move a single input from some other chunk into `chunks[receiver]`, keeping every donor either
+/// empty or above the dust threshold and the receiver's proof under `max_weight`.
+///
+/// Returns `false` if no input can be moved.
+fn move_input_into_chunk(
+    chunks: &mut [SettlementChunk],
+    receiver: usize,
+    to_address: &ArkAddress,
+    max_weight: u64,
+    dust: Amount,
+) -> Result<bool, Error> {
+    // Prefer donating from the richest chunk, and prefer big inputs, so the receiver clears the
+    // dust threshold in as few moves as possible.
+    let mut donors: Vec<usize> = (0..chunks.len()).filter(|i| *i != receiver).collect();
+    donors.sort_by_key(|i| std::cmp::Reverse(chunks[*i].total_amount));
+
+    for donor in donors {
+        let mut candidates = chunks[donor].input_amounts();
+        candidates.sort_by_key(|(_, _, amount)| std::cmp::Reverse(*amount));
+
+        for (is_onchain, index, amount) in candidates {
+            // The donor must stay settleable: either it keeps an above-dust total or it is
+            // drained completely.
+            let donor_remaining = chunks[donor].total_amount - amount;
+            let donor_drained = donor_remaining == Amount::ZERO;
+            if donor_remaining < dust && !donor_drained {
+                continue;
+            }
+
+            // Simulate the move with a clone first, so a rejected candidate leaves the donor
+            // untouched and the remaining candidate indices valid.
+            let candidate = chunks[donor].clone_input(is_onchain, index);
+            chunks[receiver].push(candidate);
+            let over_weight = chunks[receiver].estimate_proof_weight(to_address)? > max_weight;
+            chunks[receiver].pop(is_onchain);
+
+            if over_weight {
+                continue;
+            }
+
+            let input = chunks[donor].remove(is_onchain, index);
+            chunks[receiver].push(input);
+
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// Prepared intent data ready for batch registration.

--- a/ark-client/src/batch.rs
+++ b/ark-client/src/batch.rs
@@ -348,7 +348,7 @@ where
 
             // Joining a batch can fail depending on the timing, so we try a few times.
             let txid = join_next_batch
-                .retry(ExponentialBuilder::default().with_max_times(0))
+                .retry(ExponentialBuilder::default().with_max_times(3))
                 .sleep(sleep)
                 .when(|err| !err.is_server_info_changed() && !err.is_intent_proof_too_large())
                 .notify(|err: &Error, dur: std::time::Duration| {

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -30,6 +30,9 @@ enum Kind {
     ServerInfoChanged(ServerInfoChangedError),
     /// An error thrown by a user of this library
     Consumer(ConsumerError),
+    /// The intent proof for a batch registration would exceed the server's maximum transaction
+    /// weight.
+    IntentProofTooLarge(IntentProofTooLargeError),
 }
 
 #[derive(Debug)]
@@ -63,6 +66,12 @@ struct ServerInfoChangedError;
 #[derive(Debug)]
 struct ConsumerError {
     source: Source,
+}
+
+#[derive(Debug)]
+struct IntentProofTooLargeError {
+    weight: u64,
+    max_weight: u64,
 }
 
 impl Error {
@@ -102,6 +111,13 @@ impl Error {
         }))
     }
 
+    pub(crate) fn intent_proof_too_large(weight: u64, max_weight: u64) -> Self {
+        Error::new(Kind::IntentProofTooLarge(IntentProofTooLargeError {
+            weight,
+            max_weight,
+        }))
+    }
+
     pub(crate) fn server_info_changed(source: impl Into<Error>) -> Self {
         source
             .into()
@@ -112,6 +128,22 @@ impl Error {
         let mut err = self;
         loop {
             if matches!(err.inner.kind, Kind::ServerInfoChanged(_)) {
+                return true;
+            }
+            err = match err.inner.cause.as_ref() {
+                Some(err) => err,
+                None => return false,
+            };
+        }
+    }
+
+    /// Returns `true` if this error chain contains an intent proof that exceeds the server's
+    /// maximum transaction weight. Retrying with the same inputs can never succeed; the
+    /// settlement must be split across fewer inputs.
+    pub fn is_intent_proof_too_large(&self) -> bool {
+        let mut err = self;
+        loop {
+            if matches!(err.inner.kind, Kind::IntentProofTooLarge(_)) {
                 return true;
             }
             err = match err.inner.cause.as_ref() {
@@ -151,7 +183,8 @@ impl Kind {
             | Kind::CoinSelect(_)
             | Kind::Wallet(_)
             | Kind::ServerInfoChanged(_)
-            | Kind::Consumer(_) => false,
+            | Kind::Consumer(_)
+            | Kind::IntentProofTooLarge(_) => false,
         }
     }
 }
@@ -181,7 +214,18 @@ impl fmt::Display for Kind {
             Kind::Wallet(ref err) => err.fmt(f),
             Kind::ServerInfoChanged(ref err) => err.fmt(f),
             Kind::Consumer(ref err) => err.fmt(f),
+            Kind::IntentProofTooLarge(ref err) => err.fmt(f),
         }
+    }
+}
+
+impl fmt::Display for IntentProofTooLargeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "intent proof weight {} exceeds the server's maximum transaction weight {}. Settle fewer inputs per batch",
+            self.weight, self.max_weight
+        )
     }
 }
 

--- a/ark-client/src/error.rs
+++ b/ark-client/src/error.rs
@@ -223,7 +223,7 @@ impl fmt::Display for IntentProofTooLargeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "intent proof weight {} exceeds the server's maximum transaction weight {}. Settle fewer inputs per batch",
+            "intent proof weight {} WU exceeds the server's maximum transaction weight {} WU. Settle fewer inputs per batch",
             self.weight, self.max_weight
         )
     }

--- a/ark-client/src/lib.rs
+++ b/ark-client/src/lib.rs
@@ -273,6 +273,12 @@ pub struct OfflineClientConfig {
     pub boltz_referral_id: BoltzReferralId,
     pub delegator_pk: Option<XOnlyPublicKey>,
     pub historical_delegator_pks: Vec<XOnlyPublicKey>,
+    /// Upper bound on the weight of the intent proof transaction used when joining a batch.
+    ///
+    /// Settlements whose proof would exceed this bound are split across multiple sequential
+    /// batches. The effective bound is the minimum of this value and the server's advertised
+    /// `max_tx_weight`; leave as `None` (the default) to just use the server's limit.
+    pub max_intent_proof_weight: Option<u64>,
 }
 
 impl Default for OfflineClientConfig {
@@ -285,6 +291,7 @@ impl Default for OfflineClientConfig {
             boltz_referral_id: BoltzReferralId::default(),
             delegator_pk: None,
             historical_delegator_pks: Vec::new(),
+            max_intent_proof_weight: None,
         }
     }
 }
@@ -457,6 +464,7 @@ pub struct OfflineClient<B, W, S> {
     contract_store: Arc<Mutex<Option<Box<dyn ContractStore>>>>,
     delegator_pk: Option<XOnlyPublicKey>,
     historical_delegator_pks: Vec<XOnlyPublicKey>,
+    max_intent_proof_weight: Option<u64>,
 }
 
 /// A client to interact with Ark server
@@ -729,6 +737,7 @@ where
             contract_store: Arc::new(Mutex::new(None)),
             delegator_pk: config.delegator_pk,
             historical_delegator_pks,
+            max_intent_proof_weight: config.max_intent_proof_weight,
         }
     }
 

--- a/ark-core/src/intent.rs
+++ b/ark-core/src/intent.rs
@@ -1,4 +1,5 @@
 use crate::contract::SpendSelection;
+use crate::script::extract_checksig_pubkeys;
 use crate::Asset;
 use crate::Error;
 use crate::ErrorContext;
@@ -30,6 +31,7 @@ use bitcoin::Transaction;
 use bitcoin::TxIn;
 use bitcoin::TxOut;
 use bitcoin::Txid;
+use bitcoin::Weight;
 use bitcoin::Witness;
 use bitcoin::XOnlyPublicKey;
 use serde::Deserialize;
@@ -316,6 +318,58 @@ where
         proof: proof_psbt,
         message,
     })
+}
+
+/// Estimate the weight of the finalized BIP322 proof transaction for an intent with the given
+/// inputs and outputs.
+///
+/// The Ark server rejects intents whose finalized proof exceeds its `max_tx_weight` setting
+/// (`TX_TOO_LARGE`). It measures the weight by finalizing the proof PSBT after inserting a fake
+/// 64-byte signature for every one of its own signer keys, producing a witness per input of one
+/// signature per `CHECKSIG`/`CHECKSIGVERIFY` pubkey in the selected leaf script, any condition
+/// witness elements, the leaf script, and the control block. We mirror that construction here
+/// with dummy signatures, so the estimate matches the weight the server computes.
+pub fn estimate_proof_weight(inputs: &[Input], outputs: &[Output]) -> Result<Weight, Error> {
+    // The message contents do not affect the weight of the proof transaction: the message is
+    // only committed to via the `to_spend` transaction referenced by the fake first input.
+    let message = IntentMessage::Register {
+        onchain_output_indexes: Vec::new(),
+        valid_at: 0,
+        expire_at: 0,
+        own_cosigner_pks: Vec::new(),
+    };
+
+    let (proof_psbt, _) = build_proof_psbt(&message, inputs, outputs)?;
+
+    let mut tx = proof_psbt.unsigned_tx;
+
+    for (i, tx_in) in tx.input.iter_mut().enumerate() {
+        // The fake first input spends an output locked by the same script as the first real
+        // input, and the server copies the first real input's condition witness onto it before
+        // finalizing.
+        let input = if i == 0 { &inputs[0] } else { &inputs[i - 1] };
+
+        let (script, control_block) = &input.spend_info;
+
+        let mut witness = Witness::new();
+
+        for _ in extract_checksig_pubkeys(script) {
+            witness.push([0u8; 64]);
+        }
+
+        if let Some(extra_witness) = input.extra_witness() {
+            for element in extra_witness {
+                witness.push(element);
+            }
+        }
+
+        witness.push(script.as_bytes());
+        witness.push(control_block.serialize());
+
+        tx_in.witness = witness;
+    }
+
+    Ok(tx.weight())
 }
 
 pub(crate) fn build_proof_psbt(

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -502,6 +502,14 @@ pub async fn set_up_client(
     regtest: Arc<Regtest>,
     secp: Secp256k1<All>,
 ) -> (Client<Regtest, Wallet, InMemorySwapStorage>, Arc<Wallet>) {
+    set_up_client_inner(regtest, secp, None).await
+}
+
+async fn set_up_client_inner(
+    regtest: Arc<Regtest>,
+    secp: Secp256k1<All>,
+    max_intent_proof_weight: Option<u64>,
+) -> (Client<Regtest, Wallet, InMemorySwapStorage>, Arc<Wallet>) {
     let mut rng = thread_rng();
 
     let sk = SecretKey::new(&mut rng);
@@ -519,6 +527,7 @@ pub async fn set_up_client(
         OfflineClientConfig {
             ark_server_url: "http://localhost:7070".to_string(),
             boltz_url: "http://localhost:9069".to_string(),
+            max_intent_proof_weight,
             ..Default::default()
         },
         xpriv,
@@ -543,37 +552,7 @@ pub async fn set_up_client_with_max_proof_weight(
     secp: Secp256k1<All>,
     max_intent_proof_weight: u64,
 ) -> (Client<Regtest, Wallet, InMemorySwapStorage>, Arc<Wallet>) {
-    let mut rng = thread_rng();
-
-    let sk = SecretKey::new(&mut rng);
-    let kp = Keypair::from_secret_key(&secp, &sk);
-
-    let network = Network::Regtest;
-
-    let wallet = Wallet::new(kp, network, "http://localhost:3000/api").unwrap();
-    let wallet = Arc::new(wallet);
-
-    let seed: [u8; 32] = rng.r#gen();
-    let xpriv = Xpriv::new_master(network, &seed).unwrap();
-
-    let client = OfflineClient::with_bip32(
-        OfflineClientConfig {
-            ark_server_url: "http://localhost:7070".to_string(),
-            boltz_url: "http://localhost:9069".to_string(),
-            max_intent_proof_weight: Some(max_intent_proof_weight),
-            ..Default::default()
-        },
-        xpriv,
-        None,
-        regtest,
-        wallet.clone(),
-        Arc::new(InMemorySwapStorage::default()),
-    )
-    .connect_with_retries(5)
-    .await
-    .unwrap();
-
-    (client, wallet)
+    set_up_client_inner(regtest, secp, Some(max_intent_proof_weight)).await
 }
 
 #[allow(unused)]

--- a/e2e-tests/tests/common.rs
+++ b/e2e-tests/tests/common.rs
@@ -534,6 +534,48 @@ pub async fn set_up_client(
     (client, wallet)
 }
 
+/// Set up a client with a cap on the intent proof weight, forcing settlements with many inputs
+/// to be split across multiple batches.
+#[allow(unused)]
+pub async fn set_up_client_with_max_proof_weight(
+    _name: String,
+    regtest: Arc<Regtest>,
+    secp: Secp256k1<All>,
+    max_intent_proof_weight: u64,
+) -> (Client<Regtest, Wallet, InMemorySwapStorage>, Arc<Wallet>) {
+    let mut rng = thread_rng();
+
+    let sk = SecretKey::new(&mut rng);
+    let kp = Keypair::from_secret_key(&secp, &sk);
+
+    let network = Network::Regtest;
+
+    let wallet = Wallet::new(kp, network, "http://localhost:3000/api").unwrap();
+    let wallet = Arc::new(wallet);
+
+    let seed: [u8; 32] = rng.r#gen();
+    let xpriv = Xpriv::new_master(network, &seed).unwrap();
+
+    let client = OfflineClient::with_bip32(
+        OfflineClientConfig {
+            ark_server_url: "http://localhost:7070".to_string(),
+            boltz_url: "http://localhost:9069".to_string(),
+            max_intent_proof_weight: Some(max_intent_proof_weight),
+            ..Default::default()
+        },
+        xpriv,
+        None,
+        regtest,
+        wallet.clone(),
+        Arc::new(InMemorySwapStorage::default()),
+    )
+    .connect_with_retries(5)
+    .await
+    .unwrap();
+
+    (client, wallet)
+}
+
 #[allow(unused)]
 pub async fn set_up_client_with_delegator(
     _name: String,

--- a/e2e-tests/tests/e2e_chunked_settlement.rs
+++ b/e2e-tests/tests/e2e_chunked_settlement.rs
@@ -1,0 +1,103 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::common::wait_until_balance;
+use ark_core::send::SendReceiver;
+use bitcoin::key::Secp256k1;
+use bitcoin::Amount;
+use common::init_tracing;
+use common::set_up_client;
+use common::set_up_client_with_max_proof_weight;
+use common::Regtest;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::sync::Arc;
+use std::time::Duration;
+
+mod common;
+
+/// A settlement whose intent proof would exceed the proof weight limit must be split across
+/// multiple sequential batches instead of being rejected by the server with `TX_TOO_LARGE`.
+///
+/// Bob's client is configured with a proof weight cap far below the server's `max_tx_weight`, so
+/// a handful of VTXOs is enough to force chunking. Against a default server, the equivalent
+/// scenario is a wallet with a few hundred VTXOs.
+#[tokio::test]
+#[ignore]
+pub async fn settlement_is_chunked_when_proof_weight_exceeds_limit() {
+    init_tracing();
+    let regtest = Arc::new(Regtest::new());
+
+    let secp = Secp256k1::new();
+
+    let (alice, _) = set_up_client("alice".to_string(), regtest.clone(), secp.clone()).await;
+
+    // Low enough that ~4-6 VTXO inputs fill a chunk, but comfortably above the weight of a
+    // single-input proof (~1,100 WU).
+    let max_proof_weight = 3_000;
+    let (bob, _) = set_up_client_with_max_proof_weight(
+        "bob".to_string(),
+        regtest.clone(),
+        secp.clone(),
+        max_proof_weight,
+    )
+    .await;
+
+    let alice_boarding_address = alice.get_boarding_address().await.unwrap();
+    let alice_fund_amount = Amount::ONE_BTC;
+
+    regtest
+        .faucet_fund(&alice_boarding_address, alice_fund_amount)
+        .await;
+
+    let mut rng = StdRng::from_entropy();
+
+    alice.settle(&mut rng).await.unwrap();
+    wait_until_balance!(&alice, confirmed: alice_fund_amount, pre_confirmed: Amount::ZERO);
+
+    // Fragment Bob's wallet into many small VTXOs.
+    let (bob_offchain_address, _) = bob.get_offchain_address().await.unwrap();
+
+    let n_payments = 8;
+    let payment_amount = Amount::from_sat(100_000);
+
+    for _ in 0..n_payments {
+        alice
+            .send(vec![SendReceiver::bitcoin(
+                bob_offchain_address,
+                payment_amount,
+            )])
+            .await
+            .unwrap();
+
+        // FIXME: We should not need to sleep here. We were running into an error when finalising
+        // the offchain transaction: the virtual TXID could not be found in the DB.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    let bob_total = payment_amount * n_payments;
+    wait_until_balance!(&bob, pre_confirmed: bob_total);
+
+    let bob_vtxos = bob.list_vtxos().await.unwrap();
+    assert_eq!(bob_vtxos.pre_confirmed().count(), n_payments as usize);
+
+    // Settling all of Bob's VTXOs at once would exceed the configured proof weight limit, so the
+    // client must split the settlement across multiple batches.
+    let commitment_txid = bob.settle_all(&mut rng).await.unwrap();
+    assert!(commitment_txid.is_some());
+
+    wait_until_balance!(&bob, confirmed: bob_total, pre_confirmed: Amount::ZERO);
+
+    // Each chunk settles into its own confirmed VTXO, so more than one confirmed VTXO proves the
+    // settlement was actually chunked.
+    let bob_vtxos = bob.list_vtxos().await.unwrap();
+    let n_confirmed = bob_vtxos.confirmed().count();
+    assert!(
+        n_confirmed > 1,
+        "expected settlement to be split into multiple batches, got {n_confirmed} confirmed VTXO(s)"
+    );
+
+    let confirmed_total = bob_vtxos
+        .confirmed()
+        .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.vtxo().amount);
+    assert_eq!(confirmed_total, bob_total);
+}

--- a/e2e-tests/tests/e2e_chunked_settlement.rs
+++ b/e2e-tests/tests/e2e_chunked_settlement.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::unwrap_used)]
 
 use crate::common::wait_until_balance;
+use ark_bdk_wallet::Wallet;
+use ark_client::Client;
+use ark_client::InMemorySwapStorage;
 use ark_core::send::SendReceiver;
 use bitcoin::key::Secp256k1;
 use bitcoin::Amount;
@@ -60,7 +63,7 @@ pub async fn settlement_is_chunked_when_proof_weight_exceeds_limit() {
     let n_payments = 8;
     let payment_amount = Amount::from_sat(100_000);
 
-    for _ in 0..n_payments {
+    for i in 0..n_payments {
         alice
             .send(vec![SendReceiver::bitcoin(
                 bob_offchain_address,
@@ -69,9 +72,10 @@ pub async fn settlement_is_chunked_when_proof_weight_exceeds_limit() {
             .await
             .unwrap();
 
-        // FIXME: We should not need to sleep here. We were running into an error when finalising
-        // the offchain transaction: the virtual TXID could not be found in the DB.
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        // Wait for the payment to land before sending the next one: sending again while the
+        // previous offchain transaction is still finalizing fails with "virtual TXID could not
+        // be found in the DB".
+        wait_until_pre_confirmed_vtxo_count(&bob, i as usize + 1).await;
     }
 
     let bob_total = payment_amount * n_payments;
@@ -100,4 +104,23 @@ pub async fn settlement_is_chunked_when_proof_weight_exceeds_limit() {
         .confirmed()
         .fold(Amount::ZERO, |acc, vtxo| acc + vtxo.vtxo().amount);
     assert_eq!(confirmed_total, bob_total);
+}
+
+/// Wait until the client's pre-confirmed VTXO count reaches `count`.
+async fn wait_until_pre_confirmed_vtxo_count(
+    client: &Client<Regtest, Wallet, InMemorySwapStorage>,
+    count: usize,
+) {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let vtxos = client.list_vtxos().await.unwrap();
+            if vtxos.pre_confirmed().count() >= count {
+                return;
+            }
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {count} pre-confirmed VTXOs"));
 }


### PR DESCRIPTION
The server rejects intent registrations whose finalized BIP322 proof exceeds its max_tx_weight (TX_TOO_LARGE). A wallet with enough VTXOs could never settle: the client retried the same over-sized intent forever.

- ark-core: estimate_proof_weight mirrors the server's proof finalization (fake 64-byte sig per CHECKSIG pubkey, condition witness, leaf script, control block) so the client can predict the weight the server computes.
- ark-client: board-type settle paths split inputs into chunks that fit under the limit and join one batch per chunk. The limit is the server's max_tx_weight, optionally capped via the new OfflineClientConfig::max_intent_proof_weight.
- join_next_batch fails fast with a dedicated non-retryable IntentProofTooLarge error instead of registering a doomed intent, and batch retry loops no longer retry on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large settlements are automatically split into multiple batches when proof limits are exceeded.
  * Added configurable maximum proof-weight limits and proof-weight estimation.
  * Added clear errors when an individual input exceeds the permitted limit.

* **Bug Fixes**
  * Prevented retries for non-recoverable oversized-proof errors.
  * Preserved input order across settlement batches.
  * Improved balance handling to minimize dust across batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->