### PR TITLE
Exclude Boltz e2e tests

### DIFF
--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -1,10 +1,9 @@
 name: Core E2E Tests
 
-# The regtest stack (Bitcoin Core + Fulcrum + mempool/esplora + arkd + emulator,
-# and Boltz for the e2e_boltz_* tests) is provided by the `regtest` git submodule
-# (arkade-regtest) and driven by its zero-dependency Node CLI (`regtest.mjs`).
-# arkd runs from a container image (ARKD_IMAGE in .env.regtest); the orchestrator
-# self-funds it on `start`.
+# The regtest stack (Bitcoin Core + Fulcrum + mempool/esplora + arkd + emulator)
+# is provided by the `regtest` git submodule (arkade-regtest) and driven by its
+# zero-dependency Node CLI (`regtest.mjs`). arkd runs from a container image
+# (ARKD_IMAGE in .env.regtest); the orchestrator self-funds it on `start`.
 
 on:
   workflow_call:
@@ -81,21 +80,10 @@ jobs:
       - name: Make binaries executable
         run: chmod +x target/debug/deps/e2e_*
 
-      # Brings up base + ark (arkd) + emulator for every e2e test. Boltz is only
-      # enabled for the e2e_boltz_* binaries. The orchestrator waits for the
+      # Brings up base + ark (arkd) + emulator. The orchestrator waits for the
       # stack to be ready and self-funds arkd before returning.
       - name: Start regtest stack
-        env:
-          TEST_BINARY: ${{ matrix.test-binary }}
-        run: |
-          test_name=$(basename "$TEST_BINARY")
-          profiles=(--profile emulator)
-          if [[ "$test_name" == e2e_boltz* ]]; then
-            profiles+=(--profile boltz)
-          fi
-
-          echo "Starting regtest for $test_name with profiles: ${profiles[*]}"
-          node regtest/regtest.mjs start --env .env.regtest "${profiles[@]}"
+        run: node regtest/regtest.mjs start --env .env.regtest --profile emulator
 
       - name: Run Test Binary
         env:
@@ -114,7 +102,7 @@ jobs:
           node regtest/regtest.mjs rpc getblockcount 2>&1 || echo "(getblockcount failed)"
           echo "=== auto-miner ticks ==="
           docker logs bitcoin-miner 2>&1 | tail -40 || echo "(bitcoin-miner not found)"
-          for c in bitcoin fulcrum mempool_web nbxplorer arkd arkd-wallet emulator lnd boltz-lnd boltz boltz-fulmine nginx-boltz lnurl-server; do
+          for c in bitcoin fulcrum mempool_web nbxplorer arkd arkd-wallet emulator; do
             echo "=== docker logs $c ==="
             docker logs "$c" 2>&1 || echo "(container $c not found)"
             echo "=== end $c ==="

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Security reports are greatly appreciated and we will publicly thank you for it.
 
 The following keys may be used to communicate sensitive information to developers:
 
-| Name | PGP Public Key URL | Fingerprint |
-|------|-------------|-------------|
-| Marco Argentieri | [https://github.com/tiero.gpg](https://github.com/tiero.gpg) | 0F6586CE8DA12FB1 |
+| Name               | PGP Public Key URL                                               | Fingerprint      |
+| ------------------ | ---------------------------------------------------------------- | ---------------- |
+| Marco Argentieri   | [https://github.com/tiero.gpg](https://github.com/tiero.gpg)     | 0F6586CE8DA12FB1 |
 | Pietralberto Mazza | [https://github.com/altafan.gpg](https://github.com/altafan.gpg) | 6C7639DEA147673B |
-| Andrew Camilleri | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg) | F918A46E23064E28 |
+| Andrew Camilleri   | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg)     | F918A46E23064E28 |
 
 You can import a key by running the following command in your terminal and verify the fingerprint matches the one above:
 

--- a/e2e-tests/tests/boltz_reverse.rs
+++ b/e2e-tests/tests/boltz_reverse.rs
@@ -17,7 +17,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 pub async fn reverse_swap() {
-    // Requires the arkade-regtest Boltz profile.
+    // Requires the Boltz regtest environment. See scripts/boltz-setup.sh.
 
     init_tracing();
     let regtest = Arc::new(Regtest::new());

--- a/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
+++ b/e2e-tests/tests/boltz_reverse_vhtlc_unilateral_exit.rs
@@ -22,7 +22,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 pub async fn reverse_swap_claim_with_vhtlc_ancestor_can_exit_unilaterally() {
-    // Requires the arkade-regtest Boltz profile.
+    // Requires the Boltz regtest environment. See scripts/boltz-setup.sh.
     init_tracing();
 
     let regtest = Arc::new(Regtest::new());

--- a/e2e-tests/tests/boltz_submarine.rs
+++ b/e2e-tests/tests/boltz_submarine.rs
@@ -20,7 +20,7 @@ mod common;
 #[tokio::test]
 #[ignore]
 pub async fn submarine_swap() {
-    // Requires the arkade-regtest Boltz profile.
+    // Requires the Boltz regtest environment. See scripts/boltz-setup.sh.
 
     init_tracing();
     let regtest = Arc::new(Regtest::new());

--- a/justfile
+++ b/justfile
@@ -7,9 +7,9 @@ set dotenv-load := true
 regtest_dir := "regtest"
 regtest_env := ".env.regtest"
 # Profiles the e2e suite needs: `emulator` transitively pulls in `base` + `ark`
-# (arkd) plus the arkade-script emulator used by the introspector tests. `boltz`
-# is needed by the e2e_boltz_* integration tests.
-regtest_profiles := "emulator,boltz"
+# (arkd) plus the arkade-script emulator used by the introspector tests. boltz /
+# delegate / solver are not exercised by the `e2e_*` suite.
+regtest_profiles := "emulator"
 
 mod ark-rest
 mod nix


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * End-to-end regtest environments now start with the emulator only.
  * Boltz, delegate, and solver services are no longer included in the standard end-to-end setup.

* **Documentation**
  * Updated test guidance to reference the current Boltz regtest environment and setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->