### PR TITLE
fix: format SECURITY.md so dprint passes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,11 @@ Security reports are greatly appreciated and we will publicly thank you for it.
 
 The following keys may be used to communicate sensitive information to developers:
 
-| Name | PGP Public Key URL | Fingerprint |
-|------|-------------|-------------|
-| Marco Argentieri | [https://github.com/tiero.gpg](https://github.com/tiero.gpg) | 0F6586CE8DA12FB1 |
+| Name               | PGP Public Key URL                                               | Fingerprint      |
+| ------------------ | ---------------------------------------------------------------- | ---------------- |
+| Marco Argentieri   | [https://github.com/tiero.gpg](https://github.com/tiero.gpg)     | 0F6586CE8DA12FB1 |
 | Pietralberto Mazza | [https://github.com/altafan.gpg](https://github.com/altafan.gpg) | 6C7639DEA147673B |
-| Andrew Camilleri | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg) | F918A46E23064E28 |
+| Andrew Camilleri   | [https://github.com/Kukks.gpg](https://github.com/Kukks.gpg)     | F918A46E23064E28 |
 
 You can import a key by running the following command in your terminal and verify the fingerprint matches the one above:
 


### PR DESCRIPTION
The `formatting-dprint` check has been failing on master since `SECURITY.md` landed in #266, so **every open PR inherits a red check that has nothing to do with its own changes**. I hit it on #268 and #270 and traced it back here.

Confirmed on a clean checkout of master:

```
$ dprint check --list-different
/Users/…/rust-sdk/SECURITY.md
```

One file, and it is not one that recent PRs touch.

## The change

Whitespace only, produced by `dprint fmt`. The markdown plugin pads table columns to a common width; the table as committed does not. No content, no links, and no fingerprints are altered — the diff is 4 lines, all padding.

## Verification

```
$ dprint check
# clean
```

Worth merging ahead of other open PRs so their checks reflect their own diffs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the formatting and alignment of the PGP key table for easier reading.
  * Kept all listed names, URLs, and fingerprints unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->