### PR TITLE
docs(client): document renewing virtual outputs

### DIFF
--- a/ark-client/README.md
+++ b/ark-client/README.md
@@ -17,6 +17,82 @@ Enable optional SQLite storage support with:
 ark-client = { version = "0.10.1", features = ["sqlite"] }
 ```
 
+## Renewing Virtual Outputs
+
+Every virtual output has an expiry. It is created inside a batch output, and
+that batch output is swept once its expiry passes. **Renewal moves a virtual
+output into a fresh batch swap before that happens.** A wallet that never
+renews will eventually hold outputs it can no longer spend through the
+operator.
+
+Renewal is a settlement: the client hands the operator a set of inputs and
+receives new confirmed virtual outputs in the next batch swap.
+
+### Choosing a Method
+
+| Method                                                                                                        | Settles                                                            | Use it when                                    |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
+| [`Client::settle`](https://docs.rs/ark-client/latest/ark_client/struct.Client.html#method.settle)             | Expired and recoverable virtual outputs, plus all boarding outputs | Periodic renewal. This is the default choice.  |
+| [`Client::settle_all`](https://docs.rs/ark-client/latest/ark_client/struct.Client.html#method.settle_all)     | Everything, including healthy virtual outputs                      | Rescuing isolated sub-dust amounts. See below. |
+| [`Client::settle_vtxos`](https://docs.rs/ark-client/latest/ark_client/struct.Client.html#method.settle_vtxos) | Exactly the outpoints you name                                     | You are managing selection yourself.           |
+
+Prefer `settle`. It leaves healthy virtual outputs alone, because including
+them only inflates batch fees without buying anything. Boarding outputs are
+always included, since freshly funded coins normally want to enter Arkade.
+
+Each returns `Ok(None)` when there was nothing to settle, so an empty wallet or
+a wallet with nothing due is not an error.
+
+```rust,no_run
+// Renew whatever is due. Safe to call on a timer.
+match client.settle(&mut rng).await? {
+    Some(commitment_txid) => println!("renewed in {commitment_txid}"),
+    None => println!("nothing due"),
+}
+```
+
+### Sub-Dust Amounts
+
+A settlement cannot produce a virtual output below the operator's dust
+threshold. If the recoverable amounts `settle` picks up do not add up to dust
+on their own, the batch swap is refused with `cannot settle into sub-dust VTXO`.
+
+Fall back to [`Client::settle_all`](https://docs.rs/ark-client/latest/ark_client/struct.Client.html#method.settle_all) in that case. It rolls the sub-dust amounts
+in alongside healthy virtual outputs, which carry enough value to clear the
+threshold.
+
+### Renewing Automatically
+
+[`Client::start_vtxo_watcher`](https://docs.rs/ark-client/latest/ark_client/struct.Client.html#method.start_vtxo_watcher) runs renewal in the background. It:
+
+1. delegates new virtual outputs to the delegate service for future renewal;
+2. self-renews anything close to expiry, as a safety net, on a 60-second tick;
+3. rotates funds off deprecated operator signers, unless you turn that arm off
+   with [`VtxoWatcherConfig::migrate_deprecated_signers`](https://docs.rs/ark-client/latest/ark_client/vtxo_watcher/struct.VtxoWatcherConfig.html#structfield.migrate_deprecated_signers).
+
+The safety net acts on virtual outputs with **less than 10% of their lifetime
+remaining**, and on anything already recoverable. It skips the pass when the
+selected amounts do not reach dust, for the reason above.
+
+```rust,no_run
+use std::sync::Arc;
+use ark_client::vtxo_watcher::VtxoWatcherConfig;
+
+let client = Arc::new(client);
+let handle = client.start_vtxo_watcher(delegator, VtxoWatcherConfig::default());
+```
+
+The watcher needs the client behind an `Arc`, and reconnects on stream errors
+with exponential backoff. Renewal stops when the returned handle is dropped, so
+hold onto it for as long as the wallet is running.
+
+### If the Window Is Missed
+
+A virtual output whose batch output was swept is **recoverable**, not lost. The
+funds are still yours at that script. What you give up is the ability to exit
+unilaterally, so recover it by settling rather than by exiting: both `settle`
+and the watcher already treat recoverable outputs as due.
+
 ## Documentation
 
 API documentation is available on [docs.rs/ark-client](https://docs.rs/ark-client).

--- a/ark-client/src/vtxo_watcher.rs
+++ b/ark-client/src/vtxo_watcher.rs
@@ -1,9 +1,27 @@
-//! Background VTXO watcher that auto-delegates and auto-renews VTXOs.
+//! Background watcher that delegates and renews virtual outputs.
 //!
-//! Full behavior:
-//! - On new VTXOs received: submit them to the delegator service for future renewal
-//! - On new VTXOs received: self-renew VTXOs that are close to expiry (safety net)
-//! - On stream error: reconnect with exponential backoff
+//! Every virtual output has an expiry. It lives in a batch output, and that batch output is swept
+//! once its expiry passes. Renewal moves a virtual output into a fresh batch swap before that
+//! happens, and this watcher does it without the application having to schedule anything.
+//!
+//! Start it with [`Client::start_vtxo_watcher`]. It does three things:
+//!
+//! - **Delegates.** New virtual outputs are submitted to the delegate service, which renews them on
+//!   the wallet's behalf.
+//! - **Renews.** As a safety net, it self-renews virtual outputs with less than 10% of their
+//!   lifetime remaining, and anything already recoverable. It checks on a 60-second tick, and skips
+//!   the pass when the selected amounts do not reach the operator's dust threshold — a settlement
+//!   cannot produce a sub-dust virtual output.
+//! - **Migrates.** On a periodic, backed-off pass it rotates funds off any deprecated operator
+//!   signer the wallet still holds pre-cutoff outputs under. Turn this arm off with
+//!   [`VtxoWatcherConfig::migrate_deprecated_signers`]; renewal and delegation are unaffected.
+//!
+//! The watcher reconnects on stream errors with exponential backoff, and stops when the returned
+//! [`VtxoWatcherHandle`] is dropped.
+//!
+//! Renewal is also available synchronously: see [`Client::settle`] for the periodic case, and
+//! [`Client::settle_all`] when isolated sub-dust amounts need healthy outputs to carry them over
+//! the dust threshold.
 
 use crate::error::ErrorContext;
 use crate::swap_storage::SwapStorage;


### PR DESCRIPTION
Closes #126. Documentation only — a README section and a module doc comment. No code changes.

## Why

Renewal is implemented and the individual methods carry reasonable rustdoc, but **nothing explains the concept anywhere in prose**. `grep -niE "renew|refresh|expir"` across every README returns only `ark-fees` hits about fee expiry. The root README and `ark-client/README.md` have zero coverage, and `docs/` contains only `cargo-minimal-lock.md` and `update-server-api.md`.

This is worse than a typical docs gap. A developer who does not know renewal exists ships a wallet whose funds quietly reach their expiry, and nothing in the crate prompts them to look.

## What's added

**`ark-client/README.md` — a "Renewing Virtual Outputs" section:**

- Why renewal is needed: a virtual output lives in a batch output, and that batch output is swept once its expiry passes.
- A table choosing between `settle`, `settle_all`, and `settle_vtxos`, with `settle` as the default and the reasoning from its own docstring (healthy outputs only inflate batch fees).
- The sub-dust case: `settle` is refused with `cannot settle into sub-dust VTXO` when recoverable amounts do not reach dust on their own, and `settle_all` is the way out because healthy outputs carry the value.
- The background watcher, with the numbers a caller cannot infer.
- What `recoverable` means if the window is missed: still your funds, no longer unilaterally exitable, recovered by settling.

**`ark-client/src/vtxo_watcher.rs` — expanded module doc**, so the same guidance appears on docs.rs rather than only on GitHub. The previous version was a six-line bullet list that named the behaviours without the thresholds.

## Facts taken from the implementation

Everything quantitative was read from the code, not from existing prose:

| Fact | Source |
|---|---|
| Self-renewal at <10% remaining lifetime | `SELF_RENEW_REMAINING_FRACTION = 0.10`, `vtxo_watcher.rs:841` |
| 60-second renewal tick | `vtxo_watcher.rs:188` |
| Pass skipped when selection is under dust | `select_vtxos_for_self_renewal`, `vtxo_watcher.rs:847` |
| `cannot settle into sub-dust VTXO` | `settle` docstring, `batch.rs:140` |
| `Ok(None)` when nothing is due | `settle_at`, `batch.rs:93` |

## Note on links

README method references link to docs.rs explicitly rather than using rustdoc intra-doc syntax — `[\`Client::settle\`]` renders as literal text on GitHub and crates.io. Verified `VtxoWatcherConfig` is under `ark_client::vtxo_watcher`, not the crate root, and corrected both the link and the sample's `use` statement accordingly.

## Verification

```
cargo check -p ark-client   # clean
cargo doc   -p ark-client --no-deps
```

No new rustdoc warnings: filtering the output for `vtxo_watcher`, `VtxoWatcherConfig`, `start_vtxo_watcher`, and `settle_all` returns nothing, so every new intra-doc link resolves. The pre-existing warnings in that crate (`SqliteSwapStorage`, `Client::send_vtxo`, several private-item links from the Boltz surface) are untouched and worth their own issue.

Confirmed the generated `vtxo_watcher/index.html` renders links to `start_vtxo_watcher`, `VtxoWatcherConfig`, `VtxoWatcherHandle`, `settle`, and `settle_all`.

## Relation to #268

Appends a new section and does not touch the intro lines #268 rewrites, so the two merge cleanly in either order. Until #268 lands, this file's header still says "Arkade servers" and "VTXOs" while the new section uses the operator and virtual output — #268 fixes the header.