### PR TITLE
docs: correct Arkade terminology and fix the docs.rs landing page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = ["cryptography::cryptocurrencies"]
 [workspace.lints.rust]
 unused-import-braces = "warn"
 unused-qualifications = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(genproto)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(genproto)', 'cfg(docsrs)'] }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ark-rs
 
-Rust crates for building Bitcoin wallets and applications that use the Arkade protocol.
+Rust crates for building Bitcoin wallets and applications with Arkade.
 
-This repository contains the Arkade Rust SDK: protocol types, transport clients, wallet integration, fee estimation, and development/test utilities.
+[![crates.io](https://img.shields.io/crates/v/ark-rs)](https://crates.io/crates/ark-rs)
+[![docs.rs](https://img.shields.io/docsrs/ark-rs)](https://docs.rs/ark-rs)
+
+This repository contains the Arkade Rust SDK: core types, transport clients, wallet integration, fee estimation, and development and test utilities.
 
 ## Crates
 
@@ -10,9 +13,9 @@ This repository contains the Arkade Rust SDK: protocol types, transport clients,
 | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
 | [`ark-rs`](./ark-rs)                                   | Convenience crate that re-exports the main SDK crates behind feature flags.                             |
 | [`ark-core`](./ark-core)                               | Core Arkade protocol types and transaction utilities.                                                   |
-| [`ark-client`](./ark-client)                           | High-level client library for interacting with Arkade servers.                                          |
-| [`ark-grpc`](./ark-grpc)                               | gRPC transport client for Arkade servers.                                                               |
-| [`ark-rest`](./ark-rest)                               | REST transport client for Arkade servers.                                                               |
+| [`ark-client`](./ark-client)                           | High-level client library for building Arkade wallets in Rust.                                          |
+| [`ark-grpc`](./ark-grpc)                               | gRPC transport client for the Arkade operator.                                                          |
+| [`ark-rest`](./ark-rest)                               | REST transport client for the Arkade operator.                                                          |
 | [`ark-bdk-wallet`](./ark-bdk-wallet)                   | [`bdk_wallet`](https://crates.io/crates/bdk_wallet)-based implementation of `ark-client` wallet traits. |
 | [`ark-fees`](./ark-fees)                               | CEL-based fee estimation library for Arkade transactions.                                               |
 | [`ark-delegator`](./ark-delegator)                     | REST client for Arkade delegator services.                                                              |
@@ -49,9 +52,9 @@ Optional `ark-rs` features:
 
 ## Examples and documentation
 
-- API documentation is published on [docs.rs](https://docs.rs/releases/search?query=ark-rs).
+- API documentation is published on [docs.rs/ark-rs](https://docs.rs/ark-rs).
 - The [`ark-client-sample`](./ark-client-sample) crate shows how to wire the client in a CLI application.
-- The [`e2e-tests`](./e2e-tests/tests) directory contains integration examples against a local Arkade server.
+- The [`e2e-tests`](./e2e-tests/tests) directory contains integration examples that run against a local operator.
 
 ## Development
 

--- a/ark-bdk-wallet/Cargo.toml
+++ b/ark-bdk-wallet/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "Implementation of ark-client on-chain wallet traits using bdk"
+description = "Implementation of the ark-client onchain wallet traits using bdk"
 
 [lints]
 workspace = true

--- a/ark-bdk-wallet/README.md
+++ b/ark-bdk-wallet/README.md
@@ -2,7 +2,7 @@
 
 BDK wallet integration for Arkade clients.
 
-This crate implements `ark-client` on-chain wallet traits using [`bdk_wallet`](https://crates.io/crates/bdk_wallet), with Esplora support on native and WebAssembly targets.
+This crate implements the onchain wallet traits of `ark-client` using [`bdk_wallet`](https://crates.io/crates/bdk_wallet), with Esplora support on native and WebAssembly targets.
 
 ## Install
 

--- a/ark-client/Cargo.toml
+++ b/ark-client/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "Main client library for interacting with Ark servers"
+description = "High-level client library for building Arkade wallets in Rust"
 
 [lints]
 workspace = true

--- a/ark-client/README.md
+++ b/ark-client/README.md
@@ -1,8 +1,8 @@
 # ark-client
 
-High-level client library for interacting with Arkade servers.
+High-level client library for building Arkade wallets in Rust.
 
-`ark-client` provides the main wallet/client abstractions for receiving, selecting, and sending VTXOs, boarding funds on-chain, estimating fees, watching VTXO state, and coordinating Arkade rounds through the supported transport clients.
+`ark-client` provides the wallet abstractions of the SDK. Use it to receive, select, and send virtual outputs, board funds from onchain, estimate fees, track the state of a virtual output, and join batch swaps through the operator. It talks to the operator through either supported transport client, `ark-grpc` or `ark-rest`.
 
 ## Install
 

--- a/ark-core/Cargo.toml
+++ b/ark-core/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "Core types and utilities for Ark"
+description = "Core Arkade types and transaction utilities"
 
 [lints]
 workspace = true

--- a/ark-delegator/Cargo.toml
+++ b/ark-delegator/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "REST client for Ark delegator services"
+description = "REST client for Arkade delegate services"
 
 [lints]
 workspace = true

--- a/ark-grpc/Cargo.toml
+++ b/ark-grpc/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "gRPC client for Ark server communication"
+description = "gRPC transport client for the Arkade operator"
 
 [lints]
 workspace = true

--- a/ark-grpc/README.md
+++ b/ark-grpc/README.md
@@ -1,6 +1,6 @@
 # ark-grpc
 
-gRPC transport client for Arkade servers.
+gRPC transport client for the Arkade operator.
 
 This crate contains the generated Arkade gRPC types plus a Rust client wrapper used by the higher-level `ark-client` crate.
 

--- a/ark-introspector-client/Cargo.toml
+++ b/ark-introspector-client/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "Client for the Ark introspector service"
+description = "Client for the Arkade introspector service"
 
 [lints]
 workspace = true

--- a/ark-rest/Cargo.toml
+++ b/ark-rest/Cargo.toml
@@ -7,7 +7,7 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "REST client for Ark server communication"
+description = "REST transport client for the Arkade operator"
 
 [lints]
 workspace = true

--- a/ark-rest/README.md
+++ b/ark-rest/README.md
@@ -1,8 +1,8 @@
 # ark-rest
 
-REST transport client for Arkade servers.
+REST transport client for the Arkade operator.
 
-This crate contains generated REST API bindings plus a Rust client wrapper for Arkade service, indexer, admin, signer manager, and wallet endpoints.
+This crate contains generated REST API bindings plus a Rust client wrapper for the service, indexer, admin, signer manager, and wallet endpoints.
 
 ## Install
 
@@ -13,7 +13,7 @@ ark-rest = "0.10.1"
 
 ## Notes
 
-The low-level API modules are generated from the Ark OpenAPI specification and are exposed for advanced use. Most applications should prefer the higher-level `Client` wrapper exported by this crate, or `ark-client` for full wallet/client functionality.
+The low-level API modules are generated from the arkd OpenAPI specification and are exposed for advanced use. Most applications should prefer the higher-level `Client` wrapper exported by this crate, or `ark-client` for full wallet functionality.
 
 ## Documentation
 

--- a/ark-rs/Cargo.toml
+++ b/ark-rs/Cargo.toml
@@ -7,7 +7,11 @@ keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = "1.86"
-description = "Collection of Rust crates designed to simplify building Bitcoin wallets with seamless support for both on-chain and off-chain transactions via the Ark protocol"
+description = "Rust crates for building Bitcoin wallets and applications with Arkade"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]
 workspace = true

--- a/ark-rs/src/lib.rs
+++ b/ark-rs/src/lib.rs
@@ -1,5 +1,43 @@
+//! Convenience crate that re-exports the Arkade Rust SDK behind feature flags.
+//!
+//! Arkade is an open execution engine for Bitcoin. Every Arkade transaction is a Bitcoin
+//! transaction, and every virtual output is a Taproot output with at least two spending paths: an
+//! instant path through the operator, and a delayed path the owner can take alone.
+//!
+//! This crate pulls the SDK together in one dependency. Each module is a re-export:
+//!
+//! | Module | Crate | Feature | Purpose |
+//! | --- | --- | --- | --- |
+//! | [`core`] | [`ark_core`] | always on | Core Arkade types and transaction utilities. |
+//! | [`client`] | [`ark_client`] | `client` | Wallet abstractions: send, receive, board, settle. |
+//! | [`grpc`] | [`ark_grpc`] | `grpc` | gRPC transport client for the operator. |
+//!
+//! # Install
+//!
+//! ```toml
+//! [dependencies]
+//! ark-rs = { version = "0.10.1", features = ["client", "grpc"] }
+//! ```
+//!
+//! `ark-core` is always available. The `client` and `grpc` modules are optional, so enable the
+//! features you need. To talk to the operator over REST instead of gRPC, depend on
+//! [`ark-rest`](https://docs.rs/ark-rest) directly.
+//!
+//! Two more features forward to the crates below:
+//!
+//! - `sqlite` — SQLite storage in `ark-client`.
+//! - `tls-native-roots` (default) or `tls-webpki-roots` — the TLS root store for both transports.
+//!
+//! # Where to start
+//!
+//! Read the [`ark_client::Client`] documentation. It covers the wallet lifecycle end to end.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 pub use ark_client as client;
 pub use ark_core as core;
 #[cfg(feature = "grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
 pub use ark_grpc as grpc;


### PR DESCRIPTION
Two related documentation fixes. No application logic is touched — only crate metadata, READMEs, and `ark-rs/src/lib.rs` re-export attributes.

## 1. Terminology in the published crate descriptions

Seven of the ten published crates described Arkade as "Ark", "the Ark protocol", or an "Ark server":

| Crate | Before | After |
|---|---|---|
| `ark-rs` | …`on-chain` and `off-chain` transactions via the Ark protocol | Rust crates for building Bitcoin wallets and applications with Arkade |
| `ark-client` | Main client library for interacting with Ark servers | High-level client library for building Arkade wallets in Rust |
| `ark-grpc` | gRPC client for Ark server communication | gRPC transport client for the Arkade operator |
| `ark-rest` | REST client for Ark server communication | REST transport client for the Arkade operator |
| `ark-core` | Core types and utilities for Ark | Core Arkade types and transaction utilities |
| `ark-delegator` | REST client for Ark delegator services | REST client for Arkade delegate services |
| `ark-bdk-wallet` | …`ark-client` on-chain wallet traits… | …the `ark-client` onchain wallet traits… |
| `ark-introspector-client` | Client for the Ark introspector service | Client for the Arkade introspector service |

These are the strings crates.io renders on each crate page, so they are the most widely seen prose in the repo. Arkade is a distinct system, and unrelated protocols ship under the "Ark" name, so the old wording invited exactly the conflation we want to avoid.

The same pass through `ark-client/README.md`, `ark-grpc/README.md`, `ark-rest/README.md`, `ark-bdk-wallet/README.md`, and the root README replaces:

- "Arkade servers" → the operator
- "VTXOs" → virtual outputs
- "Arkade rounds" → batch swaps
- "on-chain" → onchain
- "the Ark OpenAPI specification" → the arkd OpenAPI specification

**Crate names, module paths, and every code identifier are unchanged.** Renaming an exported symbol is a breaking change and is out of scope here.

## 2. The docs.rs landing page for `ark-rs`

https://docs.rs/ark-rs/latest/ark_rs/ served a page whose only visible re-export was `ark_core`. `ark_client` and `ark_grpc` sit behind non-default features, and the crate had no docs.rs metadata and no crate-level documentation, so the landing page told a reader almost nothing.

This adds:

- A `//!` crate doc on `ark-rs/src/lib.rs`: what the crate is for, a table mapping each module to its crate and feature, an install snippet, the forwarded features, and a pointer to `ark_client::Client` as the place to start.
- `[package.metadata.docs.rs] all-features = true` plus `rustdoc-args = ["--cfg", "docsrs"]`.
- `#[cfg_attr(docsrs, doc(cfg(feature = "…")))]` on the `client` and `grpc` re-exports, so the rendered page shows which feature gates each one.
- `cfg(docsrs)` registered in the workspace `check-cfg` list, so the new attribute does not trip the `unexpected_cfgs` lint.
- A crates.io badge and a docs.rs badge on the root README, and a direct `docs.rs/ark-rs` link replacing a `docs.rs/releases/search?query=ark-rs` query.

## Verification

```
cargo check -p ark-rs --all-features          # clean
cargo doc   -p ark-rs --all-features --no-deps # clean on stable
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p ark-rs --all-features --no-deps
```

Inspecting the generated `ark_rs/index.html` from the nightly build: all three re-exports (`ark_core`, `ark_client`, `ark_grpc`) render, and the feature badges resolve to `client` and `grpc`. The `doc_cfg` attribute is gated behind `cfg(docsrs)`, so stable builds are unaffected.

## Relation to open issues

Closes most of #216 — crate doc, docs.rs metadata, `doc(cfg)` annotations, README badge and link. The per-crate READMEs and the root crate list it also asked for had already landed.

Also covers the last two unchecked non-coverage items on #205. What remains on both issues is rustdoc coverage across all public items, which is a separate and much larger effort worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the SDK’s Arkade focus, wallet-building capabilities, operator transport options, and supported services.
  - Expanded getting-started guidance, installation details, feature flags, TLS options, and module documentation.
  - Updated documentation links, badges, endpoint coverage, and local operator testing references.
  - Standardized terminology across package descriptions and READMEs.

- **Improvements**
  - Enhanced docs.rs configuration so documentation includes available features and relevant conditional documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->